### PR TITLE
Uninitialize minhook and Overlay (if console true) during Shutdown()

### DIFF
--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -98,6 +98,9 @@ void Initialize(HMODULE mod)
 
 void Shutdown()
 {
+    if(Options::Get().Console)
+        Overlay::Shutdown();
+
     kiero::shutdown();
 
     MH_DisableHook(MH_ALL_HOOKS);

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -99,6 +99,9 @@ void Initialize(HMODULE mod)
 void Shutdown()
 {
     kiero::shutdown();
+
+    MH_DisableHook(MH_ALL_HOOKS);
+    MH_Uninitialize();
 }
 
 BOOL APIENTRY DllMain(HMODULE mod, DWORD ul_reason_for_call, LPVOID) {


### PR DESCRIPTION
Properly dispose of minhook on shutdown.