### PR TITLE
Implemented better method for command queue retrieval

### DIFF
--- a/src/overlay/Overlay.h
+++ b/src/overlay/Overlay.h
@@ -67,7 +67,6 @@ protected:
 	void DrawImgui(IDXGISwapChain3* apSwapChain);
 
 	static long PresentD3D12(IDXGISwapChain3* pSwapChain, UINT SyncInterval, UINT Flags);
-	static void ExecuteCommandListsD3D12(ID3D12CommandQueue* apCommandQueue, UINT NumCommandLists, ID3D12CommandList* const* ppCommandLists);
 	static BOOL SetMousePosition(void* apThis, HWND Wnd, long X, long Y);
 	static BOOL ClipToCenter(CGameEngine::UnkC0* apThis);
 	static LRESULT APIENTRY WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);

--- a/src/overlay/Overlay_D3D12.cpp
+++ b/src/overlay/Overlay_D3D12.cpp
@@ -96,6 +96,9 @@ void Overlay::InitializeD3D12(IDXGISwapChain3* pSwapChain)
             d3d12Device->CreateRenderTargetView(m_frameContexts[i].BackBuffer, nullptr, m_frameContexts[i].MainRenderTargetDescriptor);
         }
 
+        uintptr_t swapChainAddr = reinterpret_cast<uintptr_t>(pSwapChain);
+        m_pCommandQueue = *reinterpret_cast<ID3D12CommandQueue**>(swapChainAddr + kiero::getCommandQueueOffset());
+
         ImGui_ImplWin32_Init(m_hwnd);
         ImGui_ImplDX12_Init(d3d12Device, buffersCounts,
             DXGI_FORMAT_R8G8B8A8_UNORM, m_pd3dSrvDescHeap,

--- a/src/overlay/Overlay_Hooks.cpp
+++ b/src/overlay/Overlay_Hooks.cpp
@@ -177,19 +177,6 @@ long Overlay::PresentD3D12(IDXGISwapChain3* pSwapChain, UINT SyncInterval, UINT 
     return Get().m_realPresentD3D12(pSwapChain, SyncInterval, Flags);
 }
 
-void Overlay::ExecuteCommandListsD3D12(ID3D12CommandQueue* apCommandQueue, UINT NumCommandLists, ID3D12CommandList* const* ppCommandLists)
-{
-    auto& overlay = Get();
-    if (overlay.m_pCommandQueue == nullptr)
-    {
-        auto desc = apCommandQueue->GetDesc();
-        if(desc.Type == D3D12_COMMAND_LIST_TYPE_DIRECT)
-            overlay.m_pCommandQueue = apCommandQueue;
-    }
-
-    overlay.m_realExecuteCommandLists(apCommandQueue, NumCommandLists, ppCommandLists);
-}
-
 BOOL Overlay::ClipToCenter(CGameEngine::UnkC0* apThis)
 {
     const HWND wnd = apThis->Wnd;
@@ -223,9 +210,6 @@ void Overlay::Hook()
 {
     if (kiero::bind(140, reinterpret_cast<void**>(&m_realPresentD3D12), &PresentD3D12) != kiero::Status::Success)
         spdlog::error("\tD3D12 Present Hook failed!");
-
-    if (kiero::bind(54, reinterpret_cast<void**>(&m_realExecuteCommandLists), &ExecuteCommandListsD3D12) != kiero::Status::Success)
-        spdlog::error("\tD3D12 ExecuteCommandLists Hook failed!");
 
     spdlog::info("\tD3D12 hook complete");
 }


### PR DESCRIPTION
This method uses offset from swapchain pointer. This is much more reliable, as other DX12 hooks may interfere with previous implementation.

Helps prevent crashing with some applications requiring DX12 hook.

Partially helps #280 and #267 . CTD is not happening anymore, but we still have an issue with rendering it seems because of order of hooking with potential other applications it seems.

Functionality with this does not break from what I tested regarding running solely this DLL.

This also helps #267 specifically in one more way than not crashing - it allows to utilize fix from https://github.com/yamashi/CyberEngineTweaks/issues/245#issuecomment-750009640 to use RTSS with this mod, like it was back in 1.04 and 1.05.

I want to have a look into that ordering or whatever may be a problem next.