### PR TITLE
Fixes for v1.10 on Windows 7

### DIFF
--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -122,7 +122,6 @@ Options::Options(Paths& aPaths)
         throw std::runtime_error("Not Cyberpunk2077.exe");
 
     set_default_logger(CreateLogger(m_paths.CETRoot() / "cyber_engine_tweaks.log", "main"));
-    spdlog::flush_every(std::chrono::seconds(3));
 
     spdlog::info("Cyber Engine Tweaks is starting...");
 

--- a/src/d3d12/D3D12.h
+++ b/src/d3d12/D3D12.h
@@ -37,7 +37,7 @@ protected:
         D3D12_CPU_DESCRIPTOR_HANDLE MainRenderTargetDescriptor{ 0 };
     };
 
-    bool ResetState();
+    bool ResetState(bool aClearDownlevelBackbuffers = true);
     bool Initialize(IDXGISwapChain* apSwapChain);
     bool InitializeDownlevel(ID3D12CommandQueue* apCommandQueue, ID3D12Resource* apSourceTex2D, HWND ahWindow);
     bool InitializeImGui(size_t aBuffersCounts);

--- a/src/d3d12/D3D12_Functions.cpp
+++ b/src/d3d12/D3D12_Functions.cpp
@@ -375,7 +375,7 @@ bool D3D12::InitializeImGui(size_t aBuffersCounts)
         return false;
     }
 
-    if (!ImGui_ImplDX12_CreateDeviceObjects()) 
+    if (!ImGui_ImplDX12_CreateDeviceObjects(m_pCommandQueue)) 
     {
         spdlog::error("D3D12::InitializeImGui() - ImGui_ImplDX12_CreateDeviceObjects call failed!");
         ImGui_ImplDX12_Shutdown();
@@ -388,7 +388,7 @@ bool D3D12::InitializeImGui(size_t aBuffersCounts)
 
 void D3D12::Update()
 {
-    ImGui_ImplDX12_NewFrame();
+    ImGui_ImplDX12_NewFrame(m_pCommandQueue);
     ImGui_ImplWin32_NewFrame(m_outSize);
     ImGui::NewFrame();
     

--- a/src/d3d12/D3D12_Functions.cpp
+++ b/src/d3d12/D3D12_Functions.cpp
@@ -9,7 +9,7 @@
 #include <window/Window.h>
 #include "Options.h"
 
-bool D3D12::ResetState()
+bool D3D12::ResetState(bool aClearDownlevelBackbuffers)
 {
     if (m_initialized)
     {   
@@ -18,7 +18,8 @@ bool D3D12::ResetState()
         ImGui_ImplWin32_Shutdown();
     }
     m_frameContexts.clear();
-    m_downlevelBackbuffers.clear();
+    if (aClearDownlevelBackbuffers)
+        m_downlevelBackbuffers.clear();
     m_pdxgiSwapChain = nullptr;
     m_pd3d12Device = nullptr;
     m_pd3dRtvDescHeap = nullptr;

--- a/src/d3d12/D3D12_Hooks.cpp
+++ b/src/d3d12/D3D12_Hooks.cpp
@@ -90,11 +90,13 @@ HRESULT D3D12::CreateCommittedResource(ID3D12Device* apDevice, const D3D12_HEAP_
         // Store the returned resource
         d3d12.m_downlevelBackbuffers.emplace_back(static_cast<ID3D12Resource*>(*appvResource));
         spdlog::debug("D3D12::CreateCommittedResourceD3D12() - found valid backbuffer target at {0}.", *appvResource);
-    }
 
-    // If D3D12 has been initialized, there is no need to continue hooking this function since the backbuffers are only created once.
-    if (d3d12.m_initialized)
-        kiero::unbind(27);
+        if (d3d12.m_initialized)
+        {
+            // Reset state (a resize may have happened), but don't touch the backbuffer list. The downlevel Present hook will take care of this
+            d3d12.ResetState(false);
+        }
+    }
 
     return result;
 }

--- a/src/d3d12/D3D12_Hooks.cpp
+++ b/src/d3d12/D3D12_Hooks.cpp
@@ -38,7 +38,10 @@ HRESULT D3D12::PresentDownlevel(ID3D12CommandQueueDownlevel* apCommandQueueDownl
     auto& d3d12 = CET::Get().GetD3D12();
 
     // On Windows 7 there is no swap chain to query the current backbuffer index. Instead do a reverse lookup in the known backbuffer list
-    auto it = std::find(d3d12.m_downlevelBackbuffers.cbegin(), d3d12.m_downlevelBackbuffers.cend(), apSourceTex2D);
+    const auto cbegin = d3d12.m_downlevelBackbuffers.size() >= g_numDownlevelBackbuffersRequired
+        ? d3d12.m_downlevelBackbuffers.cend() - g_numDownlevelBackbuffersRequired
+        : d3d12.m_downlevelBackbuffers.cbegin();
+    auto it = std::find(cbegin, d3d12.m_downlevelBackbuffers.cend(), apSourceTex2D);
     if (it == d3d12.m_downlevelBackbuffers.cend())
     {
         if (d3d12.m_initialized)

--- a/src/imgui_impl/dx12.h
+++ b/src/imgui_impl/dx12.h
@@ -29,9 +29,9 @@ struct D3D12_GPU_DESCRIPTOR_HANDLE;
 // font_srv_cpu_desc_handle and font_srv_gpu_desc_handle are handles to a single SRV descriptor to use for the internal font texture.
 IMGUI_IMPL_API bool ImGui_ImplDX12_Init(ID3D12Device* apDevice, int aNumFramesInFlight, DXGI_FORMAT aRTVFormat, ID3D12DescriptorHeap* apSRVHeapDesc, D3D12_CPU_DESCRIPTOR_HANDLE aFontSRVDescCPU, D3D12_GPU_DESCRIPTOR_HANDLE aFontSRVDescGPU);
 IMGUI_IMPL_API void ImGui_ImplDX12_Shutdown();
-IMGUI_IMPL_API void ImGui_ImplDX12_NewFrame();
+IMGUI_IMPL_API void ImGui_ImplDX12_NewFrame(ID3D12CommandQueue* apCommandQueue);
 IMGUI_IMPL_API void ImGui_ImplDX12_RenderDrawData(ImDrawData* apDrawData, ID3D12GraphicsCommandList* apCommandLists);
 
 // Use if you want to reset your rendering device without losing Dear ImGui state.
 IMGUI_IMPL_API void ImGui_ImplDX12_InvalidateDeviceObjects();
-IMGUI_IMPL_API bool ImGui_ImplDX12_CreateDeviceObjects();
+IMGUI_IMPL_API bool ImGui_ImplDX12_CreateDeviceObjects(ID3D12CommandQueue* apCommandQueue);


### PR DESCRIPTION
This fixes a number of issues on Windows 7 (also see issue #429):
- Changed imgui to reuse the game's D3D12 command queue rather than making a new one. This fixes a crash on Windows 7 and ensures the GPU node index of the command queue always corresponds to the mask used by the game.
- Fixed D3D12 backbuffer index finding on Windows 7 with v1.10.
- Fixed window resizes breaking the overlay on Windows 7 with v1.10.

~~An unresolved issue on Windows 7 currently is zombie `Cyberpunk2077.exe`s sticking around after exiting the game.~~ Also fixed.