### PR TITLE
Add Windows 7 support to overlay

### DIFF
--- a/src/common/D3D12Downlevel.h
+++ b/src/common/D3D12Downlevel.h
@@ -1,0 +1,280 @@
+/*-------------------------------------------------------------------------------------
+ *
+ * Copyright (c) Microsoft Corporation
+ *
+ *-------------------------------------------------------------------------------------*/
+
+
+/* this ALWAYS GENERATED file contains the definitions for the interfaces */
+
+
+ /* File created by MIDL compiler version 8.01.0622 */
+
+
+
+/* verify that the <rpcndr.h> version is high enough to compile this file*/
+#ifndef __REQUIRED_RPCNDR_H_VERSION__
+#define __REQUIRED_RPCNDR_H_VERSION__ 500
+#endif
+
+/* verify that the <rpcsal.h> version is high enough to compile this file*/
+#ifndef __REQUIRED_RPCSAL_H_VERSION__
+#define __REQUIRED_RPCSAL_H_VERSION__ 100
+#endif
+
+#include "rpc.h"
+#include "rpcndr.h"
+
+#ifndef __RPCNDR_H_VERSION__
+#error this stub requires an updated version of <rpcndr.h>
+#endif /* __RPCNDR_H_VERSION__ */
+
+#ifndef COM_NO_WINDOWS_H
+#include "windows.h"
+#include "ole2.h"
+#endif /*COM_NO_WINDOWS_H*/
+
+#ifndef __d3d12downlevel_h__
+#define __d3d12downlevel_h__
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1020)
+#pragma once
+#endif
+
+/* Forward Declarations */ 
+
+#ifndef __ID3D12CommandQueueDownlevel_FWD_DEFINED__
+#define __ID3D12CommandQueueDownlevel_FWD_DEFINED__
+typedef interface ID3D12CommandQueueDownlevel ID3D12CommandQueueDownlevel;
+
+#endif 	/* __ID3D12CommandQueueDownlevel_FWD_DEFINED__ */
+
+
+#ifndef __ID3D12DeviceDownlevel_FWD_DEFINED__
+#define __ID3D12DeviceDownlevel_FWD_DEFINED__
+typedef interface ID3D12DeviceDownlevel ID3D12DeviceDownlevel;
+
+#endif 	/* __ID3D12DeviceDownlevel_FWD_DEFINED__ */
+
+
+/* header files for imported files */
+#include "oaidl.h"
+#include "ocidl.h"
+#include "d3d12.h"
+#include "dxgi1_4.h"
+
+#ifdef __cplusplus
+extern "C"{
+#endif 
+
+
+/* interface __MIDL_itf_d3d12downlevel_0000_0000 */
+/* [local] */ 
+
+#include <winapifamily.h>
+#pragma region Desktop Family
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+typedef 
+enum D3D12_DOWNLEVEL_PRESENT_FLAGS
+    {
+        D3D12_DOWNLEVEL_PRESENT_FLAG_NONE	= 0,
+        D3D12_DOWNLEVEL_PRESENT_FLAG_WAIT_FOR_VBLANK	= ( D3D12_DOWNLEVEL_PRESENT_FLAG_NONE + 1 ) 
+    } 	D3D12_DOWNLEVEL_PRESENT_FLAGS;
+
+DEFINE_ENUM_FLAG_OPERATORS( D3D12_DOWNLEVEL_PRESENT_FLAGS );
+
+
+extern RPC_IF_HANDLE __MIDL_itf_d3d12downlevel_0000_0000_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_d3d12downlevel_0000_0000_v0_0_s_ifspec;
+
+#ifndef __ID3D12CommandQueueDownlevel_INTERFACE_DEFINED__
+#define __ID3D12CommandQueueDownlevel_INTERFACE_DEFINED__
+
+/* interface ID3D12CommandQueueDownlevel */
+/* [unique][local][object][uuid] */ 
+
+
+EXTERN_C const IID IID_ID3D12CommandQueueDownlevel;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("38a8c5ef-7ccb-4e81-914f-a6e9d072c494")
+    ID3D12CommandQueueDownlevel : public IUnknown
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE Present( 
+            _In_  ID3D12GraphicsCommandList *pOpenCommandList,
+            _In_  ID3D12Resource *pSourceTex2D,
+            _In_  HWND hWindow,
+            D3D12_DOWNLEVEL_PRESENT_FLAGS Flags) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct ID3D12CommandQueueDownlevelVtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            ID3D12CommandQueueDownlevel * This,
+            REFIID riid,
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            ID3D12CommandQueueDownlevel * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            ID3D12CommandQueueDownlevel * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *Present )( 
+            ID3D12CommandQueueDownlevel * This,
+            _In_  ID3D12GraphicsCommandList *pOpenCommandList,
+            _In_  ID3D12Resource *pSourceTex2D,
+            _In_  HWND hWindow,
+            D3D12_DOWNLEVEL_PRESENT_FLAGS Flags);
+        
+        END_INTERFACE
+    } ID3D12CommandQueueDownlevelVtbl;
+
+    interface ID3D12CommandQueueDownlevel
+    {
+        CONST_VTBL struct ID3D12CommandQueueDownlevelVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define ID3D12CommandQueueDownlevel_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define ID3D12CommandQueueDownlevel_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define ID3D12CommandQueueDownlevel_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define ID3D12CommandQueueDownlevel_Present(This,pOpenCommandList,pSourceTex2D,hWindow,Flags)	\
+    ( (This)->lpVtbl -> Present(This,pOpenCommandList,pSourceTex2D,hWindow,Flags) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __ID3D12CommandQueueDownlevel_INTERFACE_DEFINED__ */
+
+
+#ifndef __ID3D12DeviceDownlevel_INTERFACE_DEFINED__
+#define __ID3D12DeviceDownlevel_INTERFACE_DEFINED__
+
+/* interface ID3D12DeviceDownlevel */
+/* [unique][local][object][uuid] */ 
+
+
+EXTERN_C const IID IID_ID3D12DeviceDownlevel;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("74eaee3f-2f4b-476d-82ba-2b85cb49e310")
+    ID3D12DeviceDownlevel : public IUnknown
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE QueryVideoMemoryInfo( 
+            UINT NodeIndex,
+            DXGI_MEMORY_SEGMENT_GROUP MemorySegmentGroup,
+            _Out_  DXGI_QUERY_VIDEO_MEMORY_INFO *pVideoMemoryInfo) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct ID3D12DeviceDownlevelVtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            ID3D12DeviceDownlevel * This,
+            REFIID riid,
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            ID3D12DeviceDownlevel * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            ID3D12DeviceDownlevel * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryVideoMemoryInfo )( 
+            ID3D12DeviceDownlevel * This,
+            UINT NodeIndex,
+            DXGI_MEMORY_SEGMENT_GROUP MemorySegmentGroup,
+            _Out_  DXGI_QUERY_VIDEO_MEMORY_INFO *pVideoMemoryInfo);
+        
+        END_INTERFACE
+    } ID3D12DeviceDownlevelVtbl;
+
+    interface ID3D12DeviceDownlevel
+    {
+        CONST_VTBL struct ID3D12DeviceDownlevelVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define ID3D12DeviceDownlevel_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define ID3D12DeviceDownlevel_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define ID3D12DeviceDownlevel_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define ID3D12DeviceDownlevel_QueryVideoMemoryInfo(This,NodeIndex,MemorySegmentGroup,pVideoMemoryInfo)	\
+    ( (This)->lpVtbl -> QueryVideoMemoryInfo(This,NodeIndex,MemorySegmentGroup,pVideoMemoryInfo) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __ID3D12DeviceDownlevel_INTERFACE_DEFINED__ */
+
+
+/* interface __MIDL_itf_d3d12downlevel_0000_0002 */
+/* [local] */ 
+
+#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) */
+#pragma endregion
+DEFINE_GUID(IID_ID3D12CommandQueueDownlevel,0x38a8c5ef,0x7ccb,0x4e81,0x91,0x4f,0xa6,0xe9,0xd0,0x72,0xc4,0x94);
+DEFINE_GUID(IID_ID3D12DeviceDownlevel,0x74eaee3f,0x2f4b,0x476d,0x82,0xba,0x2b,0x85,0xcb,0x49,0xe3,0x10);
+
+
+extern RPC_IF_HANDLE __MIDL_itf_d3d12downlevel_0000_0002_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_d3d12downlevel_0000_0002_v0_0_s_ifspec;
+
+/* Additional Prototypes for ALL interfaces */
+
+/* end of Additional Prototypes */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
+

--- a/src/kiero/kiero.cpp
+++ b/src/kiero/kiero.cpp
@@ -21,6 +21,7 @@
 #if KIERO_INCLUDE_D3D12
 # include <dxgi.h>
 # include <d3d12.h>
+# include "common/D3D12Downlevel.h"
 #endif
 
 #if KIERO_INCLUDE_OPENGL
@@ -46,6 +47,7 @@
 static kiero::RenderType::Enum g_renderType = kiero::RenderType::None;
 static uint150_t* g_methodsTable = NULL;
 static uintptr_t g_commandQueueOffset = 0;
+static bool g_isDownLevelDevice = false;
 
 kiero::Status::Enum kiero::init(RenderType::Enum _renderType)
 {
@@ -473,53 +475,77 @@ kiero::Status::Enum kiero::init(RenderType::Enum _renderType)
 					return Status::UnknownError;
 				}
 
-				DXGI_RATIONAL refreshRate;
-				refreshRate.Numerator = 60;
-				refreshRate.Denominator = 1;
+				ID3D12DeviceDownlevel* downlevelDevice;
+				g_isDownLevelDevice = device->QueryInterface(__uuidof(ID3D12DeviceDownlevel), (void**)&downlevelDevice) >= 0;
+                IDXGISwapChain* swapChain = NULL;
+				ID3D12CommandQueueDownlevel* commandQueueDownlevel = NULL;
 
-				DXGI_MODE_DESC bufferDesc;
-				bufferDesc.Width = 100;
-				bufferDesc.Height = 100;
-				bufferDesc.RefreshRate = refreshRate;
-				bufferDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-				bufferDesc.ScanlineOrdering = DXGI_MODE_SCANLINE_ORDER_UNSPECIFIED;
-				bufferDesc.Scaling = DXGI_MODE_SCALING_UNSPECIFIED;
-
-				DXGI_SAMPLE_DESC sampleDesc;
-				sampleDesc.Count = 1;
-				sampleDesc.Quality = 0;
-
-				DXGI_SWAP_CHAIN_DESC swapChainDesc = {};
-				swapChainDesc.BufferDesc = bufferDesc;
-				swapChainDesc.SampleDesc = sampleDesc;
-				swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-				swapChainDesc.BufferCount = 2;
-				swapChainDesc.OutputWindow = window;
-				swapChainDesc.Windowed = 1;
-				swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-				swapChainDesc.Flags = DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH;
-
-				IDXGISwapChain* swapChain;
-				if (factory->CreateSwapChain(commandQueue, &swapChainDesc, &swapChain) < 0)
+				if (!g_isDownLevelDevice)
 				{
-					::DestroyWindow(window);
-					::UnregisterClass(windowClass.lpszClassName, windowClass.hInstance);
-					return Status::UnknownError;
+					DXGI_RATIONAL refreshRate;
+					refreshRate.Numerator = 60;
+					refreshRate.Denominator = 1;
+
+					DXGI_MODE_DESC bufferDesc;
+					bufferDesc.Width = 100;
+					bufferDesc.Height = 100;
+					bufferDesc.RefreshRate = refreshRate;
+					bufferDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+					bufferDesc.ScanlineOrdering = DXGI_MODE_SCANLINE_ORDER_UNSPECIFIED;
+					bufferDesc.Scaling = DXGI_MODE_SCALING_UNSPECIFIED;
+
+					DXGI_SAMPLE_DESC sampleDesc;
+					sampleDesc.Count = 1;
+					sampleDesc.Quality = 0;
+
+					DXGI_SWAP_CHAIN_DESC swapChainDesc = {};
+					swapChainDesc.BufferDesc = bufferDesc;
+					swapChainDesc.SampleDesc = sampleDesc;
+					swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+					swapChainDesc.BufferCount = 2;
+					swapChainDesc.OutputWindow = window;
+					swapChainDesc.Windowed = 1;
+					swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+					swapChainDesc.Flags = DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH;
+
+					if (factory->CreateSwapChain(commandQueue, &swapChainDesc, &swapChain) < 0)
+					{
+						::DestroyWindow(window);
+						::UnregisterClass(windowClass.lpszClassName, windowClass.hInstance);
+						return Status::UnknownError;
+					}
+
+	                auto valueToFind = reinterpret_cast<uintptr_t>(commandQueue);
+	                auto* swapChainPtr = reinterpret_cast<uintptr_t*>(swapChain);
+
+	                auto addr = std::find(swapChainPtr, swapChainPtr + 512, valueToFind);
+
+	                g_commandQueueOffset = reinterpret_cast<uintptr_t>(addr) - reinterpret_cast<uintptr_t>(swapChainPtr);
 				}
+                else
+                {
+                	if (commandQueue->QueryInterface(__uuidof(ID3D12CommandQueueDownlevel), (void**)&commandQueueDownlevel) < 0)
+                	{
+                		::DestroyWindow(window);
+						::UnregisterClass(windowClass.lpszClassName, windowClass.hInstance);
+						return Status::UnknownError;
+                	}
+                	
+	                auto* commandQueueDownlevelPtr = reinterpret_cast<uintptr_t*>(commandQueueDownlevel);
+	                auto addr = std::find(commandQueueDownlevelPtr, commandQueueDownlevelPtr + 512, reinterpret_cast<uintptr_t>(commandQueue));
 
-                auto valueToFind = reinterpret_cast<uintptr_t>(commandQueue);
-                auto* swapChainPtr = reinterpret_cast<uintptr_t*>(swapChain);
-
-                auto addr = std::find(swapChainPtr, swapChainPtr + 512, valueToFind);
-
-                g_commandQueueOffset = reinterpret_cast<uintptr_t>(addr) - reinterpret_cast<uintptr_t>(swapChainPtr);
+	                g_commandQueueOffset = reinterpret_cast<uintptr_t>(addr) - reinterpret_cast<uintptr_t>(commandQueueDownlevelPtr);
+                }
 
 				g_methodsTable = (uint150_t*)::calloc(150, sizeof(uint150_t));
 				::memcpy(g_methodsTable, *(uint150_t**)device, 44 * sizeof(uint150_t));
 				::memcpy(g_methodsTable + 44, *(uint150_t**)commandQueue, 19 * sizeof(uint150_t));
 				::memcpy(g_methodsTable + 44 + 19, *(uint150_t**)commandAllocator, 9 * sizeof(uint150_t));
 				::memcpy(g_methodsTable + 44 + 19 + 9, *(uint150_t**)commandList, 60 * sizeof(uint150_t));
-				::memcpy(g_methodsTable + 44 + 19 + 9 + 60, *(uint150_t**)swapChain, 18 * sizeof(uint150_t));
+				if (swapChain != NULL)
+					::memcpy(g_methodsTable + 44 + 19 + 9 + 60, *(uint150_t**)swapChain, 18 * sizeof(uint150_t));
+                else if (commandQueueDownlevel != NULL)
+					::memcpy(g_methodsTable + 44 + 19 + 9 + 60, *(uint150_t**)commandQueueDownlevel, 4 * sizeof(uint150_t));
 
 #if KIERO_USE_MINHOOK
 #endif
@@ -536,8 +562,17 @@ kiero::Status::Enum kiero::init(RenderType::Enum _renderType)
 				commandList->Release();
 				commandList = NULL;
 
-				swapChain->Release();
-				swapChain = NULL;
+				if (swapChain != NULL)
+				{
+					swapChain->Release();
+					swapChain = NULL;
+				}
+
+				if (commandQueueDownlevel != NULL)
+				{
+					commandQueueDownlevel->Release();
+					commandQueueDownlevel = NULL;
+				}
 
 				::DestroyWindow(window);
 				::UnregisterClass(windowClass.lpszClassName, windowClass.hInstance);
@@ -746,7 +781,9 @@ void kiero::unbind(uint16_t _index)
 	if (g_renderType != RenderType::None)
 	{
 #if KIERO_USE_MINHOOK
-		MH_DisableHook((void*)g_methodsTable[_index]);
+		void* target = (void*)g_methodsTable[_index];
+		MH_DisableHook(target);
+		MH_RemoveHook(target);
 #endif
 	}
 }
@@ -766,3 +803,7 @@ uintptr_t kiero::getCommandQueueOffset()
     return g_commandQueueOffset;
 }
 
+bool kiero::isDownLevelDevice()
+{
+	return g_isDownLevelDevice;
+}

--- a/src/kiero/kiero.cpp
+++ b/src/kiero/kiero.cpp
@@ -378,48 +378,48 @@ kiero::Status::Enum kiero::init(RenderType::Enum _renderType)
 					return Status::ModuleNotFoundError;
 				}
 
-                if ((libD3D12 = ::GetModuleHandle(KIERO_TEXT("d3d12.dll"))) == NULL)
-                {
-                    if ((libD3D12 = ::LoadLibraryEx(KIERO_TEXT("d3d12.dll"), NULL, LOAD_LIBRARY_SEARCH_SYSTEM32)) == NULL)
-                    {
-                        const char* localD3d12Paths[] =
-                        {
-                            KIERO_TEXT(".\\d3d12.dll"),
-                            KIERO_TEXT(".\\d3d12on7\\d3d12.dll"),
-                            KIERO_TEXT(".\\12on7\\d3d12.dll")
-                        };
+				if ((libD3D12 = ::GetModuleHandle(KIERO_TEXT("d3d12.dll"))) == NULL)
+				{
+					if ((libD3D12 = ::LoadLibraryEx(KIERO_TEXT("d3d12.dll"), NULL, LOAD_LIBRARY_SEARCH_SYSTEM32)) == NULL)
+					{
+						const char* localD3d12Paths[] =
+						{
+							KIERO_TEXT(".\\d3d12.dll"),
+							KIERO_TEXT(".\\d3d12on7\\d3d12.dll"),
+							KIERO_TEXT(".\\12on7\\d3d12.dll")
+						};
 
-                        for (uint32_t i = 0; i < KIERO_ARRAY_SIZE(localD3d12Paths); i++)
-                        {
-                            libD3D12 = LoadLibrary(localD3d12Paths[i]);
-                            if (libD3D12 != NULL)
-                                break;
-                        }
+						for (uint32_t i = 0; i < KIERO_ARRAY_SIZE(localD3d12Paths); i++)
+						{
+							libD3D12 = LoadLibrary(localD3d12Paths[i]);
+							if (libD3D12 != NULL)
+								break;
+						}
 
-                        if (libD3D12 == NULL)
-                        {
-                            ::DestroyWindow(window);
-                            ::UnregisterClass(windowClass.lpszClassName, windowClass.hInstance);
-                            return Status::ModuleNotFoundError;
-                        }
-                    }
-                }
+						if (libD3D12 == NULL)
+						{
+							::DestroyWindow(window);
+							::UnregisterClass(windowClass.lpszClassName, windowClass.hInstance);
+							return Status::ModuleNotFoundError;
+						}
+					}
+				}
 
-                void* CreateDXGIFactory;
-                if ((CreateDXGIFactory = ::GetProcAddress(libDXGI, "CreateDXGIFactory")) == NULL)
-                {
-                    ::DestroyWindow(window);
-                    ::UnregisterClass(windowClass.lpszClassName, windowClass.hInstance);
-                    return Status::UnknownError;
-                }
+				void* CreateDXGIFactory;
+				if ((CreateDXGIFactory = ::GetProcAddress(libDXGI, "CreateDXGIFactory")) == NULL)
+				{
+					::DestroyWindow(window);
+					::UnregisterClass(windowClass.lpszClassName, windowClass.hInstance);
+					return Status::UnknownError;
+				}
 
-                IDXGIFactory* factory;
-                if (((long(__stdcall*)(const IID&, void**))(CreateDXGIFactory))(__uuidof(IDXGIFactory), (void**)&factory) < 0)
-                {
-                    ::DestroyWindow(window);
-                    ::UnregisterClass(windowClass.lpszClassName, windowClass.hInstance);
-                    return Status::UnknownError;
-                }
+				IDXGIFactory* factory;
+				if (((long(__stdcall*)(const IID&, void**))(CreateDXGIFactory))(__uuidof(IDXGIFactory), (void**)&factory) < 0)
+				{
+					::DestroyWindow(window);
+					::UnregisterClass(windowClass.lpszClassName, windowClass.hInstance);
+					return Status::UnknownError;
+				}
 
 				IDXGIAdapter* adapter;
 				if (factory->EnumAdapters(0, &adapter) == DXGI_ERROR_NOT_FOUND)
@@ -429,21 +429,21 @@ kiero::Status::Enum kiero::init(RenderType::Enum _renderType)
 					return Status::UnknownError;
 				}
 
-                void* D3D12CreateDevice;
-                if ((D3D12CreateDevice = ::GetProcAddress(libD3D12, "D3D12CreateDevice")) == NULL)
-                {
-                    ::DestroyWindow(window);
-                    ::UnregisterClass(windowClass.lpszClassName, windowClass.hInstance);
-                    return Status::UnknownError;
-                }
+				void* D3D12CreateDevice;
+				if ((D3D12CreateDevice = ::GetProcAddress(libD3D12, "D3D12CreateDevice")) == NULL)
+				{
+					::DestroyWindow(window);
+					::UnregisterClass(windowClass.lpszClassName, windowClass.hInstance);
+					return Status::UnknownError;
+				}
 
-                ID3D12Device* device;
-                if (((long(__stdcall*)(IUnknown*, D3D_FEATURE_LEVEL, const IID&, void**))(D3D12CreateDevice))(adapter, D3D_FEATURE_LEVEL_11_0, __uuidof(ID3D12Device), (void**)&device) < 0)
-                {
-                    ::DestroyWindow(window);
-                    ::UnregisterClass(windowClass.lpszClassName, windowClass.hInstance);
-                    return Status::UnknownError;
-                }
+				ID3D12Device* device;
+				if (((long(__stdcall*)(IUnknown*, D3D_FEATURE_LEVEL, const IID&, void**))(D3D12CreateDevice))(adapter, D3D_FEATURE_LEVEL_11_0, __uuidof(ID3D12Device), (void**)&device) < 0)
+				{
+					::DestroyWindow(window);
+					::UnregisterClass(windowClass.lpszClassName, windowClass.hInstance);
+					return Status::UnknownError;
+				}
 
 				D3D12_COMMAND_QUEUE_DESC queueDesc;
 				queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
@@ -477,7 +477,7 @@ kiero::Status::Enum kiero::init(RenderType::Enum _renderType)
 
 				ID3D12DeviceDownlevel* downlevelDevice;
 				g_isDownLevelDevice = device->QueryInterface(__uuidof(ID3D12DeviceDownlevel), (void**)&downlevelDevice) >= 0;
-                IDXGISwapChain* swapChain = NULL;
+				IDXGISwapChain* swapChain = NULL;
 				ID3D12CommandQueueDownlevel* commandQueueDownlevel = NULL;
 
 				if (!g_isDownLevelDevice)
@@ -515,27 +515,27 @@ kiero::Status::Enum kiero::init(RenderType::Enum _renderType)
 						return Status::UnknownError;
 					}
 
-	                auto valueToFind = reinterpret_cast<uintptr_t>(commandQueue);
-	                auto* swapChainPtr = reinterpret_cast<uintptr_t*>(swapChain);
+					auto valueToFind = reinterpret_cast<uintptr_t>(commandQueue);
+					auto* swapChainPtr = reinterpret_cast<uintptr_t*>(swapChain);
 
-	                auto addr = std::find(swapChainPtr, swapChainPtr + 512, valueToFind);
+					auto addr = std::find(swapChainPtr, swapChainPtr + 512, valueToFind);
 
-	                g_commandQueueOffset = reinterpret_cast<uintptr_t>(addr) - reinterpret_cast<uintptr_t>(swapChainPtr);
+					g_commandQueueOffset = reinterpret_cast<uintptr_t>(addr) - reinterpret_cast<uintptr_t>(swapChainPtr);
 				}
-                else
-                {
-                	if (commandQueue->QueryInterface(__uuidof(ID3D12CommandQueueDownlevel), (void**)&commandQueueDownlevel) < 0)
-                	{
-                		::DestroyWindow(window);
+				else
+				{
+					if (commandQueue->QueryInterface(__uuidof(ID3D12CommandQueueDownlevel), (void**)&commandQueueDownlevel) < 0)
+					{
+						::DestroyWindow(window);
 						::UnregisterClass(windowClass.lpszClassName, windowClass.hInstance);
 						return Status::UnknownError;
-                	}
-                	
-	                auto* commandQueueDownlevelPtr = reinterpret_cast<uintptr_t*>(commandQueueDownlevel);
-	                auto addr = std::find(commandQueueDownlevelPtr, commandQueueDownlevelPtr + 512, reinterpret_cast<uintptr_t>(commandQueue));
+					}
+					
+					auto* commandQueueDownlevelPtr = reinterpret_cast<uintptr_t*>(commandQueueDownlevel);
+					auto addr = std::find(commandQueueDownlevelPtr, commandQueueDownlevelPtr + 512, reinterpret_cast<uintptr_t>(commandQueue));
 
-	                g_commandQueueOffset = reinterpret_cast<uintptr_t>(addr) - reinterpret_cast<uintptr_t>(commandQueueDownlevelPtr);
-                }
+					g_commandQueueOffset = reinterpret_cast<uintptr_t>(addr) - reinterpret_cast<uintptr_t>(commandQueueDownlevelPtr);
+				}
 
 				g_methodsTable = (uint150_t*)::calloc(150, sizeof(uint150_t));
 				::memcpy(g_methodsTable, *(uint150_t**)device, 44 * sizeof(uint150_t));
@@ -544,7 +544,7 @@ kiero::Status::Enum kiero::init(RenderType::Enum _renderType)
 				::memcpy(g_methodsTable + 44 + 19 + 9, *(uint150_t**)commandList, 60 * sizeof(uint150_t));
 				if (swapChain != NULL)
 					::memcpy(g_methodsTable + 44 + 19 + 9 + 60, *(uint150_t**)swapChain, 18 * sizeof(uint150_t));
-                else if (commandQueueDownlevel != NULL)
+				else if (commandQueueDownlevel != NULL)
 					::memcpy(g_methodsTable + 44 + 19 + 9 + 60, *(uint150_t**)commandQueueDownlevel, 4 * sizeof(uint150_t));
 
 #if KIERO_USE_MINHOOK
@@ -800,7 +800,7 @@ uint150_t* kiero::getMethodsTable()
 
 uintptr_t kiero::getCommandQueueOffset()
 {
-    return g_commandQueueOffset;
+	return g_commandQueueOffset;
 }
 
 bool kiero::isDownLevelDevice()

--- a/src/kiero/kiero.h
+++ b/src/kiero/kiero.h
@@ -74,6 +74,7 @@ namespace kiero
 	RenderType::Enum getRenderType();
 	uint150_t* getMethodsTable();
 	uintptr_t getCommandQueueOffset();
+	bool isDownLevelDevice();
 }
 
 #endif // __KIERO_H__

--- a/src/overlay/Overlay.cpp
+++ b/src/overlay/Overlay.cpp
@@ -35,7 +35,7 @@ Overlay& Overlay::Get()
 
 extern IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
 
-void Overlay::DrawImgui(IDXGISwapChain3* apSwapChain)
+void Overlay::DrawImgui()
 {
     Scripting::Get();
 

--- a/src/overlay/Overlay.h
+++ b/src/overlay/Overlay.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "reverse/BasicTypes.h"
+#include "common/D3D12Downlevel.h"
 
 typedef TweakDBID TDBID;
 
@@ -9,6 +10,8 @@ struct ScriptStack;
 struct UnknownString;
 
 using TPresentD3D12 = long(IDXGISwapChain3* pSwapChain, UINT SyncInterval, UINT Flags);
+using TPresentD3D12Downlevel = HRESULT(ID3D12CommandQueueDownlevel* pCommandQueueDownlevel, ID3D12GraphicsCommandList* pOpenCommandList, ID3D12Resource* pSourceTex2D, HWND hWindow, D3D12_DOWNLEVEL_PRESENT_FLAGS Flags);
+using TCreateCommittedResource = HRESULT(ID3D12Device *pDevice, const D3D12_HEAP_PROPERTIES* pHeapProperties, D3D12_HEAP_FLAGS HeapFlags, const D3D12_RESOURCE_DESC* pDesc, D3D12_RESOURCE_STATES InitialResourceState, const D3D12_CLEAR_VALUE* pOptimizedClearValue, const IID* riidResource, void** ppvResource);
 using TExecuteCommandLists = void(ID3D12CommandQueue* apCommandQueue, UINT NumCommandLists, ID3D12CommandList* const* ppCommandLists);
 using TSetMousePosition = BOOL(void* apThis, HWND Wnd, long X, long Y);
 using TClipToCenter = HWND(RED4ext::REDreverse::CGameEngine::UnkC0* apThis);
@@ -53,10 +56,14 @@ protected:
 	};
 
 	bool InitializeD3D12(IDXGISwapChain3* pSwapChain);
+	bool InitializeD3D12Downlevel(ID3D12CommandQueue* pCommandQueue, ID3D12Resource* pSourceTex2D);
+	bool InitializeImGui(size_t buffersCounts, const std::function<bool(Overlay* overlay)>& reset);
 	void Render(IDXGISwapChain3* pSwapChain);
-	void DrawImgui(IDXGISwapChain3* apSwapChain);
+	void DrawImgui();
 
 	static long PresentD3D12(IDXGISwapChain3* pSwapChain, UINT SyncInterval, UINT Flags);
+	static HRESULT PresentD3D12Downlevel(ID3D12CommandQueueDownlevel* pCommandQueueDownlevel, ID3D12GraphicsCommandList* pOpenCommandList, ID3D12Resource* pSourceTex2D, HWND hWindow, D3D12_DOWNLEVEL_PRESENT_FLAGS Flags);
+	static HRESULT CreateCommittedResourceD3D12(ID3D12Device* pDevice, const D3D12_HEAP_PROPERTIES* pHeapProperties, D3D12_HEAP_FLAGS HeapFlags, const D3D12_RESOURCE_DESC* pDesc, D3D12_RESOURCE_STATES InitialResourceState, const D3D12_CLEAR_VALUE* pOptimizedClearValue, const IID* riidResource, void** ppvResource);
 	static void ExecuteCommandListsD3D12(ID3D12CommandQueue* apCommandQueue, UINT NumCommandLists, ID3D12CommandList* const* ppCommandLists);
 	static BOOL SetMousePosition(void* apThis, HWND Wnd, long X, long Y);
 	static BOOL ClipToCenter(RED4ext::REDreverse::CGameEngine::UnkC0* apThis);
@@ -77,9 +84,12 @@ private:
 	Overlay();
 
 	TPresentD3D12* m_realPresentD3D12{ nullptr };
+	TPresentD3D12Downlevel* m_realPresentD3D12Downlevel{ nullptr };
+	TCreateCommittedResource* m_realCreateCommittedResource{ nullptr };
 	TExecuteCommandLists* m_realExecuteCommandLists{ nullptr };
 
 	std::vector<FrameContext> m_frameContexts;
+	std::vector<CComPtr<ID3D12Resource>> m_downlevelBackbuffers;
 	CComPtr<IDXGISwapChain3> m_pdxgiSwapChain;
 	CComPtr<ID3D12Device> m_pd3d12Device;
 	CComPtr<ID3D12DescriptorHeap> m_pd3dRtvDescHeap;

--- a/src/overlay/Overlay_D3D12.cpp
+++ b/src/overlay/Overlay_D3D12.cpp
@@ -49,9 +49,10 @@ bool Overlay::InitializeD3D12(IDXGISwapChain3* pSwapChain)
         return true;
     };
 
-    static auto reset = [](Overlay* overlay) 
+    static auto reset = [](Overlay* overlay)
     {
         overlay->m_frameContexts.clear();
+        overlay->m_downlevelBackbuffers.clear();
         overlay->m_pdxgiSwapChain = nullptr;
         overlay->m_pd3d12Device = nullptr;
         overlay->m_pd3dRtvDescHeap = nullptr;
@@ -156,37 +157,9 @@ bool Overlay::InitializeD3D12(IDXGISwapChain3* pSwapChain)
     for (auto& context : m_frameContexts)
         m_pd3d12Device->CreateRenderTargetView(context.BackBuffer, nullptr, context.MainRenderTargetDescriptor);
 
-    IMGUI_CHECKVERSION();
-    ImGui::CreateContext();
-    ImGuiIO& io = ImGui::GetIO();
-    ImGui::StyleColorsDark();
-    io.Fonts->AddFontDefault();
-    io.IniFilename = NULL;
-
-    if (!ImGui_ImplWin32_Init(m_hWnd)) 
+    if (!InitializeImGui(buffersCounts, reset))
     {
-        spdlog::error("\tOverlay::InitializeD3D12() - ImGui_ImplWin32_Init call failed!");
-        ImGui::DestroyContext();
-        return reset(this);
-    }
-
-    if (!ImGui_ImplDX12_Init(m_pd3d12Device, buffersCounts,
-        DXGI_FORMAT_R8G8B8A8_UNORM, m_pd3dSrvDescHeap,
-        m_pd3dSrvDescHeap->GetCPUDescriptorHandleForHeapStart(),
-        m_pd3dSrvDescHeap->GetGPUDescriptorHandleForHeapStart()))
-    {
-        spdlog::error("\tOverlay::InitializeD3D12() - ImGui_ImplDX12_Init call failed!");
-        ImGui_ImplWin32_Shutdown();
-        ImGui::DestroyContext();
-        return reset(this);
-    }
-
-    if (!ImGui_ImplDX12_CreateDeviceObjects()) 
-    {
-        spdlog::error("\tOverlay::InitializeD3D12() - ImGui_ImplDX12_CreateDeviceObjects call failed!");
-        ImGui_ImplDX12_Shutdown();
-        ImGui_ImplWin32_Shutdown();
-        ImGui::DestroyContext();
+        spdlog::error("\tOverlay::InitializeD3D12() - failed to initialize ImGui!");
         return reset(this);
     }
 
@@ -202,14 +175,181 @@ bool Overlay::InitializeD3D12(IDXGISwapChain3* pSwapChain)
     return true;
 }
 
+bool Overlay::InitializeD3D12Downlevel(ID3D12CommandQueue* pCommandQueue, ID3D12Resource* pSourceTex2D)
+{
+    static auto reset = [](Overlay* overlay)
+    {
+        overlay->m_frameContexts.clear();
+        overlay->m_downlevelBackbuffers.clear();
+        overlay->m_pdxgiSwapChain = nullptr;
+        overlay->m_pd3d12Device = nullptr;
+        overlay->m_pd3dRtvDescHeap = nullptr;
+        overlay->m_pd3dSrvDescHeap = nullptr;
+        overlay->m_pd3dCommandList = nullptr;
+        // NOTE: not clearing m_hWnd, m_wndProc and m_pCommandQueue, as these should be persistent once set till the EOL of Overlay
+        return false;
+    };
+
+    // Window hook (repeated till successful, should be on first call)
+    if (m_hWnd == nullptr) 
+    {
+        if (EnumWindows(EnumWindowsProcMy, reinterpret_cast<LPARAM>(&m_hWnd)))
+            spdlog::error("\tOverlay::InitializeD3D12Downlevel() - window hook failed!");
+        else 
+        {
+            m_wndProc = reinterpret_cast<WNDPROC>(SetWindowLongPtr(m_hWnd, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(WndProc)));
+            spdlog::info("\tOverlay::InitializeD3D12Downlevel() - window hook complete.");
+        }
+    }
+
+    if (!pCommandQueue || !pSourceTex2D)
+        return false;
+
+    if (m_initialized) 
+        return true;
+
+    m_pCommandQueue = pCommandQueue;
+
+    if (FAILED(pSourceTex2D->GetDevice(IID_PPV_ARGS(&m_pd3d12Device))))
+    {
+        spdlog::error("\tOverlay::InitializeD3D12Downlevel() - failed to get device!");
+        return reset(this);
+    }
+
+    // Limit to at most 3 buffers
+    const auto buffersCounts = std::min<size_t>(m_downlevelBackbuffers.size(), 3);
+    m_frameContexts.resize(buffersCounts);
+    if (buffersCounts == 0)
+    {
+        spdlog::error("\tOverlay::InitializeD3D12Downlevel() - no backbuffers were found!");
+        return reset(this);
+    }
+
+    D3D12_DESCRIPTOR_HEAP_DESC rtvdesc;
+    rtvdesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+    rtvdesc.NumDescriptors = static_cast<UINT>(buffersCounts);
+    rtvdesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+    rtvdesc.NodeMask = 1;
+    if (FAILED(m_pd3d12Device->CreateDescriptorHeap(&rtvdesc, IID_PPV_ARGS(&m_pd3dRtvDescHeap))))
+    {
+        spdlog::error("\tOverlay::InitializeD3D12Downlevel() - failed to create RTV descriptor heap!");
+        return reset(this);
+    }
+
+    const SIZE_T rtvDescriptorSize = m_pd3d12Device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+    D3D12_CPU_DESCRIPTOR_HANDLE rtvHandle = m_pd3dRtvDescHeap->GetCPUDescriptorHandleForHeapStart();
+    for (auto& context : m_frameContexts)
+    {
+        context.MainRenderTargetDescriptor = rtvHandle;
+        rtvHandle.ptr += rtvDescriptorSize;
+    }
+
+    D3D12_DESCRIPTOR_HEAP_DESC srvdesc = {};
+    srvdesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+    srvdesc.NumDescriptors = 1;
+    srvdesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+    if (FAILED(m_pd3d12Device->CreateDescriptorHeap(&srvdesc, IID_PPV_ARGS(&m_pd3dSrvDescHeap))))
+    {
+        spdlog::error("\tOverlay::InitializeD3D12Downlevel() - failed to create SRV descriptor heap!");
+        return reset(this);
+    }
+    
+    for (auto& context : m_frameContexts)
+    {
+        if (FAILED(m_pd3d12Device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&context.CommandAllocator))))
+        {
+            spdlog::error("\tOverlay::InitializeD3D12Downlevel() - failed to create command allocator!");
+            return reset(this);
+        }
+    }
+
+    if (FAILED(m_pd3d12Device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_frameContexts[0].CommandAllocator, nullptr, IID_PPV_ARGS(&m_pd3dCommandList))))
+    {
+        spdlog::error("\tOverlay::InitializeD3D12Downlevel() - failed to create command list!");
+        return reset(this);
+    }
+
+    if (FAILED(m_pd3dCommandList->Close()))
+    {
+        spdlog::error("\tOverlay::InitializeD3D12Downlevel() - failed to close command list!");
+        return reset(this);
+    }
+
+    // Skip the first N - 3 buffers as they are no longer in use
+    auto skip = m_downlevelBackbuffers.size() - buffersCounts;
+    for (size_t i = 0; i < buffersCounts; i++)
+    {
+        auto& context = m_frameContexts[i];
+        context.BackBuffer = m_downlevelBackbuffers[i + skip];
+        m_pd3d12Device->CreateRenderTargetView(context.BackBuffer, nullptr, context.MainRenderTargetDescriptor);
+    }
+
+    if (!InitializeImGui(buffersCounts, reset))
+    {
+        spdlog::error("\tOverlay::InitializeD3D12Downlevel() - failed to initialize ImGui!");
+        return reset(this);
+    }
+
+    spdlog::info("\tOverlay::InitializeD3D12Downlevel() - initialization successful!");
+    m_initialized = true;
+
+    return true;
+}
+
+bool Overlay::InitializeImGui(size_t buffersCounts, const std::function<bool(Overlay* overlay)>& reset)
+{
+    IMGUI_CHECKVERSION();
+    ImGui::CreateContext();
+    ImGuiIO& io = ImGui::GetIO();
+    ImGui::StyleColorsDark();
+    io.Fonts->AddFontDefault();
+    io.IniFilename = NULL;
+
+    if (!ImGui_ImplWin32_Init(m_hWnd)) 
+    {
+        spdlog::error("\tOverlay::InitializeImGui() - ImGui_ImplWin32_Init call failed!");
+        ImGui::DestroyContext();
+        return reset(this);
+    }
+
+    if (!ImGui_ImplDX12_Init(m_pd3d12Device, static_cast<int>(buffersCounts),
+        DXGI_FORMAT_R8G8B8A8_UNORM, m_pd3dSrvDescHeap,
+        m_pd3dSrvDescHeap->GetCPUDescriptorHandleForHeapStart(),
+        m_pd3dSrvDescHeap->GetGPUDescriptorHandleForHeapStart()))
+    {
+        spdlog::error("\tOverlay::InitializeImGui() - ImGui_ImplDX12_Init call failed!");
+        ImGui_ImplWin32_Shutdown();
+        ImGui::DestroyContext();
+        return reset(this);
+    }
+
+    if (!ImGui_ImplDX12_CreateDeviceObjects()) 
+    {
+        spdlog::error("\tOverlay::InitializeImGui() - ImGui_ImplDX12_CreateDeviceObjects call failed!");
+        ImGui_ImplDX12_Shutdown();
+        ImGui_ImplWin32_Shutdown();
+        ImGui::DestroyContext();
+        return reset(this);
+    }
+
+    return true;
+}
+
 void Overlay::Render(IDXGISwapChain3* pSwapChain)
 {
+    // On Windows 7 there is no swap chain to query the current backbuffer index, so instead we simply count to 3 and wrap around.
+    // Increment the buffer index here even if the overlay is not enabled, so we stay in sync with the game's present calls.
+    // TODO: investigate if there isn't a better way of doing this
+    static uint32_t downLevelBufferIndex = 0;
+    const uint32_t currentDownlevelBufferIndex = downLevelBufferIndex;
+    downLevelBufferIndex = downLevelBufferIndex == 2 ? 0 : downLevelBufferIndex + 1;
+
     if (!IsEnabled())
         return;
 
-    DrawImgui(pSwapChain);
+    DrawImgui();
 
-    const auto bufferIndex = pSwapChain->GetCurrentBackBufferIndex();
+    const auto bufferIndex = pSwapChain != nullptr ? pSwapChain->GetCurrentBackBufferIndex() : currentDownlevelBufferIndex;
     auto& frameContext = m_frameContexts[bufferIndex];
     frameContext.CommandAllocator->Reset();
 


### PR DESCRIPTION
This PR adds support for Windows 7 to the overlay, using Direct3D12 with D3D12On7 as discussed in #134.

Notes on implementation:
- I've mostly kept to the naming scheme Microsoft uses when it discusses D3D12 on Windows 7. This means that variables and functions specific to Windows 7 are suffixed with 'downlevel' to distinguish them from common D3D12 functionality.
- Two hooks have been added: `PresentD3D12Downlevel` and `CreateCommittedResource`. These functions are only hooked on Windows 7. The `PresentD3D12Downlevel` hook serves the same purpose as the current `Present` hook but for Windows 7, where Present is called on the device and not on the swap chain. The  `CreateCommittedResource` hook is required to find the backbuffer addresses, since there is no swap chain to query these from. This function unhooks automatically after D3D12 is initialized and it has served its purpose.
- `InitializeD3D12Downlevel` is the main function responsible for initializing D3D12 on Windows 7. It is largely based on the existing `InitializeD3D12`, but I felt there were enough differences to warrant splitting the two. I moved ImGui initialization to a shared function, since this works with no changes on Windows 7 and 10.
- Because there is no swap chain on D3D12 on Windows 7, it is not possible to obtain the current back buffer index in `Overlay::Render()`. This could potentially mean large amounts of flickering due to the overlay only being in 1/3rd of frames. I've worked around this by adding a simple counter that wraps to 0 after every 3 calls to `Present()`. This actuallly works surprisingly well, but note that I haven't tested this thorougly over multiple hours of play, and only on one machine. If the counter does turn out to de-sync over time, an alternative might be to reverse the game to obtain the current backbuffer index that way.

Problems/limitations:
- Changing the resolution or resizing the window will break the overlay on Windows 7, even if you restore the old resolution afterwards. This is due to the difficulty of finding the Present backbuffers when there is no swap chain to query them from. This is also the reason for the existence of the `CreateCommittedResource` hook. Theoretically this hook could be made to collect potential backbuffer addresses indefinitely after the game has started, but that still leaves the issue of figuring out what the correct moment to reinitialize D3D12 is after a resize has occurred. Besides this, Cyberpunk 2077 itself handles window resizes very poorly to begin with (try it on Windows 10 if you want), so I don't currently see much use for this.