### PR TITLE
[imgui] Remove XInput dependency

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -20,7 +20,7 @@ target("RED4ext")
     add_includedirs("vendor/RED4ext/src/red4ext.sdk/", { public = true })
 
 target("cyber_engine_tweaks")
-    add_defines("KIERO_USE_MINHOOK=1", "KIERO_INCLUDE_D3D12=1")
+    add_defines("KIERO_USE_MINHOOK=1", "KIERO_INCLUDE_D3D12=1", "IMGUI_IMPL_WIN32_DISABLE_GAMEPAD")
     set_kind("shared")
     set_filename("cyber_engine_tweaks.asi")
     add_files("src/**.cpp")


### PR DESCRIPTION
This PR disables gamepad support in imgui, which required XInput and was causing CET to (attempt to) load a different version of XInput than the one used by the game.