### PR TITLE
Split Log output by newline

### DIFF
--- a/src/overlay/Overlay.cpp
+++ b/src/overlay/Overlay.cpp
@@ -396,7 +396,13 @@ bool Overlay::IsEnabled() const
 void Overlay::Log(const std::string& acpText)
 {
     std::lock_guard<std::recursive_mutex> _{ m_outputLock };
-    m_outputLines.emplace_back(acpText);
+    std::istringstream lines(acpText);
+    std::string line;
+
+    while (std::getline(lines, line))
+    {
+        m_outputLines.emplace_back(line);
+    }
     m_outputScroll = true;
 }
 


### PR DESCRIPTION
This PR splits the Log() output into lines as `ImGuiListClipper` is designed to work with mostly-uniformly sized rows. This fixes the issue where console can't scroll to the bottom when `Dump()` output is bigger than the console.