### PR TITLE
Move kiero::shutdown to Overlay destructor, change code style in dllmain

### DIFF
--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -90,8 +90,6 @@ void Shutdown()
     if(Options::Get().Console)
         Overlay::Shutdown();
 
-    kiero::shutdown();
-
     MH_DisableHook(MH_ALL_HOOKS);
     MH_Uninitialize();
 }
@@ -100,16 +98,16 @@ BOOL APIENTRY DllMain(HMODULE mod, DWORD ul_reason_for_call, LPVOID)
 {
     DisableThreadLibraryCalls(mod);
 
-    switch(ul_reason_for_call) {
-    case DLL_PROCESS_ATTACH:
-        Initialize(mod);
-        break;
-
-    case DLL_PROCESS_DETACH:
-        Shutdown();
-        break;
-    default:
-        break;
+    switch(ul_reason_for_call) 
+    {
+        case DLL_PROCESS_ATTACH:
+            Initialize(mod);
+            break;
+        case DLL_PROCESS_DETACH:
+            Shutdown();
+            break;
+        default:
+            break;
     }
 
     return TRUE;

--- a/src/overlay/Overlay.cpp
+++ b/src/overlay/Overlay.cpp
@@ -370,11 +370,13 @@ Overlay::Overlay() = default;
 
 Overlay::~Overlay() 
 {
+    kiero::shutdown();
+
+    if (m_hWnd != nullptr)
+        SetWindowLongPtr(m_hWnd, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(m_wndProc));
+
     if (m_initialized) 
     {
-        if (m_hWnd != nullptr)
-            SetWindowLongPtr(m_hWnd, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(m_wndProc));
-            
         ImGui_ImplDX12_Shutdown();
         ImGui_ImplWin32_Shutdown();
         ImGui::DestroyContext();


### PR DESCRIPTION
Modified a bit shutdown procedure again... Hopefully last time for a while. 

Also corrected style in dllmain with this commit, as I found out it stands out when compared to others.