### PR TITLE
[overlay] Make text input grab keyboard focus

### DIFF
--- a/src/overlay/Overlay.cpp
+++ b/src/overlay/Overlay.cpp
@@ -108,6 +108,7 @@ void Overlay::DrawImgui()
         }
 
         ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
+        ImGui::SetKeyboardFocusHere();
         const auto execute = ImGui::InputText("", command, std::size(command), ImGuiInputTextFlags_EnterReturnsTrue);
         ImGui::SetItemDefaultFocus();
         if (execute)
@@ -118,8 +119,6 @@ void Overlay::DrawImgui()
 
             if (m_inputClear)
                 std::memset(command, 0, sizeof(command));
-
-            ImGui::SetKeyboardFocusHere();
         }
     }
     else


### PR DESCRIPTION
Small quality of life change: make it so that pressing the console key will focus the overlay's text input field so it's possible to begin typing immediately.

It looks like this was already the intended behaviour, only `ImGui::SetKeyboardFocusHere()` was being called after creating the widget, whereas the docs say that it applies focus to the *following* widget (which didn't exist because the text input is the last widget added).