### PR TITLE
Add disable_win7_vsync to options

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Works with 1.06.
 | Remove pedestrians and traffic | Removes most of the pedestrians and traffic |
 | Disable Async Compute | Disables async compute, this can give a boost on older GPUs (Nvidia 10xx series for example)|
 | Disable Antialiasing TAA | Disables antialiasing, not recommended but you do what you want! |
+| Disable Windows 7 VSync | Disables VSync on Windows 7 to bypass the 60 FPS limit |
 | Console | Adds an overlay to draw a console so you can write any kind of script command (full Lua support) |
 
 ### Upcoming

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -102,6 +102,7 @@ Options::Options(HMODULE aModule)
         this->PatchDisableIntroMovies = config.value("disable_intro_movies", this->PatchDisableIntroMovies);
         this->PatchDisableVignette = config.value("disable_vignette", this->PatchDisableVignette);
         this->PatchDisableBoundaryTeleport = config.value("disable_boundary_teleport", this->PatchDisableBoundaryTeleport);
+        this->PatchDisableWin7Vsync = config.value("disable_win7_vsync", this->PatchDisableWin7Vsync);
 
         this->DumpGameOptions = config.value("dump_game_options", this->DumpGameOptions);
         this->Console = config.value("console", this->Console);
@@ -131,6 +132,7 @@ Options::Options(HMODULE aModule)
     config["disable_intro_movies"] = this->PatchDisableIntroMovies;
     config["disable_vignette"] = this->PatchDisableVignette;
     config["disable_boundary_teleport"] = this->PatchDisableBoundaryTeleport;
+    config["disable_win7_vsync"] = this->PatchDisableWin7Vsync;
 
     std::ofstream o(configPath);
     o << config.dump(4) << std::endl;

--- a/src/Options.h
+++ b/src/Options.h
@@ -19,6 +19,7 @@ struct Options
     bool PatchDisableIntroMovies{ false };
     bool PatchDisableVignette{ false };
     bool PatchDisableBoundaryTeleport{ false };
+    bool PatchDisableWin7Vsync{ false };
 
     bool DumpGameOptions{ false };
     bool Console{ true };

--- a/src/d3d12/D3D12_Hooks.cpp
+++ b/src/d3d12/D3D12_Hooks.cpp
@@ -32,6 +32,9 @@ HRESULT D3D12::Present(IDXGISwapChain* apSwapChain, UINT aSyncInterval, UINT aPr
 
 HRESULT D3D12::PresentDownlevel(ID3D12CommandQueueDownlevel* apCommandQueueDownlevel, ID3D12GraphicsCommandList* apOpenCommandList, ID3D12Resource* apSourceTex2D, HWND ahWindow, D3D12_DOWNLEVEL_PRESENT_FLAGS aFlags)
 {
+    if (Options::Get().PatchDisableWin7Vsync)
+        aFlags &= ~D3D12_DOWNLEVEL_PRESENT_FLAG_WAIT_FOR_VBLANK;
+
     auto& d3d12 = Get();
 
     // On Windows 7 there is no swap chain to query the current backbuffer index, so instead we simply count to 3 and wrap around.


### PR DESCRIPTION
The game always passes `D3D12_DOWNLEVEL_PRESENT_FLAG_WAIT_FOR_VBLANK` to `ID3D12CommandQueueDownlevel::Present` regardless of the actually selected VSync setting. This means FPS is limited to 60 on Windows 7 no matter what.

This PR adds an option to disable VSync on Windows 7 by stripping the flag in the `D3D12::PresentDownlevel` hook.