### PR TITLE
Allow calling functions that don't expect ScriptGameInstance

### DIFF
--- a/src/scripting/Scripting.cpp
+++ b/src/scripting/Scripting.cpp
@@ -494,9 +494,11 @@ sol::object Scripting::Execute(const std::string& aFuncName, sol::variadic_args 
     RED4ext::CName name;
     uint8_t argOffset = 0;
 
-    if (pFunc->params.size > 0) {
+    if (pFunc->params.size > 0)
+    {
         auto* pType = pFunc->params[0]->type;
-        if (pType == pGIType) {
+        if (pType == pGIType)
+        {
             argOffset = 1;
         }
     }

--- a/src/scripting/Scripting.cpp
+++ b/src/scripting/Scripting.cpp
@@ -461,7 +461,6 @@ sol::object Scripting::Execute(const std::string& aFuncName, sol::variadic_args 
     static const auto hashGameInstance = RED4ext::FNV1a("ScriptGameInstance");
     auto* pGIType = pRtti->GetType(RED4ext::FNV1a("ScriptGameInstance"));
 
-
     auto* pPlayerSystem = pRtti->GetClass(hashcpPlayerSystem);
     auto* gameInstanceType = pRtti->GetClass(hashGameInstance);
 
@@ -497,6 +496,7 @@ sol::object Scripting::Execute(const std::string& aFuncName, sol::variadic_args 
     if (pFunc->params.size > 0)
     {
         auto* pType = pFunc->params[0]->type;
+        // check if the first argument is expected to be ScriptGameInstance
         if (pType == pGIType)
         {
             argOffset = 1;
@@ -504,7 +504,6 @@ sol::object Scripting::Execute(const std::string& aFuncName, sol::variadic_args 
     }
 
     std::vector<CStackType> args(aArgs.size() + argOffset);
-
 
     if (pFunc->params.size - argOffset != aArgs.size())
     {
@@ -517,6 +516,7 @@ sol::object Scripting::Execute(const std::string& aFuncName, sol::variadic_args 
 
     if (argOffset > 0)
     {
+        // Inject the ScriptGameInstance into first argument
         args[0].type = pFunc->params[0]->type;
         args[0].value = &unk10;
     }


### PR DESCRIPTION
I've added some logic that checks if the first argument of `pFunc` expects a `ScriptGameInstance` before injecting the instance.

This enables calling of functions that don't require a `ScriptGameInstance`.

For example, calling `Game.GetFunFact()` without this PR will return `Function 'Game.GetFunFact' expects 4294967295 parameters, not 0`, whereas with the PR, it will call and return that function.

I haven't touched C++ for almost 20 years so apologies for any mistakes. Tested against master and 1.06.

Note: Build will fail because lua.org's SSL certificate expired earlier today.