### PR TITLE
D3D12on7 changes

### DIFF
--- a/src/overlay/Overlay_D3D12.cpp
+++ b/src/overlay/Overlay_D3D12.cpp
@@ -227,6 +227,8 @@ bool Overlay::InitializeD3D12Downlevel(ID3D12CommandQueue* pCommandQueue, ID3D12
     }
 
     m_pCommandQueue = pCommandQueue;
+    m_outWidth = static_cast<UINT>(pSourceTex2D->GetDesc().Width);
+    m_outHeight = pSourceTex2D->GetDesc().Height;
 
     if (hWindow != m_hWnd) 
         spdlog::warn("Overlay::InitializeD3D12Downlevel() - current output window does not match hooked window! Currently hooked to {0} while current output window is {1}.", reinterpret_cast<void*>(m_hWnd), reinterpret_cast<void*>(hWindow));


### PR DESCRIPTION
- Revert 2facdc7 (resize detection); was causing CTD even if not resizing for some users. Resize detection will have to be done some other way (if at all possible reliably on Windows 7, since there is no swap chain)
- Initialize `m_outWidth` and `m_outHeight` in `InitializeD3D12Downlevel` so that console properly spans the entire window width on Windows 7