### PR TITLE
Minor fixes

### DIFF
--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -1,6 +1,5 @@
 #include <stdafx.h>
 
-#include <kiero/kiero.h>
 #include <overlay/Overlay.h>
 
 #include "Image.h"
@@ -67,20 +66,6 @@ void Initialize(HMODULE mod)
         Overlay::Initialize(&options.GameImage);
 
     MH_EnableHook(MH_ALL_HOOKS);
-
-    if (options.Console)
-    {
-        std::thread t([]()
-            {
-                if (kiero::init(kiero::RenderType::D3D12) != kiero::Status::Success)
-                {
-                    spdlog::error("Kiero failed!");
-                }
-                else
-                    Overlay::Get().Hook();
-            });
-        t.detach();
-    }
 
     spdlog::default_logger()->flush();
 }

--- a/src/overlay/Overlay.cpp
+++ b/src/overlay/Overlay.cpp
@@ -75,6 +75,7 @@ void Overlay::DrawImgui()
                 for (int i = clipper.DisplayStart; i < clipper.DisplayEnd; ++i) 
                 {
                     auto& item = m_outputLines[i];
+                    ImGui::PushID(i);
                     if (ImGui::Selectable(item.c_str()))
                     {
                         auto str = item;
@@ -83,6 +84,7 @@ void Overlay::DrawImgui()
 
                         std::strncpy(command, str.c_str(), sizeof(command) - 1);
                     }
+                    ImGui::PopID();
                 }
 
             if (m_outputScroll)

--- a/src/overlay/Overlay.h
+++ b/src/overlay/Overlay.h
@@ -54,10 +54,9 @@ protected:
 		CComPtr<ID3D12Resource> MainRenderTargetResource;
 		D3D12_CPU_DESCRIPTOR_HANDLE MainRenderTargetDescriptor{ 0 };
 	};
-
 	bool InitializeD3D12(IDXGISwapChain3* pSwapChain);
 	bool InitializeD3D12Downlevel(ID3D12CommandQueue* pCommandQueue, ID3D12Resource* pSourceTex2D);
-	bool InitializeImGui(size_t buffersCounts, const std::function<bool(Overlay* overlay)>& reset);
+	bool InitializeImGui();
 	void Render(IDXGISwapChain3* pSwapChain);
 	void DrawImgui();
 
@@ -82,6 +81,8 @@ protected:
 private:
 
 	Overlay();
+
+	bool InitializeD3D12Reset();
 
 	TPresentD3D12* m_realPresentD3D12{ nullptr };
 	TPresentD3D12Downlevel* m_realPresentD3D12Downlevel{ nullptr };

--- a/src/overlay/Overlay.h
+++ b/src/overlay/Overlay.h
@@ -56,7 +56,7 @@ protected:
 	};
 	bool InitializeD3D12(IDXGISwapChain3* pSwapChain);
 	bool InitializeD3D12Downlevel(ID3D12CommandQueue* pCommandQueue, ID3D12Resource* pSourceTex2D);
-	bool InitializeImGui();
+	bool InitializeImGui(size_t buffersCounts);
 	void Render(IDXGISwapChain3* pSwapChain);
 	void DrawImgui();
 

--- a/src/overlay/Overlay_D3D12.cpp
+++ b/src/overlay/Overlay_D3D12.cpp
@@ -157,7 +157,7 @@ bool Overlay::InitializeD3D12(IDXGISwapChain3* pSwapChain)
     for (auto& context : m_frameContexts)
         m_pd3d12Device->CreateRenderTargetView(context.BackBuffer, nullptr, context.MainRenderTargetDescriptor);
 
-    if (!InitializeImGui())
+    if (!InitializeImGui(buffersCounts))
     {
         spdlog::error("\tOverlay::InitializeD3D12() - failed to initialize ImGui!");
         return InitializeD3D12Reset();
@@ -271,7 +271,7 @@ bool Overlay::InitializeD3D12Downlevel(ID3D12CommandQueue* pCommandQueue, ID3D12
         m_pd3d12Device->CreateRenderTargetView(context.BackBuffer, nullptr, context.MainRenderTargetDescriptor);
     }
 
-    if (!InitializeImGui())
+    if (!InitializeImGui(buffersCounts))
     {
         spdlog::error("\tOverlay::InitializeD3D12Downlevel() - failed to initialize ImGui!");
         return InitializeD3D12Reset();
@@ -283,7 +283,7 @@ bool Overlay::InitializeD3D12Downlevel(ID3D12CommandQueue* pCommandQueue, ID3D12
     return true;
 }
 
-bool Overlay::InitializeImGui()
+bool Overlay::InitializeImGui(size_t buffersCounts)
 {
     IMGUI_CHECKVERSION();
     ImGui::CreateContext();
@@ -299,7 +299,7 @@ bool Overlay::InitializeImGui()
         return false;
     }
 
-    if (!ImGui_ImplDX12_Init(m_pd3d12Device, static_cast<int>(m_frameContexts.size()),
+    if (!ImGui_ImplDX12_Init(m_pd3d12Device, static_cast<int>(buffersCounts),
         DXGI_FORMAT_R8G8B8A8_UNORM, m_pd3dSrvDescHeap,
         m_pd3dSrvDescHeap->GetCPUDescriptorHandleForHeapStart(),
         m_pd3dSrvDescHeap->GetGPUDescriptorHandleForHeapStart()))

--- a/src/overlay/Overlay_D3D12.cpp
+++ b/src/overlay/Overlay_D3D12.cpp
@@ -24,6 +24,19 @@ BOOL CALLBACK EnumWindowsProcMy(HWND hwnd, LPARAM lParam)
     return TRUE;
 }
 
+bool Overlay::InitializeD3D12Reset()
+{
+    m_frameContexts.clear();
+    m_downlevelBackbuffers.clear();
+    m_pdxgiSwapChain = nullptr;
+    m_pd3d12Device = nullptr;
+    m_pd3dRtvDescHeap = nullptr;
+    m_pd3dSrvDescHeap = nullptr;
+    m_pd3dCommandList = nullptr;
+    // NOTE: not clearing m_hWnd, m_wndProc and m_pCommandQueue, as these should be persistent once set till the EOL of Overlay
+    return false;
+}
+
 bool Overlay::InitializeD3D12(IDXGISwapChain3* pSwapChain)
 {
     static auto checkCmdQueue = [](Overlay* overlay) 
@@ -47,19 +60,6 @@ bool Overlay::InitializeD3D12(IDXGISwapChain3* pSwapChain)
             return false;
         }
         return true;
-    };
-
-    static auto reset = [](Overlay* overlay)
-    {
-        overlay->m_frameContexts.clear();
-        overlay->m_downlevelBackbuffers.clear();
-        overlay->m_pdxgiSwapChain = nullptr;
-        overlay->m_pd3d12Device = nullptr;
-        overlay->m_pd3dRtvDescHeap = nullptr;
-        overlay->m_pd3dSrvDescHeap = nullptr;
-        overlay->m_pd3dCommandList = nullptr;
-        // NOTE: not clearing m_hWnd, m_wndProc and m_pCommandQueue, as these should be persistent once set till the EOL of Overlay
-        return false;
     };
 
     // Window hook (repeated till successful, should be on first call)
@@ -97,7 +97,7 @@ bool Overlay::InitializeD3D12(IDXGISwapChain3* pSwapChain)
     if (FAILED(m_pdxgiSwapChain->GetDevice(IID_PPV_ARGS(&m_pd3d12Device))))
     {
         spdlog::error("\tOverlay::InitializeD3D12() - failed to get device!");
-        return reset(this);
+        return InitializeD3D12Reset();
     }
 
     DXGI_SWAP_CHAIN_DESC sdesc;
@@ -119,7 +119,7 @@ bool Overlay::InitializeD3D12(IDXGISwapChain3* pSwapChain)
     if (FAILED(m_pd3d12Device->CreateDescriptorHeap(&rtvdesc, IID_PPV_ARGS(&m_pd3dRtvDescHeap))))
     {
         spdlog::error("\tOverlay::InitializeD3D12() - failed to create RTV descriptor heap!");
-        return reset(this);
+        return InitializeD3D12Reset();
     }
 
     const SIZE_T rtvDescriptorSize = m_pd3d12Device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
@@ -137,30 +137,30 @@ bool Overlay::InitializeD3D12(IDXGISwapChain3* pSwapChain)
     if (FAILED(m_pd3d12Device->CreateDescriptorHeap(&srvdesc, IID_PPV_ARGS(&m_pd3dSrvDescHeap))))
     {
         spdlog::error("\tOverlay::InitializeD3D12() - failed to create SRV descriptor heap!");
-        return reset(this);
+        return InitializeD3D12Reset();
     }
     
     for (auto& context : m_frameContexts)
         if (FAILED(m_pd3d12Device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&context.CommandAllocator))))
         {
             spdlog::error("\tOverlay::InitializeD3D12() - failed to create command allocator!");
-            return reset(this);
+            return InitializeD3D12Reset();
         }
 
     if (FAILED(m_pd3d12Device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_frameContexts[0].CommandAllocator, nullptr, IID_PPV_ARGS(&m_pd3dCommandList))) ||
         FAILED(m_pd3dCommandList->Close()))
     {
         spdlog::error("\tOverlay::InitializeD3D12() - failed to create command list!");
-        return reset(this);
+        return InitializeD3D12Reset();
     }
 
     for (auto& context : m_frameContexts)
         m_pd3d12Device->CreateRenderTargetView(context.BackBuffer, nullptr, context.MainRenderTargetDescriptor);
 
-    if (!InitializeImGui(buffersCounts, reset))
+    if (!InitializeImGui())
     {
         spdlog::error("\tOverlay::InitializeD3D12() - failed to initialize ImGui!");
-        return reset(this);
+        return InitializeD3D12Reset();
     }
 
     spdlog::info("\tOverlay::InitializeD3D12() - initialization successful!");
@@ -177,19 +177,6 @@ bool Overlay::InitializeD3D12(IDXGISwapChain3* pSwapChain)
 
 bool Overlay::InitializeD3D12Downlevel(ID3D12CommandQueue* pCommandQueue, ID3D12Resource* pSourceTex2D)
 {
-    static auto reset = [](Overlay* overlay)
-    {
-        overlay->m_frameContexts.clear();
-        overlay->m_downlevelBackbuffers.clear();
-        overlay->m_pdxgiSwapChain = nullptr;
-        overlay->m_pd3d12Device = nullptr;
-        overlay->m_pd3dRtvDescHeap = nullptr;
-        overlay->m_pd3dSrvDescHeap = nullptr;
-        overlay->m_pd3dCommandList = nullptr;
-        // NOTE: not clearing m_hWnd, m_wndProc and m_pCommandQueue, as these should be persistent once set till the EOL of Overlay
-        return false;
-    };
-
     // Window hook (repeated till successful, should be on first call)
     if (m_hWnd == nullptr) 
     {
@@ -213,7 +200,7 @@ bool Overlay::InitializeD3D12Downlevel(ID3D12CommandQueue* pCommandQueue, ID3D12
     if (FAILED(pSourceTex2D->GetDevice(IID_PPV_ARGS(&m_pd3d12Device))))
     {
         spdlog::error("\tOverlay::InitializeD3D12Downlevel() - failed to get device!");
-        return reset(this);
+        return InitializeD3D12Reset();
     }
 
     // Limit to at most 3 buffers
@@ -222,7 +209,7 @@ bool Overlay::InitializeD3D12Downlevel(ID3D12CommandQueue* pCommandQueue, ID3D12
     if (buffersCounts == 0)
     {
         spdlog::error("\tOverlay::InitializeD3D12Downlevel() - no backbuffers were found!");
-        return reset(this);
+        return InitializeD3D12Reset();
     }
 
     D3D12_DESCRIPTOR_HEAP_DESC rtvdesc;
@@ -233,7 +220,7 @@ bool Overlay::InitializeD3D12Downlevel(ID3D12CommandQueue* pCommandQueue, ID3D12
     if (FAILED(m_pd3d12Device->CreateDescriptorHeap(&rtvdesc, IID_PPV_ARGS(&m_pd3dRtvDescHeap))))
     {
         spdlog::error("\tOverlay::InitializeD3D12Downlevel() - failed to create RTV descriptor heap!");
-        return reset(this);
+        return InitializeD3D12Reset();
     }
 
     const SIZE_T rtvDescriptorSize = m_pd3d12Device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
@@ -251,7 +238,7 @@ bool Overlay::InitializeD3D12Downlevel(ID3D12CommandQueue* pCommandQueue, ID3D12
     if (FAILED(m_pd3d12Device->CreateDescriptorHeap(&srvdesc, IID_PPV_ARGS(&m_pd3dSrvDescHeap))))
     {
         spdlog::error("\tOverlay::InitializeD3D12Downlevel() - failed to create SRV descriptor heap!");
-        return reset(this);
+        return InitializeD3D12Reset();
     }
     
     for (auto& context : m_frameContexts)
@@ -259,20 +246,20 @@ bool Overlay::InitializeD3D12Downlevel(ID3D12CommandQueue* pCommandQueue, ID3D12
         if (FAILED(m_pd3d12Device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&context.CommandAllocator))))
         {
             spdlog::error("\tOverlay::InitializeD3D12Downlevel() - failed to create command allocator!");
-            return reset(this);
+            return InitializeD3D12Reset();
         }
     }
 
     if (FAILED(m_pd3d12Device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_frameContexts[0].CommandAllocator, nullptr, IID_PPV_ARGS(&m_pd3dCommandList))))
     {
         spdlog::error("\tOverlay::InitializeD3D12Downlevel() - failed to create command list!");
-        return reset(this);
+        return InitializeD3D12Reset();
     }
 
     if (FAILED(m_pd3dCommandList->Close()))
     {
         spdlog::error("\tOverlay::InitializeD3D12Downlevel() - failed to close command list!");
-        return reset(this);
+        return InitializeD3D12Reset();
     }
 
     // Skip the first N - 3 buffers as they are no longer in use
@@ -284,10 +271,10 @@ bool Overlay::InitializeD3D12Downlevel(ID3D12CommandQueue* pCommandQueue, ID3D12
         m_pd3d12Device->CreateRenderTargetView(context.BackBuffer, nullptr, context.MainRenderTargetDescriptor);
     }
 
-    if (!InitializeImGui(buffersCounts, reset))
+    if (!InitializeImGui())
     {
         spdlog::error("\tOverlay::InitializeD3D12Downlevel() - failed to initialize ImGui!");
-        return reset(this);
+        return InitializeD3D12Reset();
     }
 
     spdlog::info("\tOverlay::InitializeD3D12Downlevel() - initialization successful!");
@@ -296,7 +283,7 @@ bool Overlay::InitializeD3D12Downlevel(ID3D12CommandQueue* pCommandQueue, ID3D12
     return true;
 }
 
-bool Overlay::InitializeImGui(size_t buffersCounts, const std::function<bool(Overlay* overlay)>& reset)
+bool Overlay::InitializeImGui()
 {
     IMGUI_CHECKVERSION();
     ImGui::CreateContext();
@@ -309,10 +296,10 @@ bool Overlay::InitializeImGui(size_t buffersCounts, const std::function<bool(Ove
     {
         spdlog::error("\tOverlay::InitializeImGui() - ImGui_ImplWin32_Init call failed!");
         ImGui::DestroyContext();
-        return reset(this);
+        return false;
     }
 
-    if (!ImGui_ImplDX12_Init(m_pd3d12Device, static_cast<int>(buffersCounts),
+    if (!ImGui_ImplDX12_Init(m_pd3d12Device, static_cast<int>(m_frameContexts.size()),
         DXGI_FORMAT_R8G8B8A8_UNORM, m_pd3dSrvDescHeap,
         m_pd3dSrvDescHeap->GetCPUDescriptorHandleForHeapStart(),
         m_pd3dSrvDescHeap->GetGPUDescriptorHandleForHeapStart()))
@@ -320,7 +307,7 @@ bool Overlay::InitializeImGui(size_t buffersCounts, const std::function<bool(Ove
         spdlog::error("\tOverlay::InitializeImGui() - ImGui_ImplDX12_Init call failed!");
         ImGui_ImplWin32_Shutdown();
         ImGui::DestroyContext();
-        return reset(this);
+        return false;
     }
 
     if (!ImGui_ImplDX12_CreateDeviceObjects()) 
@@ -329,7 +316,7 @@ bool Overlay::InitializeImGui(size_t buffersCounts, const std::function<bool(Ove
         ImGui_ImplDX12_Shutdown();
         ImGui_ImplWin32_Shutdown();
         ImGui::DestroyContext();
-        return reset(this);
+        return false;
     }
 
     return true;


### PR DESCRIPTION
Few smaller fixes, didnt wanted to pull each one separately...

- fix problem with unselectable console items
- change a bit Overlay's Initialize/Shutdown again (CTD at exit is not yet fixed still, some more debugging to do... if we want to just F it, we could remove Overlay::Shutdown from picture temporarily...)
- pulled out that reset lambda from InitializeD3D12 as was proposed in #318
- do not call reset inside InitializeImGui, it should have not been there (prolly nothing bad in the end, but was redundant to say the least)

Wanted to do other Overlay changes to things that got added... But as I cannot debug these changes, I rather play it safe... And just pulled that single function out, leaving other things as they were.

Hope @Mattiwatti gets around eventually to finish it.