### PR TITLE
Move WIN32_LEAN_AND_MEAN define to xmake.lua

### DIFF
--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -38,7 +38,6 @@
 #include <d3dcompiler.h>
 #include <Windows.h>
 #include <SDKDDKVer.h>
-#define WIN32_LEAN_AND_MEAN
 #include <DbgHelp.h>
 
 #include <TiltedCore/Allocator.hpp>

--- a/xmake.lua
+++ b/xmake.lua
@@ -20,7 +20,7 @@ target("RED4ext")
     add_includedirs("vendor/RED4ext/src/red4ext.sdk/", { public = true })
 
 target("cyber_engine_tweaks")
-    add_defines("KIERO_USE_MINHOOK=1", "KIERO_INCLUDE_D3D12=1", "IMGUI_IMPL_WIN32_DISABLE_GAMEPAD")
+    add_defines("KIERO_USE_MINHOOK=1", "KIERO_INCLUDE_D3D12=1", "IMGUI_IMPL_WIN32_DISABLE_GAMEPAD", "WIN32_LEAN_AND_MEAN")
     -- set_pcxxheader("src/stdafx.h") -- see: https://github.com/xmake-io/xmake/issues/1171#issuecomment-751421178
     set_kind("shared")
     set_filename("cyber_engine_tweaks.asi")


### PR DESCRIPTION
I suggest moving WIN32_LEAN_AND_MEAN to xmake.lua.

I believe it should be moved from its current location, as other files could include Windows.h which this mainly relates to.

If not moving it into xmake.lua, at least I would move it up a bit in stdafx.h, as now, it is in weird place in general in my opinion.