### PR TITLE
Fix ImGui.CalcTextSize overloads (Lua bindings)

### DIFF
--- a/src/sol_imgui/README.md
+++ b/src/sol_imgui/README.md
@@ -1324,13 +1324,12 @@ selected, activated = ImGui.MenuItem("Label", "ALT+F4", selected, true)
 ## Text Utilities
 ```lua
   -- ImGui.CalcTextSize(...)
-  -- Parameters: text (text), text (text_end) [O], bool (hide_text_after_double_hash) [O], float (wrap_width) [O]
+  -- Parameters: text (text), bool (hide_text_after_double_hash) [O], float (wrap_width) [O]
   -- Returns: float (x), float (y)
   -- Overloads
   x, y = ImGui.CalcTextSize("Calculate me")
-  x, y = ImGui.CalcTextSize("Calculate me", " with an ending?")
-  x, y = ImGui.CalcTextSize("Calculate me", " with an ending?", true)
-  x, y = ImGui.CalcTextSize("Calculate me", " with an ending?", true, 100)
+  x, y = ImGui.CalcTextSize("Calculate me", true)
+  x, y = ImGui.CalcTextSize("Calculate me", true, 100)
 ```
 
 ## Color Utilities

--- a/src/sol_imgui/sol_imgui.h
+++ b/src/sol_imgui/sol_imgui.h
@@ -1549,9 +1549,8 @@ namespace sol_ImGui
 
     // Text Utilities
     inline std::tuple<float, float> CalcTextSize(const std::string& text)																					{ const auto vec2{ ImGui::CalcTextSize(text.c_str()) }; return std::make_tuple(vec2.x, vec2.y); }
-    inline std::tuple<float, float> CalcTextSize(const std::string& text, const std::string& text_end)														{ const auto vec2{ ImGui::CalcTextSize(text.c_str(), text_end.c_str()) }; return std::make_tuple(vec2.x, vec2.y); }
-    inline std::tuple<float, float> CalcTextSize(const std::string& text, const std::string& text_end, bool hide_text_after_double_hash)					{ const auto vec2{ ImGui::CalcTextSize(text.c_str(), text_end.c_str(), hide_text_after_double_hash) }; return std::make_tuple(vec2.x, vec2.y); }
-    inline std::tuple<float, float> CalcTextSize(const std::string& text, const std::string& text_end, bool hide_text_after_double_hash, float wrap_width)	{ const auto vec2{ ImGui::CalcTextSize(text.c_str(), text_end.c_str(), hide_text_after_double_hash, wrap_width) }; return std::make_tuple(vec2.x, vec2.y); }
+    inline std::tuple<float, float> CalcTextSize(const std::string& text, bool hide_text_after_double_hash)					{ const auto vec2{ ImGui::CalcTextSize(text.c_str(), nullptr, hide_text_after_double_hash) }; return std::make_tuple(vec2.x, vec2.y); }
+    inline std::tuple<float, float> CalcTextSize(const std::string& text, bool hide_text_after_double_hash, float wrap_width)	{ const auto vec2{ ImGui::CalcTextSize(text.c_str(), nullptr, hide_text_after_double_hash, wrap_width) }; return std::make_tuple(vec2.x, vec2.y); }
 
     // Color Utilities
     inline sol::as_table_t<std::vector<float>> ColorConvertU32ToFloat4(unsigned int in)
@@ -2698,9 +2697,8 @@ namespace sol_ImGui
 #pragma region Text Utilities
         ImGui.set_function("CalcTextSize"					, sol::overload(
                                                                 sol::resolve<std::tuple<float, float>(const std::string&)>(CalcTextSize),
-                                                                sol::resolve<std::tuple<float, float>(const std::string&, const std::string&)>(CalcTextSize),
-                                                                sol::resolve<std::tuple<float, float>(const std::string&, const std::string&, bool)>(CalcTextSize),
-                                                                sol::resolve<std::tuple<float, float>(const std::string&, const std::string&, bool, float)>(CalcTextSize)
+                                                                sol::resolve<std::tuple<float, float>(const std::string&, bool)>(CalcTextSize),
+                                                                sol::resolve<std::tuple<float, float>(const std::string&, bool, float)>(CalcTextSize)
                                                             ));
 #pragma endregion Text Utilities
 


### PR DESCRIPTION
@Nats-ji pointed out this issue :P 

That text_end argument was just retarded for Lua, doesnt make any sense for it.