### PR TITLE
[mimalloc] Use RtlGenRandom instead of BCryptGenRandom to init PRNG

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -1,5 +1,6 @@
 set_languages("cxx17")
 
+add_requires("mimalloc", {configs = {cxflags = "-DMI_USE_RTLGENRANDOM"}})
 add_requires("spdlog", "nlohmann_json", "minhook", "imgui", "sol2", "tiltedcore", { external = false })
 
 add_rules("mode.debug", "mode.release")


### PR DESCRIPTION
This fixes an access violation on Windows 7 during Mimalloc's PRNG initialization (manifests as "error 998" from the ASI loader). See [this comment](https://github.com/yamashi/CyberEngineTweaks/issues/134#issuecomment-751355244) on #134 for details.

Thanks to @waruqi for the help with xmake.