### PR TITLE
[d3d12on7] Refactor backbuffer indexing and handle resizes

### DIFF
--- a/src/d3d12/D3D12.h
+++ b/src/d3d12/D3D12.h
@@ -11,6 +11,8 @@ using TExecuteCommandLists = void(ID3D12CommandQueue*, UINT, ID3D12CommandList* 
 
 struct D3D12
 {
+    static const uint32_t g_numDownlevelBackbuffersRequired = 3; // Windows 7 only: number of buffers needed before we start rendering
+
     static void Initialize();
     static void Shutdown();
     static D3D12& Get();


### PR DESCRIPTION
This is a fixed version of the (now reverted) resize detection on Windows 7 that was added in 2facdc7, which was causing crashes to desktop for some users. This version has been tested and verified working by a user who was getting CTDs with the previous version.

Apart from working resize handling, the backbuffer index is now found using a better method than the naive `+= 1` strategy that was being used previously. The index of the passed-in buffer is found using a reverse lookup in the known list. If the buffer is not found, a window resize is assumed and the D3D12 state is reset.