### PR TITLE
Enable ImGui keyboard navigation and sol_imgui.h update/fix

### DIFF
--- a/src/imgui_impl/win32.cpp
+++ b/src/imgui_impl/win32.cpp
@@ -63,6 +63,7 @@ bool ImGui_ImplWin32_Init(HWND ahWnd)
     ImGuiIO& io = ImGui::GetIO();
     io.BackendFlags |= ImGuiBackendFlags_HasMouseCursors;         // We can honor GetMouseCursor() values (optional)
     io.BackendFlags |= ImGuiBackendFlags_HasSetMousePos;          // We can honor io.WantSetMousePos requests (optional, rarely used)
+    io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
     io.BackendPlatformName = "imgui_impl_win32";
     io.ImeWindowHandle = ahWnd;
 
@@ -155,7 +156,7 @@ static void ImGui_ImplWin32_UpdateMousePos(SIZE aOutSize)
             if (::GetCursorPos(&pos) && ::ScreenToClient(g_hWnd, &pos))
                 if (!aOutSize.cx || !aOutSize.cy)
                     io.MousePos = ImVec2((float)pos.x, (float)pos.y);
-                else 
+                else
                 {
                     RECT clientRect;
                     ::GetClientRect(g_hWnd, &clientRect);

--- a/src/sol_imgui/README.md
+++ b/src/sol_imgui/README.md
@@ -23,7 +23,7 @@ You can find all the supported functions and overloads below.
   shouldDraw = ImGui.Begin("Name")
   open, shouldDraw = ImGui.Begin("Name", open)
   open, shouldDraw = ImGui.Begin("Name", open, ImGuiWindowFlags.NoMove)
-  
+
   -- ImGui.End()
   ImGui.End()
 ```
@@ -39,7 +39,7 @@ You can find all the supported functions and overloads below.
   shouldDraw = ImGui.BeginChild("Name", 100, 200)
   shouldDraw = ImGui.BeginChild("Name", 100, 200, true)
   shouldDraw = ImGui.BeginChild("Name", 100, 200, true, ImGuiWindowFlags.NoMove)
-  
+
   -- ImGui.EndChild()
   ImGui.EndChild()
 ```
@@ -49,122 +49,122 @@ You can find all the supported functions and overloads below.
   -- ImGui.IsWindowAppearing()
   -- Returns: bool (appearing)
   appearing = ImGui.IsWindowAppearing()
-  
+
   -- ImGui.IsWindowCollapsed()
   -- Returns: bool (collapsed)
   collapsed = ImGui.IsWindowCollapsed()
-  
+
   -- ImGui.IsWindowFocused(...)
   -- Parameters: ImGuiFocusedFlags (flags) [O]
   -- Returns: bool (focused)
   -- Overloads
   focused = ImGui.IsWindowFocused()
   focused = ImGui.IsWindowFocused(ImGuiFocusedFlags.ChildWindows)
-  
+
   -- ImGui.IsWindowHovered(...)
   -- Parameters: ImGuiHoveredFlags (flags) [O]
   -- Returns: bool (hovered)
   -- Overloads
   hovered = ImGui.IswindowHovered()
   hovered = ImGui.IsWindowHovered(ImGuiHoveredFlags.ChildWindows)
-  
+
   -- ImGui.GetWindowDpiScale()
   -- Returns: float (dpiScale)
   dpiScale = ImGui.GetWindowDpiScale()
-  
+
   -- ImGui.GetWindowPos()
   -- Returns: float (pos_x), float (pos_y)
   pos_x, pos_y = ImGui.GetWindowPos()
-  
+
   -- ImGui.GetWindowSize()
   -- Returns: float (size_x), float (size_y)
   size_x, size_y = ImGui.GetWindowSize()
-  
+
   -- ImGui.GetWindowWidth()
   -- Returns: float (width)
   width = ImGui.GetWindowWidth()
-  
+
   -- ImGui.GetWindowHeight()
   -- Returns: float (height)
   height = ImGui.GetWindowHeight()
-  
+
   -- ImGui.SetNextWindowPos(...)
   -- Parameters: float (pos_x), float (pos_y), ImGuiCond (cond) [O], float (pivot_x) [O], float (pivot_y) [O]
   -- Overloads
   ImGui.SetNextWindowPos(100, 100)
   ImGui.SetNextWindowPos(100, 100, ImGuiCond.Always)
   ImGui.SetNextWindowPos(100, 100, ImGuiCond.Always, 0, 0.5)
-  
+
   -- ImGui.SetNextWindowSize(...)
   -- Parameters: float (size_x), float (size_y), ImGuiCond (cond) [O]
   -- Overloads
   ImGui.SetNextWindowSize(500, 500)
   ImGui.SetNextWindowSize(500, 500, ImGuiCond.Appearing)
-  
+
   -- ImGui.SetNextWindowSizeConstraints(...)
   -- Parameters: float (min_x), float (min_y), float (max_x), float (max_y)
   ImGui.SetNextWindowSizeConstraints(100, 100, 500, 600)
-  
+
   -- ImGui.SetNextWindowContentSize(...)
   -- Parameters: float (size_x), float (size_y)
   ImGui.SetNextWindowContentSize(200, 100)
-  
+
   -- ImGui.SetNextWindowCollapsed(...)
   -- Parameters: bool (collapsed), ImGuiCond (cond) [O]
   -- Overloads
   ImGui.SetNextWindowCollapsed(true)
   ImGui.SetNextWindowCollapsed(true, ImGuiCond.Appearing)
-  
+
   -- ImGui.SetNextWindowFocus()
   ImGui.SetNextWindowFocus()
-  
+
   -- ImGui.SetNextWindowBgAlpha(...)
   -- Parameters: float (alpha)
   ImGui.SetNextWindowBgAlpha(0.5)
-  
+
   -- ImGui.SetWindowPos(...)
   -- Parameters: float (pos_x), float (pos_y), ImguiCond (cond) [O]
   -- Overloads
   ImGui.SetWindowPos(100, 100)
   ImGui.SetWindowPos(100, 100, ImGuiCond.Appearing)
-  
+
   -- ImGui.SetWindowSize(...)
   -- Parameters: float (size_x), float (size_y), ImguiCond (cond) [O]
   -- Overloads
   ImGui.SetWindowSize(100, 300)
   ImGui.SetWindowSize(100, 300, ImGuiCond.Appearing)
-  
+
   -- ImGui.SetWindowCollapsed(...)
   -- Parameters: bool (collapsed), ImguiCond (cond) [O]
   -- Overloads
   ImGui.SetWindowCollapsed(false)
   ImGui.SetWindowCollapsed(true, ImGuiCond.Appearing)
-  
+
   -- ImGui.SetWindowFocus()
   ImGui.SetWindowFocus()
-  
+
   -- ImGui.SetWindowFontScale(...)
   -- Parameters: float (scale)
   ImGui.SetWindowFontScale(1.2)
-  
+
   -- ImGui.SetWindowPos(...)
   -- Parameters: text (name), float (pos_x), float (pos_y), ImGuiCond (cond) [O]
   -- Overloads
   ImGui.SetWindowPos("WindowName", 100, 100)
   ImGui.SetWindowPos("WindowName", 100, 100, ImGuiCond.Always)
-  
+
   -- ImGui.SetWindowSize(...)
   -- Parameters: text (name), float (size_x), float (size_y), ImGuiCond (cond) [O]
   -- Overloads
   ImGui.SetWindowSize("WindowName", 300, 400)
   ImGui.SetWindowSize("WindowName", 300, 400, ImGuiCond.Always)
-  
+
   -- ImGui.SetWindowCollapsed(...)
   -- Parameters: text (name), bool (collapsed), ImGuiCond (cond) [O]
   -- Overloads
   ImGui.SetWindowCollapsed("WindowName", true)
   ImGui.SetWindowCollapsed("WindowName", false, ImGuiCond.Always)
-  
+
   -- ImGui.SetWindowFocus(...)
   -- Parameters: text (name)
   ImGui.SetWindowFocus("WindowName")
@@ -175,19 +175,19 @@ You can find all the supported functions and overloads below.
   -- ImGui.GetContentRegionMax()
   -- Returns: float (x), float (y)
   x, y = ImGui.GetContentRegionMax()
-  
+
   -- ImGui.GetContentRegionAvail()
   -- Returns: float (x), float (y)
   x, y = ImGui.GetContentRegionAvail()
-  
+
   -- ImGui.GetWindowContentRegionMin()
   -- Returns: float (x), float (y)
   x, y = ImGui.GetWindowContentRegionMin()
-  
+
   -- ImGui.GetWindowContentRegionMax()
   -- Returns: float (x), float (y)
   x, y = ImGui.GetWindowContentRegionMax()
-  
+
   -- ImGui.GetWindowContentRegionWidth()
   -- Returns: float (width)
   width = ImGui.GetWindowContentRegionWidth()
@@ -198,45 +198,45 @@ You can find all the supported functions and overloads below.
   -- ImGui.GetScrollX()
   -- Returns: float (x)
   x = ImGui.GetScrollX()
-  
+
   -- ImGui.GetScrollY()
   -- Returns: float (y)
   y = ImGui.GetScrollY()
-  
+
   -- ImGui.GetScrollMaxX()
   -- Returns: float (x)
   x = ImGui.GetScrollMaxX()
-  
+
   -- ImGui.GetScrollMaxY()
   -- Returns: float (y)
   y = ImGui.GetScrollMaxY()
-  
+
   -- ImGui.SetScrollX(...)
   -- Parameters: float (scroll_x)
   ImGui.SetScrollX(0.7)
-  
+
   -- ImGui.SetScrollY(...)
   -- Parameters: float (scroll_y)
   ImGui.SetScrollY(0.7)
-  
+
   -- ImGui.SetScrollHereX(...)
   -- Parameters: float (center_x_ratio) [O]
   -- Overloads
   ImGui.SetScrollHereX()
   ImGui.SetScrollHereX(0.5)
-  
+
   -- ImGui.SetScrollHereY(...)
   -- Parameters: float (center_y_ratio) [O]
   -- Overloads
   ImGui.SetScrollHereY()
   ImGui.SetScrollHereY(0.5)
-  
+
   -- ImGui.SetScrollFromPosX(...)
   -- Parameters: float (local_x), float (center_x_ratio) [O]
   -- Overloads
   ImGui.SetScrollFromPosX(10)
   ImGui.SetScrollFromPosX(10, 0.5)
-  
+
   -- ImGui.SetScrollFromPosY(...)
   -- Parameters: float (local_y), float (center_y_ratio) [O]
   -- Overloads
@@ -245,40 +245,41 @@ You can find all the supported functions and overloads below.
 ```
 
 ## Parameters Stacks (Shared)  
+```lua
   -- ImGui.PushStyleColor(...)
   -- Parameters A: ImGuiCol (idx), int (color_u32)
   -- Parameters B: ImGuiCol (idx), float (color_r), float (color_g), float (color_b), float (color_a)
   -- Overloads
   ImGui.PushStyleColor(ImGuiCol.Tab, 0xF42069FF)
   ImGui.PushStyleColor(ImGuiCol.Border, 1, 0, 0, 1)
-  
+
   -- ImGui.PopStyleColor(...)
   -- Parameters: int (count) [O]
   -- Overloads
   ImGui.PopStyleColor()
   ImGui.PopStyleColor(5)
-  
+
   -- ImGui.PushStyleVar(...)
   -- Parameters A: ImGuiStyleVar (idx), float (value)
   -- Parameters B: ImGuiStyleVar (idx), float (value_x), float (value_y)
   -- Overloads
   ImGui.PushStyleVar(ImGuiStyleVar.Alpha, 0.5)
   ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, 0.2, 0.1)
-  
+
   -- ImGui.PopStyleVar(...)
   -- Parameters: int (count) [O]
   ImGui.PopStyleVar()
   ImGui.PopStyleVar(2)
-  
+
   -- ImGui.GetStyleColorVec4(...)
   -- Parameters: ImGuiCol (idx)
   -- Returns: float (color_r), float (color_g), float (color_b), float (color_a)
   color_r, color_g, color_b, color_a = ImGui.GetStyleColorVec4(ImGuiCol.Text)
-    
+
   -- ImGui.GetFontSize()
   -- Returns: float (fontSize)
   fontSize = ImGui.GetFontSize()
-  
+
   -- ImGui.GetFontTexUvWhitePixel()
   -- Returns: float (x), float (y)
   x, y = ImGui.GetFontTexUvWhitePixel()
@@ -298,38 +299,38 @@ You can find all the supported functions and overloads below.
   -- ImGui.PushItemWidth(...)
   -- Parameters: float (width)
   ImGui.PushItemWidth(100)
-  
+
   -- ImGui.PopItemWidth()
   ImGui.PopItemWidth()
-  
+
   -- ImGui.SetNextItemWidth(...)
   -- Parameters: float (width)
   ImGui.SetNextItemWidth(100)
-  
+
   -- ImGui.CalcItemWidth()
   -- Returns: float (width)
   width = ImGui.CalcItemWidth()
-  
+
   -- ImGui.PushTextWrapPos(...)
   -- Parameters: float (wrap_local_pos_x) [O]
   -- Overloads
   ImGui.PushTextWrapPos()
   ImGui.PushTextWrapPos(50)
-  
+
   -- ImGui.PopTextWrapPos()
   ImGui.PopTextWrapPos()
-  
+
   -- ImGui.PushAllowKeyboardFocus(...)
   -- Parameters: bool (allow_keyboard_focus)
   ImGui.PushAllowKeyboardFocus(true)
-  
+
   -- ImGui.PopAllowKeyboardFocus()
   ImGui.PopAllowKeyboardFocus()
-  
+
   -- ImGui.PushButtonRepeat(...)
   -- Parameters: bool (repeat)
   ImGui.PushButtonRepeat(true)
-  
+
   -- ImGui.PopButtonRepeat()
   ImGui.PopButtonRepeat()
 ```
@@ -338,91 +339,91 @@ You can find all the supported functions and overloads below.
 ```lua
   -- ImGui.Separator()
   ImGui.Separator
-  
+
   -- ImGui.SameLine(...)
   -- Parameters: float (offset_from_start_x) [O], float (spacing) [O]
   -- Overloads
   ImGui.SameLine()
   ImGui.SameLine(100)
   ImGui.SameLine(100, 5)
-  
+
   -- ImGui.NewLine()
   ImGui.NewLine()
-  
+
   -- ImGui.Spacing()
   ImGui.Spacing()
-  
+
   -- ImGui.Dummy(...)
   -- Parameters: float (size_x), float (size_y)
   ImGui.Dummy(100, 200)
-  
+
   -- ImGui.Indent(...)
   -- Parameters: float (indent_w) [O]
   ImGui.Indent()
   ImGui.Indent(10)
-  
+
   -- ImGui.Unindent(...)
   -- Parameters: float (indent_w) [O]
   ImGui.Unindent()
   ImGui.Unindent(-10)
-  
+
   -- ImGui.BeginGroup()
   ImGui.BeginGroup()
-  
+
   -- ImGui.EndGroup()
   ImGui.EndGroup()
-  
+
   -- ImGui.GetCursorPos()
   -- Returns: float (x), float(y)
   x, y = ImGui.GetCursorPos()
-  
+
   -- ImGui.GetCursorPosX()
   -- Returns: float (x)
   x = ImGui.GetCursorPosX()
-  
+
   -- ImGui.GetCursorPosY()
   -- Returns: float (y)
   y = ImGui.GetCursorPosY()
-  
+
   -- ImGui.SetCursorPos(...)
   -- Parameters: float (x), float (y)
   ImGui.SetCursorPos(10, 10)
-  
+
   -- ImGui.SetCursorPosX(...)
   -- Parameters: float (x)
   ImGui.SetCursorPosX(10)
-  
+
   -- ImGui.SetCursorPosY(...)
   -- Parameters: float (y)
   ImGui.SetCursorPosY(10)
-  
+
   -- ImGui.GetCursorStartPos()
   -- Returns: float (x), float(y)
   x, y = ImGui.GetCursorStartPos()
-  
+
   -- ImGui.GetCursorScreenPos()
   -- Returns: float (x), float(y)
   x, y = ImGui.GetCursorScreenPos()
-  
+
   -- ImGui.SetCursorScreenPos(...)
   -- Parameters: float (x), float (y)
   ImGui.SetCursorScreenPos(10, 10)
-  
+
   -- ImGui.AlignTextToFramePadding()
   ImGui.AlignTextToFramePadding()
-  
+
   -- ImGui.GetTextLineHeight()
   -- Returns: float (height)
   height = ImGui.GetTextLineHeight()
-  
+
   -- ImGui.GetTextLineHeightWithSpacing()
   -- Returns: float (height)
   height = ImGui.GetTextLineHeightWithSpacing()
-  
+
   -- ImGui.GetFrameHeight()
   -- Returns: float (height)
   height = ImGui.GetFrameHeight()
-  
+
   -- ImGui.GetFrameHeightWithSpacing()
   -- Returns: float (height)
   height = ImGui.GetFrameHeightWithSpacing()
@@ -438,10 +439,10 @@ You can find all the supported functions and overloads below.
   ImGui.PushID("MyID")
   ImGui.PushID("MyID_Begin", "MyID_End")
   ImGui.PushID(1)
-  
+
   -- ImGui.PopID()
   ImGui.PopID()
-  
+
   -- ImGui.GetID(...)
   -- Parameters A: text (str_id)
   -- Parameters B: text (str_id_begin), text (str_id_end)
@@ -458,27 +459,27 @@ You can find all the supported functions and overloads below.
   -- Overloads
   ImGui.TextUnformatted("I am Unformatted")
   ImGui.TextUnformatted("I am ", "Unformatted")
-  
+
   -- ImGui.Text(...)
   -- Parameters: text (text)
   ImGui.Text("Well hello there, General Kenobi")
-  
+
   -- ImGui.TextColored(...)
   -- Parameters: float (color_r), float (color_g), float (color_b), float (color_a), text (text)
   ImGui.TextColored(1, 0, 0, 1, "Well hello there, General Kenobi")
-  
+
   -- ImGui.TextDisabled(...)
   -- Parameters: text (text)
   ImGui.TextDisabled("Well hello there, General Kenobi")
-  
+
   -- ImGui.TextWrapped(...)
   -- Parameters: text (text)
   ImGui.TextWrapped("Well hello there, General Kenobi")
-  
+
   -- ImGui.LabelText(...)
   -- Parameters: text (label), text (text)
   ImGui.LabelText("Well hello there", "General Kenobi")
-  
+
   -- ImGui.BulletText(...)
   -- Parameters: text (text)
   ImGui.BulletText("Well hello there, General Kenobi")
@@ -492,27 +493,27 @@ You can find all the supported functions and overloads below.
   -- Overloads
   clicked = ImGui.Button("Label")
   clicked = ImGui.Button("Label", 100, 50)
-  
+
   -- ImGui.SmallButton(...)
   -- Parameters: text (label)
   -- Returns: bool (clicked)
   clicked = ImGui.SmallButton("Label")
-  
+
   -- ImGui.InvisibleButton(...)
   -- Parameters: text (label), float (size_x), float (size_y)
   -- Returns: bool (clicked)
   clicked = ImGui.InvisibleButton("Label", 100, 50)
-  
+
   -- ImGui.ArrowButton(...)
   -- Parameters: text (str_id), ImGuiDir (dir)
   -- Returns: bool (clicked)
   clicked = ImGui.ArrowButton("I have an arrow", ImGuiDir.Down)
-  
+
   -- ImGui.Checkbox(...)
   -- Parameters: text (label), bool (value)
   -- Returns: bool (value), bool (pressed)
   value, pressed = ImGui.Checkbox("My Checkbox", value)
-  
+
   -- ImGui.RadioButton(...)
   -- Parameters A: text (label), bool (active)
   -- Parameters B: text (label), int (value), int (v_button)
@@ -521,14 +522,14 @@ You can find all the supported functions and overloads below.
   -- Overloads
   pressed = ImGui.RadioButton("Click me", pressed == true)
   value, pressed = ImGui.RadioButton("Click me too", value, 2)
-  
+
   -- ImGui.ProgressBar(...)
   -- Parameters: float (fraction), float (size_x) [O], float (size_y) [O], text (overlay) [O]
   -- Overloads
   ImGui.ProgressBar(0.5)
   ImGui.ProgressBar(0.5, 100, 25)
   ImGui.ProgressBar(0.5, 100, 25, "Loading Failed. Sike. - 50%")
-  
+
   -- ImGui.Bullet()
   ImGui.Bullet()
 ```
@@ -541,13 +542,13 @@ You can find all the supported functions and overloads below.
   -- Overloads
   shouldDraw = ImGui.BeginCombo("My Combo", "Preview")
   shouldDraw = ImGui.BeginCombo("My Combo", "Preview", ImGuiComboFlags.PopupAlignLeft)
-  
+
   -- ImGui.EndCombo()
   ImGui.EndCombo()
-  
+
   -- ImGui.Combo(...)
-  -- Parameters A: text (label), int (current_item), table (items), int (items_count), int (popup_max_height_in_items) [O] 
-  -- Parameters B: text (label), int (current_item), text (items_separated_by_zeros), int (popup_max_height_in_items) [O] 
+  -- Parameters A: text (label), int (current_item), table (items), int (items_count), int (popup_max_height_in_items) [O]
+  -- Parameters B: text (label), int (current_item), text (items_separated_by_zeros), int (popup_max_height_in_items) [O]
   -- Returns: int (current_item), bool (clicked)
   -- Overloads
   current_item, clicked = ImGui.Combo("Label", current_item, { "Option 1 ", "Option 2" }, 2)
@@ -559,7 +560,7 @@ You can find all the supported functions and overloads below.
 ## Widgets: Drags
 ```lua
   -- ImGui.DragFloat(...)
-  -- Parameters: text (label), float (value), float (value_speed) [O], float (value_min) [O], float (value_max) [O], text (format) [O], float (power) [O]
+  -- Parameters: text (label), float (value), float (value_speed) [O], float (value_min) [O], float (value_max) [O], text (format) [O], ImGuiSliderFlags (flags) [O]
   -- Returns: float (value), bool (used)
   -- Overloads
   value, used = ImGui.DragFloat("Label", value)
@@ -567,10 +568,10 @@ You can find all the supported functions and overloads below.
   value, used = ImGui.DragFloat("Label", value, 0.01, -10)
   value, used = ImGui.DragFloat("Label", value, 0.01, -10, 10)
   value, used = ImGui.DragFloat("Label", value, 0.01, -10, 10, "%.1f")
-  value, used = ImGui.DragFloat("Label", value, 0.01, -10, 10, "%.1f", 0.5)
-  
+  value, used = ImGui.DragFloat("Label", value, 0.01, -10, 10, "%.1f", ImGuiSliderFlags.Logarithmic)
+
   -- ImGui.DragFloat2(...)
-  -- Parameters: text (label), table (values), float (value_speed) [O], float (value_min) [O], float (value_max) [O], text (format) [O], float (power) [O]
+  -- Parameters: text (label), table (values), float (value_speed) [O], float (value_min) [O], float (value_max) [O], text (format) [O], ImGuiSliderFlags (flags) [O]
   -- Returns: table (values), bool (used)
   -- Overloads
   values, used = ImGui.DragFloat2("Label", values)
@@ -578,10 +579,10 @@ You can find all the supported functions and overloads below.
   values, used = ImGui.DragFloat2("Label", values, 0.01, -10)
   values, used = ImGui.DragFloat2("Label", values, 0.01, -10, 10)
   values, used = ImGui.DragFloat2("Label", values, 0.01, -10, 10, "%.1f")
-  values, used = ImGui.DragFloat2("Label", values, 0.01, -10, 10, "%.1f", 0.5)
-  
+  values, used = ImGui.DragFloat2("Label", values, 0.01, -10, 10, "%.1f", ImGuiSliderFlags.Logarithmic)
+
   -- ImGui.DragFloat3(...)
-  -- Parameters: text (label), table (values), float (value_speed) [O], float (value_min) [O], float (value_max) [O], text (format) [O], float (power) [O]
+  -- Parameters: text (label), table (values), float (value_speed) [O], float (value_min) [O], float (value_max) [O], text (format) [O], ImGuiSliderFlags (flags) [O]
   -- Returns: table (values), bool (used)
   -- Overloads
   values, used = ImGui.DragFloat3("Label", values)
@@ -589,10 +590,10 @@ You can find all the supported functions and overloads below.
   values, used = ImGui.DragFloat3("Label", values, 0.01, -10)
   values, used = ImGui.DragFloat3("Label", values, 0.01, -10, 10)
   values, used = ImGui.DragFloat3("Label", values, 0.01, -10, 10, "%.1f")
-  values, used = ImGui.DragFloat3("Label", values, 0.01, -10, 10, "%.1f", 0.5)
-  
+  values, used = ImGui.DragFloat3("Label", values, 0.01, -10, 10, "%.1f", ImGuiSliderFlags.Logarithmic)
+
   -- ImGui.DragFloat4(...)
-  -- Parameters: text (label), table (values), float (value_speed) [O], float (value_min) [O], float (value_max) [O], text (format) [O], float (power) [O]
+  -- Parameters: text (label), table (values), float (value_speed) [O], float (value_min) [O], float (value_max) [O], text (format) [O], ImGuiSliderFlags (flags) [O]
   -- Returns: table (values), bool (used)
   -- Overloads
   values, used = ImGui.DragFloat4("Label", values)
@@ -600,8 +601,8 @@ You can find all the supported functions and overloads below.
   values, used = ImGui.DragFloat4("Label", values, 0.01, -10)
   values, used = ImGui.DragFloat4("Label", values, 0.01, -10, 10)
   values, used = ImGui.DragFloat4("Label", values, 0.01, -10, 10, "%.1f")
-  values, used = ImGui.DragFloat4("Label", values, 0.01, -10, 10, "%.1f", 0.5)
-  
+  values, used = ImGui.DragFloat4("Label", values, 0.01, -10, 10, "%.1f", ImGuiSliderFlags.Logarithmic)
+
   -- ImGui.DragInt(...)
   -- Parameters: text (label), int (value), float (value_speed) [O], int (value_min) [O], int (value_max) [O], text (format) [O]
   -- Returns: int (value), bool (used)
@@ -611,7 +612,7 @@ You can find all the supported functions and overloads below.
   value, used = ImGui.DragInt("Label", value, 0.01, -10)
   value, used = ImGui.DragInt("Label", value, 0.01, -10, 10)
   value, used = ImGui.DragInt("Label", value, 0.01, -10, 10, "%d")
-  
+
   -- ImGui.DragInt2(...)
   -- Parameters: text (label), table (values), float (value_speed) [O], int (value_min) [O], int (value_max) [O], text (format) [O]
   -- Returns: table (values), bool (used)
@@ -621,7 +622,7 @@ You can find all the supported functions and overloads below.
   values, used = ImGui.DragInt2("Label", values, 0.01, -10)
   values, used = ImGui.DragInt2("Label", values, 0.01, -10, 10)
   values, used = ImGui.DragInt2("Label", values, 0.01, -10, 10, "%d")
-  
+
   -- ImGui.DragInt3(...)
   -- Parameters: text (label), table (values), float (value_speed) [O], int (value_min) [O], int (value_max) [O], text (format) [O]
   -- Returns: table (values), bool (used)
@@ -631,7 +632,7 @@ You can find all the supported functions and overloads below.
   values, used = ImGui.DragInt3("Label", values, 0.01, -10)
   values, used = ImGui.DragInt3("Label", values, 0.01, -10, 10)
   values, used = ImGui.DragInt3("Label", values, 0.01, -10, 10, "%d")
-  
+
   -- ImGui.DragInt4(...)
   -- Parameters: text (label), table (values), float (value_speed) [O], int (value_min) [O], int (value_max) [O], text (format) [O]
   -- Returns: table (values), bool (used)
@@ -646,37 +647,37 @@ You can find all the supported functions and overloads below.
 ## Widgets: Sliders
 ```lua
   -- ImGui.SliderFloat(...)
-  -- Parameters: text (label), float (value), float (value_min), float (value_max), text (format) [O], float (power) [O]
+  -- Parameters: text (label), float (value), float (value_min), float (value_max), text (format) [O], ImGuiSliderFlags (flags) [O]
   -- Returns: float (value), bool (used)
   -- Overloads
   value, used = ImGui.SliderFloat("Label", value, -10, 10)
   value, used = ImGui.SliderFloat("Label", value, -10, 10, "%.1f")
-  value, used = ImGui.SliderFloat("Label", value, -10, 10, "%.1f", 0.5)
-  
+  value, used = ImGui.SliderFloat("Label", value, -10, 10, "%.1f", ImGuiSliderFlags.Logarithmic)
+
   -- ImGui.SliderFloat2(...)
-  -- Parameters: text (label), table (values), float (value_min), float (value_max), text (format) [O], float (power) [O]
+  -- Parameters: text (label), table (values), float (value_min), float (value_max), text (format) [O], ImGuiSliderFlags (flags) [O]
   -- Returns: table (values), bool (used)
   -- Overloads
   values, used = ImGui.SliderFloat2("Label", values, 0.01, -10, 10)
   values, used = ImGui.SliderFloat2("Label", values, 0.01, -10, 10, "%.1f")
-  values, used = ImGui.SliderFloat2("Label", values, 0.01, -10, 10, "%.1f", 0.5)
-  
+  values, used = ImGui.SliderFloat2("Label", values, 0.01, -10, 10, "%.1f", ImGuiSliderFlags.Logarithmic)
+
   -- ImGui.SliderFloat3(...)
-  -- Parameters: text (label), table (values), float (value_min), float (value_max), text (format) [O], float (power) [O]
+  -- Parameters: text (label), table (values), float (value_min), float (value_max), text (format) [O], ImGuiSliderFlags (flags) [O]
   -- Returns: table (values), bool (used)
   -- Overloads
   values, used = ImGui.SliderFloat3("Label", values, 0.01, -10, 10)
   values, used = ImGui.SliderFloat3("Label", values, 0.01, -10, 10, "%.1f")
-  values, used = ImGui.SliderFloat3("Label", values, 0.01, -10, 10, "%.1f", 0.5)
-  
+  values, used = ImGui.SliderFloat3("Label", values, 0.01, -10, 10, "%.1f", ImGuiSliderFlags.Logarithmic)
+
   -- ImGui.SliderFloat4(...)
-  -- Parameters: text (label), table (values), float (value_min), float (value_max), text (format) [O], float (power) [O]
+  -- Parameters: text (label), table (values), float (value_min), float (value_max), text (format) [O], ImGuiSliderFlags (flags) [O]
   -- Returns: table (values), bool (used)
   -- Overloads
   values, used = ImGui.SliderFloat4("Label", values, 0.01, -10, 10)
   values, used = ImGui.SliderFloat4("Label", values, 0.01, -10, 10, "%.1f")
-  values, used = ImGui.SliderFloat4("Label", values, 0.01, -10, 10, "%.1f", 0.5)
-  
+  values, used = ImGui.SliderFloat4("Label", values, 0.01, -10, 10, "%.1f", ImGuiSliderFlags.Logarithmic)
+
   -- ImGui.SliderAngle(...)
   -- Parameters: text (label), float (v_rad), float (v_degrees_min) [O], float (v_degrees_max) [O], text (format) [O]
   -- Returns: float (v_rad), bool (used)
@@ -685,43 +686,43 @@ You can find all the supported functions and overloads below.
   v_rad, used = ImGui.SliderAngle("Label", v_rad, -255)
   v_rad, used = ImGui.SliderAngle("Label", v_rad, -255, 360)
   v_rad, used = ImGui.SliderAngle("Label", v_rad, -255, 360, "%.0f deg")
-  
+
   -- ImGui.SliderInt(...)
   -- Parameters: text (label), int (value), int (value_min), int (value_max), text (format) [O]
   -- Returns: int (value), bool (used)
   -- Overloads
   value, used = ImGui.SliderInt("Label", value, -10, 10)
   value, used = ImGui.SliderInt("Label", value, -10, 10, "%d")
-  
+
   -- ImGui.SliderInt2(...)
   -- Parameters: text (label), table (values), int (value_min), int (value_max), text (format) [O]
   -- Returns: table (values), bool (used)
   -- Overloads
   values, used = ImGui.SliderInt2("Label", values, -10, 10)
   values, used = ImGui.SliderInt2("Label", values, -10, 10, "%d")
-  
+
   -- ImGui.SliderInt3(...)
   -- Parameters: text (label), table (values), int (value_min), int (value_max), text (format) [O]
   -- Returns: table (values), bool (used)
   -- Overloads
   values, used = ImGui.SliderInt3("Label", values, -10, 10)
   values, used = ImGui.SliderInt3("Label", values, -10, 10, "%d")
-  
+
   -- ImGui.SliderInt4(...)
   -- Parameters: text (label), table (values), int (value_min), int (value_max), text (format) [O]
   -- Returns: table (values), bool (used)
   -- Overloads
   values, used = ImGui.SliderInt4("Label", values, -10, 10)
   values, used = ImGui.SliderInt4("Label", values, -10, 10, "%d")
-  
+
   -- ImGui.VSliderFloat(...)
-  -- Parameters: text (label), float (size_x), float (size_y), float (value), float (value_min), float (value_max), text (format) [O], float (power) [O]
+  -- Parameters: text (label), float (size_x), float (size_y), float (value), float (value_min), float (value_max), text (format) [O], ImGuiSliderFlags (flags) [O]
   -- Returns: float (value), bool (used)
   -- Overloads
   value, used = ImGui.VSliderFloat("Label", 100, 25, value, -10, 10)
   value, used = ImGui.VSliderFloat("Label", 100, 25, value, -10, 10, "%.1f")
-  value, used = ImGui.VSliderFloat("Label", 100, 25, value, -10, 10, "%.1f", 0.5)
-  
+  value, used = ImGui.VSliderFloat("Label", 100, 25, value, -10, 10, "%.1f", ImGuiSliderFlags.Logarithmic)
+
   -- ImGui.VSliderInt(...)
   -- Parameters: text (label), float (size_x), float (size_y), int (value), int (value_min), int (value_max), text (format) [O]
   -- Returns: int (value), bool (used)
@@ -738,7 +739,7 @@ You can find all the supported functions and overloads below.
   -- Overloads
   text, selected = ImGui.InputText("Label", text, 100)
   text, selected = ImGui.InputText("Label", text, 100, ImGuiInputTextFlags.ReadOnly)
-  
+
   -- ImGui.InputTextMultiline(...)
   -- Parameters: text (label), text (text), int (buf_size), float (size_x) [O], float (size_y) [O], ImGuiInputTextFlags (flags) [O]
   -- Returns: text (text), bool (selected)
@@ -746,14 +747,14 @@ You can find all the supported functions and overloads below.
   text, selected = ImGui.InputTextMultiline("Label", text, 100)
   text, selected = ImGui.InputTextMultiline("Label", text, 100, 200, 35)
   text, selected = ImGui.InputTextMultiline("Label", text, 100, 200, 35, ImGuiInputTextFlags.ReadOnly)
-  
+
   -- ImGui.InputTextWithHint(...)
   -- Parameters: text (label), text (hint), text (text), int (buf_size), ImGuiInputTextFlags (flags) [O]
   -- Returns: text (text), bool (selected)
   -- Overloads
   text, selected = ImGui.InputTextWithHint("Label", "Hint", text, 100)
   text, selected = ImGui.InputTextWithHint("Label", "Hint", text, 100, ImGuiInputTextFlags.ReadOnly)
-  
+
   -- ImGui.InputFloat(...)
   -- Parameters: text (label), float (value), float (step) [O], float (step_fast) [O], text (format) [O], ImGuiInputTextFlags (flags) [O]
   -- Returns: float (value), bool (used)
@@ -763,7 +764,7 @@ You can find all the supported functions and overloads below.
   value, used = ImGui.InputFloat("Label", value, 1, 10)
   value, used = ImGui.InputFloat("Label", value, 1, 10, "%.1f")
   value, used = ImGui.InputFloat("Label", value, 1, 10, "%.1f", ImGuiInputTextFlags.None)
-  
+
   -- ImGui.InputFloat2(...)
   -- Parameters: text (label), table (values), text (format) [O], ImGuiInputTextFlags (flags) [O]
   -- Returns: table (values), bool (used)
@@ -771,7 +772,7 @@ You can find all the supported functions and overloads below.
   values, used = ImGui.InputFloat2("Label", values)
   values, used = ImGui.InputFloat2("Label", values, "%.1f")
   values, used = ImGui.InputFloat2("Label", values, "%.1f", ImGuiInputTextFlags.None)
-  
+
   -- ImGui.InputFloat3(...)
   -- Parameters: text (label), table (values), text (format) [O], ImGuiInputTextFlags (flags) [O]
   -- Returns: table (values), bool (used)
@@ -779,7 +780,7 @@ You can find all the supported functions and overloads below.
   values, used = ImGui.InputFloat3("Label", values)
   values, used = ImGui.InputFloat3("Label", values, "%.1f")
   values, used = ImGui.InputFloat3("Label", values, "%.1f", ImGuiInputTextFlags.None)
-  
+
   -- ImGui.InputFloat4(...)
   -- Parameters: text (label), table (values), text (format) [O], ImGuiInputTextFlags (flags) [O]
   -- Returns: table (values), bool (used)
@@ -787,37 +788,37 @@ You can find all the supported functions and overloads below.
   values, used = ImGui.InputFloat4("Label", values)
   values, used = ImGui.InputFloat4("Label", values, "%.1f")
   values, used = ImGui.InputFloat4("Label", values, "%.1f", ImGuiInputTextFlags.None)
-  
+
   -- ImGui.InputInt(...)
-  -- Parameters: text (label), int (value), int (step) [O], int (step_fast) [O], ImGuiInputTextFlags (flags) [O] 
+  -- Parameters: text (label), int (value), int (step) [O], int (step_fast) [O], ImGuiInputTextFlags (flags) [O]
   -- Returns: int (value), bool (used)
   -- Overloads
   value, used = ImGui.InputInt("Label", value)
   value, used = ImGui.InputInt("Label", value, 1)
   value, used = ImGui.InputInt("Label", value, 1, 10)
   value, used = ImGui.InputInt("Label", value, 1, 10, ImGuiInputTextFlags.None)
-  
+
   -- ImGui.InputInt2(...)
-  -- Parameters: text (label), table (values), ImGuiInputTextFlags (flags) [O] 
+  -- Parameters: text (label), table (values), ImGuiInputTextFlags (flags) [O]
   -- Returns: table (values), bool (used)
   -- Overloads
   values, used = ImGui.InputInt2("Label", values)
   values, used = ImGui.InputInt2("Label", values, ImGuiInputTextFlags.None)
-  
+
   -- ImGui.InputInt3(...)
-  -- Parameters: text (label), table (values), ImGuiInputTextFlags (flags) [O] 
+  -- Parameters: text (label), table (values), ImGuiInputTextFlags (flags) [O]
   -- Returns: table (values), bool (used)
   -- Overloads
   values, used = ImGui.InputInt3("Label", values)
   values, used = ImGui.InputInt3("Label", values, ImGuiInputTextFlags.None)
-  
+
   -- ImGui.InputInt4(...)
-  -- Parameters: text (label), table (values), ImGuiInputTextFlags (flags) [O] 
+  -- Parameters: text (label), table (values), ImGuiInputTextFlags (flags) [O]
   -- Returns: table (values), bool (used)
   -- Overloads
   values, used = ImGui.InputInt4("Label", values)
   values, used = ImGui.InputInt4("Label", values, ImGuiInputTextFlags.None)
-  
+
   -- ImGui.InputDouble(...)
   -- Parameters: text (label), double (value), double (step) [O], double (step_fast) [O], text (format) [O], ImGuiInputTextFlags (flags) [O]
   -- Returns: double (value), bool (used)
@@ -832,33 +833,33 @@ You can find all the supported functions and overloads below.
 ## Widgets: Color Editor / Picker
 ```lua
   -- ImGui.ColorEdit3(...)
-  -- Parameters: text (label), table (col), ImGuiColorEditFlags (flags) [O] 
+  -- Parameters: text (label), table (col), ImGuiColorEditFlags (flags) [O]
   -- Returns: table (col), bool (used)
   -- Overloads
   col, used = ImGui.ColorEdit3("Label", col)
   col, used = ImGui.ColorEdit3("Label", col, ImGuiColorEditFlags.NoTooltip)
-  
+
   -- ImGui.ColorEdit4(...)
-  -- Parameters: text (label), table (col), ImGuiColorEditFlags (flags) [O] 
+  -- Parameters: text (label), table (col), ImGuiColorEditFlags (flags) [O]
   -- Returns: table (col), bool (used)
   -- Overloads
   col, used = ImGui.ColorEdit4("Label", col)
   col, used = ImGui.ColorEdit4("Label", col, ImGuiColorEditFlags.NoTooltip)
-  
+
   -- ImGui.ColorPicker3(...)
-  -- Parameters: text (label), table (col), ImGuiColorEditFlags (flags) [O] 
+  -- Parameters: text (label), table (col), ImGuiColorEditFlags (flags) [O]
   -- Returns: table (col), bool (used)
   -- Overloads
   col, used = ImGui.ColorPicker3("Label", col)
   col, used = ImGui.ColorPicker3("Label", col, ImGuiColorEditFlags.NoTooltip)
-  
+
   -- ImGui.ColorPicker4(...)
-  -- Parameters: text (label), table (col), ImGuiColorEditFlags (flags) [O] 
+  -- Parameters: text (label), table (col), ImGuiColorEditFlags (flags) [O]
   -- Returns: table (col), bool (used)
   -- Overloads
   col, used = ImGui.ColorPicker4("Label", col)
   col, used = ImGui.ColorPicker4("Label", col, ImGuiColorEditFlags.NoTooltip)
-  
+
   -- ImGui.ColorButton(...)
   -- Parameters: text (desc_id), table (col), ImGuiColorEditFlags (flags) [O], float (size_x) [O], float (size_y) [O]
   -- Returns: bool (pressed)
@@ -866,7 +867,7 @@ You can find all the supported functions and overloads below.
   pressed = ImGui.ColorButton("Desc ID", { 1, 0, 0, 1 })
   pressed = ImGui.ColorButton("Desc ID", { 1, 0, 0, 1 }, ImGuiColorEditFlags.None)
   pressed = ImGui.ColorButton("Desc ID", { 1, 0, 0, 1 }, ImGuiColorEditFlags.None, 100, 100)
-  
+
   -- ImGui.SetColorEditOptions(...)
   -- Parameters: ImGuiColorEditFlags (flags)
   ImGui.SetColorEditOptions(ImGuiColorEditFlags.NoTooltip | ImGuiColorEditFlags_NoInputs)
@@ -880,7 +881,7 @@ You can find all the supported functions and overloads below.
   -- Overloads
   open = ImGui.TreeNode("Label")
   open = ImGui.TreeNode("Label", "Some Text")
-  
+
   -- ImGui.TreeNodeEx(...)
   -- Parameters: text (label), ImGuiTreeNodeFlags (flags) [O], text (fmt) [O]
   -- Returns: bool (open)
@@ -888,18 +889,18 @@ You can find all the supported functions and overloads below.
   open = ImGui.TreeNodeEx("Label")
   open = ImGui.TreeNodeEx("Label", ImGuiTreeNodeFlags.Selected)
   open = ImGui.TreeNodeEx("Label", ImGuiTreeNodeFlags.Selected, "Some Text")
-  
+
   -- ImGui.TreePush(...)
   -- Parameters: text (str_id)
   ImGui.TreePush("String ID")
-  
+
   -- ImGui.TreePop()
   ImGui.TreePop()
-  
+
   -- ImGui.GetTreeNodeToLabelSpacing()
   -- Returns: float (spacing)
   spacing = ImGui.GetTreeNodeToLabelSpacing()
-  
+
   -- ImGui.CollapsingHeader(...)
   -- Parameters A: text (label), ImGuiTreeNodeFlags (flags) [O]
   -- Parameters B: text (label), bool (open), ImGuiTreeNodeFlags (flags) [O]
@@ -910,7 +911,7 @@ You can find all the supported functions and overloads below.
   notCollapsed = ImGui.CollapsingHeader("Label", ImGuiTreeNodeFlags.Selected)
   open, notCollapsed = ImGui.CollapsingHeader("Label", open)
   open, notCollapsed = ImGui.CollapsingHeader("Label", open, ImGuiTreeNodeFlags.Selected)
-  
+
   -- ImGui.SetNextItemOpen(...)
   -- Parameters: bool (open), ImGuiCond (cond) [O]
   -- Overloads
@@ -938,16 +939,16 @@ You can find all the supported functions and overloads below.
   -- Overloads
   current_item, clicked = ImGui.ListBox("Label", current_item, { "Item 1", "Item 2", 2 })
   current_item, clicked = ImGui.ListBox("Label", current_item, { "Item 1", "Item 2", 2 }, 5)
-  
+
   -- ImGui.ListBoxHeader(...)
-  -- Parameters A: text (label), float (size_x), float (size_y) 
+  -- Parameters A: text (label), float (size_x), float (size_y)
   -- Parameters B: text (label), int (items_count), int (height_in_items) [0]
   -- Returns: bool (open)
   -- Overloads
   open = ImGui.ListBoxHeader("Label", 100.0, 100.0) -- size as params
   open = ImGui.ListBoxHeader("Label", 5)
   open = ImGui.ListBoxHeader("Label", 5, 5)     -- items count and height
-  
+
   -- ImGui.ListBoxFooter()
   ImGui.ListBoxFooter()
 ```
@@ -1006,10 +1007,10 @@ selected, activated = ImGui.MenuItem("Label", "ALT+F4", selected, true)
 ```lua
   -- ImGui.BeginTooltip()
   ImGui.BeginTooltip()
-  
+
   -- ImGui.EndTooltip()
   ImGui.EndTooltip()
-  
+
   -- ImGui.SetTooltip(...)
   -- Parameters: text (fmt)
   ImGui.SetTooltip("Did you know that I have the high ground?")
@@ -1023,7 +1024,7 @@ selected, activated = ImGui.MenuItem("Label", "ALT+F4", selected, true)
   -- Overloads
   open = ImGui.BeginPopup("String ID")
   open = ImGui.BeginPopup("String ID", ImGuiWindowFlags.NoCollapse)
-  
+
   -- ImGui.BeginPopupModal(...)
   -- Parameters: text (name), bool (open) [O], ImGuiWindowFlags (flags) [O]
   -- Returns: bool (open)
@@ -1031,16 +1032,16 @@ selected, activated = ImGui.MenuItem("Label", "ALT+F4", selected, true)
   open = ImGui.BeginPopupModal("Name")
   open = ImGui.BeginPopupModal("Name", open)
   open = ImGui.BeginPopupModal("Name", open, ImGuiWindowFlags.NoCollapse)
-  
+
   -- ImGui.EndPopup()
   ImGui.EndPopup()
-  
+
   -- ImGui.OpenPopup(...)
   -- Parameters: text (str_id), ImGuiPopupFlags (popup_flags)
   -- Overloads
   ImGui.OpenPopup("String ID")
   ImGui.OpenPopup("String ID", ImGuiPopupFlags.NoOpenOverExistingPopup)
-  
+
   -- ImGui.OpenPopupContextItem(...)
   -- Parameters: text (str_id), ImGuiPopupFlags (popup_flags)
   -- Returns: bool (open)
@@ -1048,10 +1049,10 @@ selected, activated = ImGui.MenuItem("Label", "ALT+F4", selected, true)
   open = ImGui.OpenPopupContextItem()
   open = ImGui.OpenPopupContextItem("String ID")
   open = ImGui.OpenPopupContextItem("String ID", ImGuiPopupFlags.NoOpenOverExistingPopup)
-  
+
   -- ImGui.CloseCurrentPopup()
   ImGui.CloseCurrentPopup()
-  
+
   -- ImGui.BeginPopupContextItem(...)
   -- Parameters: text (str_id), ImGuiPopupFlags (popup_flags)
   -- Returns: bool (open)
@@ -1059,7 +1060,7 @@ selected, activated = ImGui.MenuItem("Label", "ALT+F4", selected, true)
   open = ImGui.BeginPopupContextItem()
   open = ImGui.BeginPopupContextItem("String ID")
   open = ImGui.BeginPopupContextItem("String ID", ImGuiPopupFlags.NoOpenOverExistingPopup)
-  
+
   -- ImGui.BeginPopupContextWindow(...)
   -- Parameters: text (str_id), ImGuiPopupFlags (popup_flags)
   -- Returns: bool (open)
@@ -1067,7 +1068,7 @@ selected, activated = ImGui.MenuItem("Label", "ALT+F4", selected, true)
   open = ImGui.BeginPopupContextWindow()
   open = ImGui.BeginPopupContextWindow("String ID")
   open = ImGui.BeginPopupContextWindow("String ID", ImGuiPopupFlags.NoOpenOverExistingPopup)
-  
+
   -- ImGui.BeginPopupContextVoid(...)
   -- Parameters: text (str_id), ImGuiPopupFlags (popup_flags)
   -- Returns: bool (open)
@@ -1075,7 +1076,7 @@ selected, activated = ImGui.MenuItem("Label", "ALT+F4", selected, true)
   open = ImGui.BeginPopupContextVoid()
   open = ImGui.BeginPopupContextVoid("String ID")
   open = ImGui.BeginPopupContextVoid("String ID", ImGuiPopupFlags.NoOpenOverExistingPopup)
-  
+
   -- ImGui.IsPopupOpen(...)
   -- Parameters: text (str_id), ImGuiPopupFlags (popup_flags)
   -- Overloads
@@ -1092,36 +1093,36 @@ selected, activated = ImGui.MenuItem("Label", "ALT+F4", selected, true)
   ImGui.Columns(2)
   ImGui.Columns(2, "MyOtherColumn")
   ImGui.Columns(3, "MyColumnWithBorder", true)
-  
+
   -- ImGui.NextColumn()
   ImGui.NextColumn()
-  
+
   -- ImGui.GetColumnIndex()
   -- Returns: int (index)
   index = ImGui.GetColumnIndex()
-  
+
   -- ImGui.GetColumnWidth(...)
   -- Parameters: int (column_index) [O]
   -- Returns: float (width)
   -- Overloads
   width = ImGui.GetColumnWidth()
   width = ImGui.getColumnWidth(2)
-  
+
   -- ImGui.SetColumnWidth(...)
   -- Parameters: int (column_index), float (width)
   ImGui.SetColumnWidth(2, 100)
-  
+
   -- ImGui.GetColumnOffset(...)
   -- Parameters: int (column_index) [O]
   -- Returns: float (offset)
   -- Overloads
   offset = ImGui.GetColumnOffset()
   offset = ImGui.GetColumnOffset(2)
-  
+
   -- ImGui.SetColumnOffset(...)
   -- Parameters: int (column_index), float (offset)
   ImGui.SetColumnOffset(2, 10)
-  
+
   -- ImGui.GetColumnsCount()
   -- Returns: int (count)
   count = ImGui.GetColumnsCount()
@@ -1135,10 +1136,10 @@ selected, activated = ImGui.MenuItem("Label", "ALT+F4", selected, true)
   -- Overloads
   open = ImGui.BeginTabBar("String ID")
   open = ImGui.BeginTabBar("String ID", ImGuiTabBarFlags.Reorderable)
-  
+
   -- ImGui.EndTabBar()
   ImGui.EndTabBar()
-  
+
   -- ImGui.BeginTabItem()
   -- Parameters A: text (label)
   -- Parameters B: text (label), bool (open), ImGuiTabItemFlags (flags) [O]
@@ -1148,10 +1149,10 @@ selected, activated = ImGui.MenuItem("Label", "ALT+F4", selected, true)
   selected = ImGui.BeginTabItem("Label")
   open, selected = ImGui.BeginTabItem("Label", open)
   open, selected = ImGui.BeginTabItem("Label", open, ImGuiTabItemFlags_NoTooltip)
-  
+
   -- ImGui.EndTabItem()
   ImGui.EndTabItem()
-  
+
   -- ImGui.SetTabItemClosed(...)
   -- Parameters: text (tab_or_docked_window_label)
   ImGui.SetTabItemClosed("MyDockedWindow")
@@ -1164,26 +1165,26 @@ selected, activated = ImGui.MenuItem("Label", "ALT+F4", selected, true)
   -- Overloads
   ImGui.LogToTTY()
   ImGui.LogToTTY(1)
-  
+
   -- ImGui.LogToFile(...)
   -- Parameters: int (auto_open_depth) [O], text (fileName) [O]
   -- Overloads
   ImGui.LogToFile()
   ImGui.LogToFile(1)
   ImGui.LogToFile(1, "myfile.txt")
-  
+
   -- ImGui.LogToClipboard(...)
   -- Parameters: int (auto_open_depth) [O]
   -- Overloads
   ImGui.LogToClipboard()
   ImGui.LogToClipboard(1)
-  
+
   -- ImGui.LogFinish()
   ImGui.LogFinish()
-  
+
   -- ImGui.LogButtons()
   ImGui.LogButtons()
-  
+
   -- ImGui.LogText(...)
   -- Parameters: text (fmt)
   ImGui.LogText("I want to log this, thanks.")
@@ -1194,7 +1195,7 @@ selected, activated = ImGui.MenuItem("Label", "ALT+F4", selected, true)
   -- ImGui.PushClipRect(...)
   -- Parameters: float (min_x), float (min_y), float (max_x), float (max_y), bool (intersect_current)
   ImGui.PushClipRect(0, 0, 100, 100, false)
-  
+
   -- ImGui.PopClipRect()
   ImGui.PopClipRect()
 ```
@@ -1203,7 +1204,7 @@ selected, activated = ImGui.MenuItem("Label", "ALT+F4", selected, true)
 ```lua
   -- ImGui.SetItemDefaultFocus()
   ImGui.SetItemDefaultFocus()
-  
+
   -- ImGui.SetKeyboardFocusHere(...)
   -- Parameters: int (offset) [O]
   -- Overloads
@@ -1219,70 +1220,70 @@ selected, activated = ImGui.MenuItem("Label", "ALT+F4", selected, true)
   -- Overloads
   hovered = ImGui.IsItemHovered()
   hovered = ImGui.IsItemHovered(ImGuiHoveredFlags.ChildWindows)
-  
+
   -- ImGui.IsItemActive()
   -- Returns: bool (active)
   active = ImGui.IsItemActive()
-  
+
   -- ImGui.IsItemFocused()
   -- Returns: bool (focused)
   focused = ImGui.IsItemFocused()
-  
+
   -- ImGui.IsItemClicked(...)
   -- Parameters: ImGuiMouseButton (mouse_button) [O]
   -- Returns: bool (clicked)
   -- Overloads
   clicked = ImGui.IsItemClicked()
   clicked = ImGui.IsItemClicked(ImGuiMouseButton.Middle)
-  
+
   -- ImGui.IsItemVisible()
   -- Returns: bool (visible)
   visible = ImGui.IsItemVisible()
-  
+
   -- ImGui.IsItemEdited()
   -- Returns: bool (edited)
   edited = ImGui.IsItemEdited()
-  
+
   -- ImGui.IsItemActivated()
   -- Returns: bool (activated)
   activated = ImGui.IsItemActivated()
-  
+
   -- ImGui.IsItemDeactivated()
   -- Returns: bool (deactivated)
   deactivated = ImGui.IsItemDeactivated()
-  
+
   -- ImGui.IsItemDeactivatedAfterEdit()
   -- Returns: bool (deactivated_after_edit)
   deactivated_after_edit = ImGui.IsItemDeactivatedAfterEdit()
-  
+
   -- ImGui.IsItemToggledOpen()
   -- Returns: bool (toggled_open)
   toggled_open = ImGui.IsItemToggledOpen()
-  
+
   -- ImGui.IsAnyItemHovered()
   -- Returns: bool (any_item_hovered)
   any_item_hovered = ImGui.IsAnyItemHovered()
-  
+
    -- ImGui.IsAnyItemActive()
   -- Returns: bool (any_item_active)
   any_item_active = ImGui.IsAnyItemActive()
-  
+
   -- ImGui.IsAnyItemFocused()
   -- Returns: bool (any_item_focused)
   any_item_focused = ImGui.IsAnyItemFocused()
-  
+
   -- ImGui.GetItemRectMin()
   -- Returns: float (x), float (y)
   x, y = ImGui.GetItemRectMin()
-  
+
   -- ImGui.GetItemRectMax()
   -- Returns: float (x), float (y)
   x, y = ImGui.GetItemRectMax()
-  
+
   -- ImGui.GetItemRectSize()
   -- Returns: float (x), float (y)
   x, y = ImGui.GetItemRectSize()
-  
+
   -- ImGui.SetItemAllowOverlap()
   ImGui.SetItemAllowOverlap()
 ```
@@ -1296,27 +1297,27 @@ selected, activated = ImGui.MenuItem("Label", "ALT+F4", selected, true)
   -- Overloads
   visible = ImGui.IsRectVisible(100, 100)
   visible = ImGui.IsRectVisible(50, 50, 200, 200)
-  
+
   -- ImGui.GetTime()
   -- Returns double (time)
   time = ImGui.GetTime()
-  
+
   -- ImGui.GetFrameCount()
   -- Returns int (frame_count)
   frame_count = ImGui.GetFrameCount()
-  
+
   -- ImGui.GetStyleColorName(...)
   -- Parameters: ImGuiCol (idx)
   -- Returns: text (style_color_name)
   style_color_name = ImGui.GetStyleColorName(ImGuiCol.Text)
-  
+
   -- ImGui.BeginChildFrame(...)
   -- Parameters: unsigned int (id), float (size_x), float (size_y), ImGuiWindowFlags (flags) [O]
   -- Returns: bool (open)
   -- Overloads
   open = ImGui.BeginChildFrame(0, 100, 100)
   open = ImGui.BeginChildFrame(0, 100, 100, ImGuiWindowFlags.NoBackground)
-  
+
   -- ImGui.EndChildFrame()
   ImGui.EndChildFrame()
 ```
@@ -1338,7 +1339,7 @@ selected, activated = ImGui.MenuItem("Label", "ALT+F4", selected, true)
   -- Parameters: float (r), float (g), float (b)
   -- Returns: float (h), float (s), float (v)
   h, s, v = ImGui.ColorConvertRGBtoHSV(1, 0, 0.5)
-  
+
   -- ImGui.ColorConvertHSVtoRGB(...)
   -- Parameters: float (h), float (s), float (v)
   -- Returns: float (r), float (g), float (b)
@@ -1352,7 +1353,7 @@ selected, activated = ImGui.MenuItem("Label", "ALT+F4", selected, true)
   -- ImGui.ColorConvertFloat4ToU32(...)
   -- Parameters: float array (color_f4={r,g,b,a})
   -- Returns: int (color_u32)
-  -- NOTE: this function is fundamentally 
+  -- NOTE: this function is fundamentally
   color_u32 = ImGui.ColorConvertFloat4ToU32({0.4, 0.2, 0, 1})
 ```
 
@@ -1361,7 +1362,7 @@ selected, activated = ImGui.MenuItem("Label", "ALT+F4", selected, true)
   -- ImGui.GetClipboardText()
   -- Returns: text (text)
   text = ImGui.GetClipboardText()
-  
+
   -- ImGui.SetClipboardText(...)
   -- Parameters: text (text)
   ImGui.SetClipboardText("I made it to the clipboard!")

--- a/src/sol_imgui/README.md
+++ b/src/sol_imgui/README.md
@@ -245,7 +245,7 @@ You can find all the supported functions and overloads below.
   ImGui.SetScrollFromPosY(10, 0.5)
 ```
 
-## Parameters Stacks (Shared)  
+## Parameters Stacks (Shared)
 ```lua
   -- ImGui.PushStyleColor(...)
   -- Parameters A: ImGuiCol (idx), int (color_u32)
@@ -881,7 +881,7 @@ You can find all the supported functions and overloads below.
 
   -- ImGui.SetColorEditOptions(...)
   -- Parameters: ImGuiColorEditFlags (flags)
-  ImGui.SetColorEditOptions(ImGuiColorEditFlags.NoTooltip | ImGuiColorEditFlags_NoInputs)
+  ImGui.SetColorEditOptions(ImGuiColorEditFlags.NoTooltip | ImGuiColorEditFlags.NoInputs)
 ```
 
 ## Widgets: Trees
@@ -1096,7 +1096,90 @@ selected, activated = ImGui.MenuItem("Label", "ALT+F4", selected, true)
   ImGui.IsPopupOpen("String ID", ImGuiPopupFlags.NoOpenOverExistingPopup)
 ```
 
-## Columns
+## Tables
+```lua
+  -- ImGui.BeginTable(...)
+  -- Parameters: string (str_id), int (column), ImGuiTableFlags (flags) [O], float (outer_size_x) [O], float (outer_size_y) [O], float (inner_width) [O]
+  -- Returns: bool
+  ImGui.BeginTable("Table1", 3)
+  ImGui.BeginTable("Table1", 3, ImGuiTableFlags.Resizable)
+  ImGui.BeginTable("Table1", 3, ImGuiTableFlags.Resizable, 200, 150)
+  ImGui.BeginTable("Table1", 3, ImGuiTableFlags.Resizable, 200, 150, 10)
+
+  -- ImGui.EndTable() // only call EndTable() if BeginTable() returns true!
+  ImGui.EndTable()
+
+  -- ImGui.TableNextRow(...) // append into the first cell of a new row.
+  -- Parameters: ImGuiTableRowFlags (flags) [O], float (min_row_height) [O]
+  ImGui.TableNextRow()
+  ImGui.TableNextRow(ImGuiTableRowFlags.Headers)
+  ImGui.TableNextRow(ImGuiTableRowFlags.Headers, 25)
+
+  -- ImGui.TableNextColumn() // append into the next column (or first column of next row if currently in last column). Return true when column is visible.
+  -- Returns: bool (visible)
+  visible = ImGui.TableNextColumn()
+
+  -- ImGui.TableSetColumnIndex(...) // append into the specified column. Return true when column is visible.
+  -- Parameter: int (column_n)
+  -- Returns: bool (visible)
+  visible = ImGui.TableSetColumnIndex(2)
+
+  -- ImGui.TableSetupColumn(...)
+  -- Parameters: string (label), ImGuiTableColumnFlags (flags) [O], float (init_width_or_weight) [O], ImU32 (user_id) [O]
+  ImGui.TableSetupColumn("Column1")
+  ImGui.TableSetupColumn("Column1", ImGuiTableColumnFlags.WidthFixed)
+  ImGui.TableSetupColumn("Column1", ImGuiTableColumnFlags.WidthFixed, 60)
+
+  -- ImGui.TableSetupScrollFreeze(...) // lock columns/rows so they stay visible when scrolled.
+  -- Parameters: int (cols), int(rows)
+  ImGui.TableSetupScrollFreeze(3, 1)
+
+  -- ImGuui.TableHeadersRow() // submit all headers cells based on data provided to TableSetupColumn() + submit context menu
+  ImGui.TableHeadersRow()
+
+  -- ImGui.TableHeader(...) // submit one header cell manually (rarely used)
+  -- Parameter: string (label)
+  ImGui.TableHeader("Header")
+
+  -- ImGui.TableGetSortSpecs() // get latest sort specs for the table (NULL if not sorting).
+  -- Returns: ImGuiTableSortSpecs*
+  ImGui.TableGetSortSpecs()
+
+  -- ImGui.TableGetColumnCount() // return number of columns (value passed to BeginTable)
+  -- Returns: int (cols)
+  cols = ImGui.TableGetColumnCount()
+
+  -- ImGui.TableGetColumnIndex() // return current column index.
+  -- Returns: int (col_index)
+  col_index = ImGui.TableGetColumnIndex()
+
+  -- ImGui.TableGetRowIndex() // return current row index.
+  -- Returns: int (row_index)
+  row_index = ImGui.TableGetRowIndex()
+
+  -- ImGui.TableGetColumnName(...) // return "" if column didn't have a name declared by TableSetupColumn(). Pass -1 to use current column.
+  -- Parameter: int (column_n) [O]
+  -- Returns: string(col_name)
+  col_name = ImGui.TableGetColumnName()
+  col_name = ImGui.TableGetColumnName(2)
+
+  -- ImGui.TableGetColumnFlags(...) // return column flags so you can query their Enabled/Visible/Sorted/Hovered status flags. Pass -1 to use current column.
+  -- Parameter: int (column_n) [O]
+  -- Returns: ImGuiTableColumnFlags
+  col_flags = ImGui.TableGetColumnFlags()
+  col_flags = ImGui.TableGetColumnFlags(2)
+
+  -- ImGui.TableSetBgColor(ImGuiTableBgTarget target, ImU32 color, int column_n = -1) // change the color of a cell, row, or column. See ImGuiTableBgTarget_ flags for details.
+  -- Parameters1: ImGuiTableBgTarget (target), ImU32 (color), int (column_n) [O]
+  -- Parameters2: ImGuiTableBgTarget (target), float (col_R), float (col_G), float (col_B), float (col_A), int (column_n) [O]
+  ImGui.TableSetBgColor(ImGuiTableBgTarget.CellBg, 0xF42069FF)
+  ImGui.TableSetBgColor(ImGuiTableBgTarget.CellBg, 0xF42069FF, 2)
+  ImGui.TableSetBgColor(ImGuiTableBgTarget.CellBg, 1, 0, 0, 1)
+  ImGui.TableSetBgColor(ImGuiTableBgTarget.CellBg, 1, 0, 0, 1, 2)
+```
+
+
+## Columns (Legacy API, prefer using Tables!)
 ```lua
   -- ImGui.Columns(...)
   -- Parameters: int (count) [O], text (id) [O], bool (border) [O]

--- a/src/sol_imgui/README.md
+++ b/src/sol_imgui/README.md
@@ -31,7 +31,7 @@ You can find all the supported functions and overloads below.
 ## Child Windows
 ```lua
   -- ImGui.BeginChild(...)
-  -- Parameters: text (name), float (size_x) [O], float (size_y) [O], ImGuiWindowFlags (flags) [O]
+  -- Parameters: text (name), float (size_x) [O], float (size_y) [O], bool (border) [O], ImGuiWindowFlags (flags) [O]
   -- Returns: bool (shouldDraw)
   -- Overloads
   shouldDraw = ImGui.BeginChild("Name", 100)
@@ -604,7 +604,7 @@ You can find all the supported functions and overloads below.
   values, used = ImGui.DragFloat4("Label", values, 0.01, -10, 10, "%.1f", ImGuiSliderFlags.Logarithmic)
 
   -- ImGui.DragInt(...)
-  -- Parameters: text (label), int (value), float (value_speed) [O], int (value_min) [O], int (value_max) [O], text (format) [O]
+  -- Parameters: text (label), int (value), float (value_speed) [O], int (value_min) [O], int (value_max) [O], text (format) [O], ImGuiSliderFlags (flags) [O]
   -- Returns: int (value), bool (used)
   -- Overloads
   value, used = ImGui.DragInt("Label", value)
@@ -612,9 +612,10 @@ You can find all the supported functions and overloads below.
   value, used = ImGui.DragInt("Label", value, 0.01, -10)
   value, used = ImGui.DragInt("Label", value, 0.01, -10, 10)
   value, used = ImGui.DragInt("Label", value, 0.01, -10, 10, "%d")
+  value, used = ImGui.DragInt("Label", value, 0.01, -10, 10, "%d", ImGuiSliderFlags.Logarithmic)
 
   -- ImGui.DragInt2(...)
-  -- Parameters: text (label), table (values), float (value_speed) [O], int (value_min) [O], int (value_max) [O], text (format) [O]
+  -- Parameters: text (label), table (values), float (value_speed) [O], int (value_min) [O], int (value_max) [O], text (format) [O], ImGuiSliderFlags (flags) [O]
   -- Returns: table (values), bool (used)
   -- Overloads
   values, used = ImGui.DragInt2("Label", values)
@@ -622,9 +623,10 @@ You can find all the supported functions and overloads below.
   values, used = ImGui.DragInt2("Label", values, 0.01, -10)
   values, used = ImGui.DragInt2("Label", values, 0.01, -10, 10)
   values, used = ImGui.DragInt2("Label", values, 0.01, -10, 10, "%d")
+  values, used = ImGui.DragInt2("Label", values, 0.01, -10, 10, "%d", ImGuiSliderFlags.Logarithmic)
 
   -- ImGui.DragInt3(...)
-  -- Parameters: text (label), table (values), float (value_speed) [O], int (value_min) [O], int (value_max) [O], text (format) [O]
+  -- Parameters: text (label), table (values), float (value_speed) [O], int (value_min) [O], int (value_max) [O], text (format) [O], ImGuiSliderFlags (flags) [O]
   -- Returns: table (values), bool (used)
   -- Overloads
   values, used = ImGui.DragInt3("Label", values)
@@ -632,9 +634,10 @@ You can find all the supported functions and overloads below.
   values, used = ImGui.DragInt3("Label", values, 0.01, -10)
   values, used = ImGui.DragInt3("Label", values, 0.01, -10, 10)
   values, used = ImGui.DragInt3("Label", values, 0.01, -10, 10, "%d")
+  values, used = ImGui.DragInt3("Label", values, 0.01, -10, 10, "%d", ImGuiSliderFlags.Logarithmic)
 
   -- ImGui.DragInt4(...)
-  -- Parameters: text (label), table (values), float (value_speed) [O], int (value_min) [O], int (value_max) [O], text (format) [O]
+  -- Parameters: text (label), table (values), float (value_speed) [O], int (value_min) [O], int (value_max) [O], text (format) [O], ImGuiSliderFlags (flags) [O]
   -- Returns: table (values), bool (used)
   -- Overloads
   values, used = ImGui.DragInt4("Label", values)
@@ -642,6 +645,7 @@ You can find all the supported functions and overloads below.
   values, used = ImGui.DragInt4("Label", values, 0.01, -10)
   values, used = ImGui.DragInt4("Label", values, 0.01, -10, 10)
   values, used = ImGui.DragInt4("Label", values, 0.01, -10, 10, "%d")
+  values, used = ImGui.DragInt4("Label", values, 0.01, -10, 10, "%d", ImGuiSliderFlags.Logarithmic)
 ```
 
 ## Widgets: Sliders
@@ -679,41 +683,46 @@ You can find all the supported functions and overloads below.
   values, used = ImGui.SliderFloat4("Label", values, 0.01, -10, 10, "%.1f", ImGuiSliderFlags.Logarithmic)
 
   -- ImGui.SliderAngle(...)
-  -- Parameters: text (label), float (v_rad), float (v_degrees_min) [O], float (v_degrees_max) [O], text (format) [O]
+  -- Parameters: text (label), float (v_rad), float (v_degrees_min) [O], float (v_degrees_max) [O], text (format) [O], ImGuiSliderFlags (flags) [O]
   -- Returns: float (v_rad), bool (used)
   -- Overloads
   v_rad, used = ImGui.SliderAngle("Label", v_rad)
   v_rad, used = ImGui.SliderAngle("Label", v_rad, -255)
   v_rad, used = ImGui.SliderAngle("Label", v_rad, -255, 360)
   v_rad, used = ImGui.SliderAngle("Label", v_rad, -255, 360, "%.0f deg")
+  v_rad, used = ImGui.SliderAngle("Label", v_rad, -255, 360, "%.0f deg", ImGuiSliderFlags.Logarithmic)
 
   -- ImGui.SliderInt(...)
-  -- Parameters: text (label), int (value), int (value_min), int (value_max), text (format) [O]
+  -- Parameters: text (label), int (value), int (value_min), int (value_max), text (format) [O], ImGuiSliderFlags (flags) [O]
   -- Returns: int (value), bool (used)
   -- Overloads
   value, used = ImGui.SliderInt("Label", value, -10, 10)
   value, used = ImGui.SliderInt("Label", value, -10, 10, "%d")
+  value, used = ImGui.SliderInt("Label", value, -10, 10, "%d", ImGuiSliderFlags.Logarithmic)
 
   -- ImGui.SliderInt2(...)
-  -- Parameters: text (label), table (values), int (value_min), int (value_max), text (format) [O]
+  -- Parameters: text (label), table (values), int (value_min), int (value_max), text (format) [O], ImGuiSliderFlags (flags) [O]
   -- Returns: table (values), bool (used)
   -- Overloads
   values, used = ImGui.SliderInt2("Label", values, -10, 10)
   values, used = ImGui.SliderInt2("Label", values, -10, 10, "%d")
+  values, used = ImGui.SliderInt2("Label", values, -10, 10, "%d", ImGuiSliderFlags.Logarithmic)
 
   -- ImGui.SliderInt3(...)
-  -- Parameters: text (label), table (values), int (value_min), int (value_max), text (format) [O]
+  -- Parameters: text (label), table (values), int (value_min), int (value_max), text (format) [O], ImGuiSliderFlags (flags) [O]
   -- Returns: table (values), bool (used)
   -- Overloads
   values, used = ImGui.SliderInt3("Label", values, -10, 10)
   values, used = ImGui.SliderInt3("Label", values, -10, 10, "%d")
+  values, used = ImGui.SliderInt3("Label", values, -10, 10, "%d", ImGuiSliderFlags.Logarithmic)
 
   -- ImGui.SliderInt4(...)
-  -- Parameters: text (label), table (values), int (value_min), int (value_max), text (format) [O]
+  -- Parameters: text (label), table (values), int (value_min), int (value_max), text (format) [O], ImGuiSliderFlags (flags) [O]
   -- Returns: table (values), bool (used)
   -- Overloads
   values, used = ImGui.SliderInt4("Label", values, -10, 10)
   values, used = ImGui.SliderInt4("Label", values, -10, 10, "%d")
+  values, used = ImGui.SliderInt4("Label", values, -10, 10, "%d", ImGuiSliderFlags.Logarithmic)
 
   -- ImGui.VSliderFloat(...)
   -- Parameters: text (label), float (size_x), float (size_y), float (value), float (value_min), float (value_max), text (format) [O], ImGuiSliderFlags (flags) [O]
@@ -724,11 +733,12 @@ You can find all the supported functions and overloads below.
   value, used = ImGui.VSliderFloat("Label", 100, 25, value, -10, 10, "%.1f", ImGuiSliderFlags.Logarithmic)
 
   -- ImGui.VSliderInt(...)
-  -- Parameters: text (label), float (size_x), float (size_y), int (value), int (value_min), int (value_max), text (format) [O]
+  -- Parameters: text (label), float (size_x), float (size_y), int (value), int (value_min), int (value_max), text (format) [O], ImGuiSliderFlags (flags) [O]
   -- Returns: int (value), bool (used)
   -- Overloads
   value, used = ImGui.VSliderInt("Label", 100, 25, value, -10, 10)
   value, used = ImGui.VSliderInt("Label", 100, 25, value, -10, 10, "%d")
+  value, used = ImGui.VSliderInt("Label", 100, 25, value, -10, 10, "%d", ImGuiSliderFlags.Logarithmic)
 ```
 
 ## Widgets: Input with Keyboard

--- a/src/sol_imgui/README.md
+++ b/src/sol_imgui/README.md
@@ -21,6 +21,7 @@ You can find all the supported functions and overloads below.
   -- Returns B & C: bool (open), bool (shouldDraw)
   -- Overloads
   shouldDraw = ImGui.Begin("Name")
+  shouldDraw = ImGui.Begin("Name", ImGuiWindowFlags.NoMove)
   open, shouldDraw = ImGui.Begin("Name", open)
   open, shouldDraw = ImGui.Begin("Name", open, ImGuiWindowFlags.NoMove)
 
@@ -34,7 +35,7 @@ You can find all the supported functions and overloads below.
   -- Parameters: text (name), float (size_x) [O], float (size_y) [O], bool (border) [O], ImGuiWindowFlags (flags) [O]
   -- Returns: bool (shouldDraw)
   -- Overloads
-  shouldDraw = ImGui.BeginChild("Name", 100)
+  shouldDraw = ImGui.BeginChild("Name")
   shouldDraw = ImGui.BeginChild("Name", 100)
   shouldDraw = ImGui.BeginChild("Name", 100, 200)
   shouldDraw = ImGui.BeginChild("Name", 100, 200, true)
@@ -1040,6 +1041,7 @@ selected, activated = ImGui.MenuItem("Label", "ALT+F4", selected, true)
   -- Returns: bool (open)
   -- Overloads
   open = ImGui.BeginPopupModal("Name")
+  open = ImGui.BeginPopupModal("Name", ImGuiWindowFlags.NoCollapse)
   open = ImGui.BeginPopupModal("Name", open)
   open = ImGui.BeginPopupModal("Name", open, ImGuiWindowFlags.NoCollapse)
 
@@ -1157,8 +1159,9 @@ selected, activated = ImGui.MenuItem("Label", "ALT+F4", selected, true)
   -- Returns B: bool (open), bool (selected)
   -- Overloads
   selected = ImGui.BeginTabItem("Label")
+  selected = ImGui.BeginTabItem("Label", ImGuiTabItemFlags.NoTooltip)
   open, selected = ImGui.BeginTabItem("Label", open)
-  open, selected = ImGui.BeginTabItem("Label", open, ImGuiTabItemFlags_NoTooltip)
+  open, selected = ImGui.BeginTabItem("Label", open, ImGuiTabItemFlags.NoTooltip)
 
   -- ImGui.EndTabItem()
   ImGui.EndTabItem()

--- a/src/sol_imgui/sol_imgui.h
+++ b/src/sol_imgui/sol_imgui.h
@@ -267,7 +267,7 @@ namespace sol_ImGui
     inline std::tuple<float, bool> DragFloat(const std::string& label, float v, float v_speed, float v_min)																				{ bool used = ImGui::DragFloat(label.c_str(), &v, v_speed, v_min); return std::make_tuple(v, used); }
     inline std::tuple<float, bool> DragFloat(const std::string& label, float v, float v_speed, float v_min, float v_max)																{ bool used = ImGui::DragFloat(label.c_str(), &v, v_speed, v_min, v_max); return std::make_tuple(v, used); }
     inline std::tuple<float, bool> DragFloat(const std::string& label, float v, float v_speed, float v_min, float v_max, const std::string& format)										{ bool used = ImGui::DragFloat(label.c_str(), &v, v_speed, v_min, v_max, format.c_str()); return std::make_tuple(v, used); }
-    inline std::tuple<float, bool> DragFloat(const std::string& label, float v, float v_speed, float v_min, float v_max, const std::string& format, float power)						{ bool used = ImGui::DragFloat(label.c_str(), &v, v_speed, v_min, v_max, format.c_str(), power); return std::make_tuple(v, used); }
+    inline std::tuple<float, bool> DragFloat(const std::string& label, float v, float v_speed, float v_min, float v_max, const std::string& format, int flags)						{ bool used = ImGui::DragFloat(label.c_str(), &v, v_speed, v_min, v_max, format.c_str(), static_cast<ImGuiSliderFlags>(flags)); return std::make_tuple(v, used); }
     inline std::tuple<sol::as_table_t<std::vector<float>>, bool> DragFloat2(const std::string& label, const sol::table& v)
     {
         const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
@@ -333,12 +333,12 @@ namespace sol_ImGui
 
         return std::make_tuple(float2, used);
     }
-    inline std::tuple<sol::as_table_t<std::vector<float>>, bool> DragFloat2(const std::string& label, const sol::table& v, float v_speed, float v_min, float v_max, const std::string& format, float power)
+    inline std::tuple<sol::as_table_t<std::vector<float>>, bool> DragFloat2(const std::string& label, const sol::table& v, float v_speed, float v_min, float v_max, const std::string& format, int flags)
     {
         const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
                             v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[2] = { float(v1), float(v2) };
-        bool used = ImGui::DragFloat2(label.c_str(), value, v_speed, v_min, v_max, format.c_str(), power);
+        bool used = ImGui::DragFloat2(label.c_str(), value, v_speed, v_min, v_max, format.c_str(), static_cast<ImGuiSliderFlags>(flags));
 
         sol::as_table_t float2 = sol::as_table(std::vector<float>{
             value[0], value[1]
@@ -416,13 +416,13 @@ namespace sol_ImGui
 
         return std::make_tuple(float3, used);
     }
-    inline std::tuple<sol::as_table_t<std::vector<float>>, bool> DragFloat3(const std::string& label, const sol::table& v, float v_speed, float v_min, float v_max, const std::string& format, float power)
+    inline std::tuple<sol::as_table_t<std::vector<float>>, bool> DragFloat3(const std::string& label, const sol::table& v, float v_speed, float v_min, float v_max, const std::string& format, int flags)
     {
         const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
             v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
             v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[3] = { float(v1), float(v2), float(v3) };
-        bool used = ImGui::DragFloat3(label.c_str(), value, v_speed, v_min, v_max, format.c_str(), power);
+        bool used = ImGui::DragFloat3(label.c_str(), value, v_speed, v_min, v_max, format.c_str(), static_cast<ImGuiSliderFlags>(flags));
 
         sol::as_table_t float3 = sol::as_table(std::vector<float>{
             value[0], value[1], value[2]
@@ -505,14 +505,14 @@ namespace sol_ImGui
 
         return std::make_tuple(float4, used);
     }
-    inline std::tuple<sol::as_table_t<std::vector<float>>, bool> DragFloat4(const std::string& label, const sol::table& v, float v_speed, float v_min, float v_max, const std::string& format, float power)
+    inline std::tuple<sol::as_table_t<std::vector<float>>, bool> DragFloat4(const std::string& label, const sol::table& v, float v_speed, float v_min, float v_max, const std::string& format, int flags)
     {
         const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
                             v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
                             v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
                             v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[4] = { float(v1), float(v2), float(v3), float(v4) };
-        bool used = ImGui::DragFloat4(label.c_str(), value, v_speed, v_min, v_max, format.c_str(), power);
+        bool used = ImGui::DragFloat4(label.c_str(), value, v_speed, v_min, v_max, format.c_str(), static_cast<ImGuiSliderFlags>(flags));
 
         sol::as_table_t float4 = sol::as_table(std::vector<float>{
             value[0], value[1], value[2], value[3]
@@ -743,7 +743,7 @@ namespace sol_ImGui
     // Widgets: Sliders
     inline std::tuple<float, bool> SliderFloat(const std::string& label, float v, float v_min, float v_max)																				{ bool used = ImGui::SliderFloat(label.c_str(), &v, v_min, v_max); return std::make_tuple(v, used); }
     inline std::tuple<float, bool> SliderFloat(const std::string& label, float v, float v_min, float v_max, const std::string& format)													{ bool used = ImGui::SliderFloat(label.c_str(), &v, v_min, v_max, format.c_str()); return std::make_tuple(v, used); }
-    inline std::tuple<float, bool> SliderFloat(const std::string& label, float v, float v_min, float v_max, const std::string& format, float power)										{ bool used = ImGui::SliderFloat(label.c_str(), &v, v_min, v_max, format.c_str(), power); return std::make_tuple(v, used); }
+    inline std::tuple<float, bool> SliderFloat(const std::string& label, float v, float v_min, float v_max, const std::string& format, int flags)										{ bool used = ImGui::SliderFloat(label.c_str(), &v, v_min, v_max, format.c_str(), static_cast<ImGuiSliderFlags>(flags)); return std::make_tuple(v, used); }
     inline std::tuple<sol::as_table_t<std::vector<float>>, bool> SliderFloat2(const std::string& label, const sol::table& v, float v_min, float v_max)
     {
         const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
@@ -770,12 +770,12 @@ namespace sol_ImGui
 
         return std::make_tuple(float2, used);
     }
-    inline std::tuple<sol::as_table_t<std::vector<float>>, bool> SliderFloat2(const std::string& label, const sol::table& v, float v_min, float v_max, const std::string& format, float power)
+    inline std::tuple<sol::as_table_t<std::vector<float>>, bool> SliderFloat2(const std::string& label, const sol::table& v, float v_min, float v_max, const std::string& format, int flags)
     {
         const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
                             v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[2] = { float(v1), float(v2) };
-        bool used = ImGui::SliderFloat2(label.c_str(), value, v_min, v_max, format.c_str(), power);
+        bool used = ImGui::SliderFloat2(label.c_str(), value, v_min, v_max, format.c_str(), static_cast<ImGuiSliderFlags>(flags));
 
         sol::as_table_t float2 = sol::as_table(std::vector<float>{
             value[0], value[1]
@@ -811,13 +811,13 @@ namespace sol_ImGui
 
         return std::make_tuple(float3, used);
     }
-    inline std::tuple<sol::as_table_t<std::vector<float>>, bool> SliderFloat3(const std::string& label, const sol::table& v, float v_min, float v_max, const std::string& format, float power)
+    inline std::tuple<sol::as_table_t<std::vector<float>>, bool> SliderFloat3(const std::string& label, const sol::table& v, float v_min, float v_max, const std::string& format, int flags)
     {
         const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
                             v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
                             v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[3] = { float(v1), float(v2), float(v3) };
-        bool used = ImGui::SliderFloat3(label.c_str(), value, v_min, v_max, format.c_str(), power);
+        bool used = ImGui::SliderFloat3(label.c_str(), value, v_min, v_max, format.c_str(), static_cast<ImGuiSliderFlags>(flags));
 
         sol::as_table_t float3 = sol::as_table(std::vector<float>{
             value[0], value[1], value[3]
@@ -855,14 +855,14 @@ namespace sol_ImGui
 
         return std::make_tuple(float4, used);
     }
-    inline std::tuple<sol::as_table_t<std::vector<float>>, bool> SliderFloat4(const std::string& label, const sol::table& v, float v_min, float v_max, const std::string& format, float power)
+    inline std::tuple<sol::as_table_t<std::vector<float>>, bool> SliderFloat4(const std::string& label, const sol::table& v, float v_min, float v_max, const std::string& format, int flags)
     {
         const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
                             v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
                             v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
                             v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[4] = { float(v1), float(v2), float(v3), float(v4) };
-        bool used = ImGui::SliderFloat4(label.c_str(), value, v_min, v_max, format.c_str(), power);
+        bool used = ImGui::SliderFloat4(label.c_str(), value, v_min, v_max, format.c_str(), static_cast<ImGuiSliderFlags>(flags));
 
         sol::as_table_t float4 = sol::as_table(std::vector<float>{
             value[0], value[1], value[2], value[3]
@@ -964,7 +964,7 @@ namespace sol_ImGui
     inline void SliderScalarN()																																							{ /* TODO: SliderScalarN(...) ==> UNSUPPORTED */ }
     inline std::tuple<float, bool> VSliderFloat(const std::string& label, float sizeX, float sizeY, float v, float v_min, float v_max)													{ bool used = ImGui::VSliderFloat(label.c_str(), { sizeX, sizeY }, &v, v_min, v_max); return std::make_tuple(v, used); }
     inline std::tuple<float, bool> VSliderFloat(const std::string& label, float sizeX, float sizeY, float v, float v_min, float v_max, const std::string& format)						{ bool used = ImGui::VSliderFloat(label.c_str(), { sizeX, sizeY }, &v, v_min, v_max, format.c_str()); return std::make_tuple(v, used); }
-    inline std::tuple<float, bool> VSliderFloat(const std::string& label, float sizeX, float sizeY, float v, float v_min, float v_max, const std::string& format, float power)			{ bool used = ImGui::VSliderFloat(label.c_str(), { sizeX, sizeY }, &v, v_min, v_max, format.c_str(), power); return std::make_tuple(v, used); }
+    inline std::tuple<float, bool> VSliderFloat(const std::string& label, float sizeX, float sizeY, float v, float v_min, float v_max, const std::string& format, int flags)			{ bool used = ImGui::VSliderFloat(label.c_str(), { sizeX, sizeY }, &v, v_min, v_max, format.c_str(), static_cast<ImGuiSliderFlags>(flags)); return std::make_tuple(v, used); }
     inline std::tuple<int, bool> VSliderInt(const std::string& label, float sizeX, float sizeY, int v, int v_min, int v_max)															{ bool used = ImGui::VSliderInt(label.c_str(), { sizeX, sizeY }, &v, v_min, v_max); return std::make_tuple(v, used); }
     inline std::tuple<int, bool> VSliderInt(const std::string& label, float sizeX, float sizeY, int v, int v_min, int v_max, const std::string& format)									{ bool used = ImGui::VSliderInt(label.c_str(), { sizeX, sizeY }, &v, v_min, v_max, format.c_str()); return std::make_tuple(v, used); }
     inline void VSliderScalar()																																							{ /* TODO: VSliderScalar(...) ==> UNSUPPORTED */ }
@@ -1583,7 +1583,7 @@ namespace sol_ImGui
         ImGui::ColorConvertHSVtoRGB(h, s, v, r, g, b);
         return std::make_tuple(r, g, b);
     }
-    
+
 #ifdef SOL_IMGUI_ENABLE_INPUT_FUNCTIONS
     // Inputs Utilities: Keyboard
     inline int GetKeyIndex(int imgui_key)																{ return ImGui::GetKeyIndex(static_cast<ImGuiKey>(imgui_key)); }
@@ -1834,6 +1834,16 @@ namespace sol_ImGui
         );
 #pragma endregion InputText Flags
 
+#pragma region Slider Flags
+        lua.new_enum("ImGuiSliderFlags",
+            "None"              , ImGuiSliderFlags_None,
+            "ClampOnInput"      , ImGuiSliderFlags_ClampOnInput,
+            "Logarithmic"       , ImGuiSliderFlags_Logarithmic,
+            "NoRoundToFormat"   , ImGuiSliderFlags_NoRoundToFormat,
+            "NoInput"           , ImGuiSliderFlags_NoInput
+        );
+#pragma endregion Slider Flags
+
 #pragma region ColorEdit Flags
         lua.new_enum("ImGuiColorEditFlags",
             "None"					, ImGuiColorEditFlags_None,
@@ -1947,7 +1957,7 @@ namespace sol_ImGui
             "NoTooltip"						, ImGuiTabItemFlags_NoTooltip
         );
 #pragma endregion TabItem Flags
-        
+
 #ifdef SOL_IMGUI_ENABLE_INPUT_FUNCTIONS
 #pragma region MouseButton
         lua.new_enum("ImGuiMouseButton",
@@ -2275,7 +2285,7 @@ namespace sol_ImGui
                                                                 sol::resolve<std::tuple<float, bool>(const std::string&, float, float, float)>(DragFloat),
                                                                 sol::resolve<std::tuple<float, bool>(const std::string&, float, float, float, float)>(DragFloat),
                                                                 sol::resolve<std::tuple<float, bool>(const std::string&, float, float, float, float, const std::string&)>(DragFloat),
-                                                                sol::resolve<std::tuple<float, bool>(const std::string&, float, float, float, float, const std::string&, float)>(DragFloat)
+                                                                sol::resolve<std::tuple<float, bool>(const std::string&, float, float, float, float, const std::string&, int)>(DragFloat)
                                                             ));
         ImGui.set_function("DragFloat2"						, sol::overload(
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&)>(DragFloat2),
@@ -2283,7 +2293,7 @@ namespace sol_ImGui
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float)>(DragFloat2),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float, float)>(DragFloat2),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float, float, const std::string&)>(DragFloat2),
-                                                                sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float, float, const std::string&, float)>(DragFloat2)
+                                                                sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float, float, const std::string&, int)>(DragFloat2)
                                                             ));
         ImGui.set_function("DragFloat3"						, sol::overload(
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&)>(DragFloat3),
@@ -2291,7 +2301,7 @@ namespace sol_ImGui
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float)>(DragFloat3),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float, float)>(DragFloat3),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float, float, const std::string&)>(DragFloat3),
-                                                                sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float, float, const std::string&, float)>(DragFloat3)
+                                                                sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float, float, const std::string&, int)>(DragFloat3)
                                                             ));
         ImGui.set_function("DragFloat4"						, sol::overload(
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&)>(DragFloat4),
@@ -2299,7 +2309,7 @@ namespace sol_ImGui
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float)>(DragFloat4),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float, float)>(DragFloat4),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float, float, const std::string&)>(DragFloat4),
-                                                                sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float, float, const std::string&, float)>(DragFloat4)
+                                                                sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float, float, const std::string&, int)>(DragFloat4)
                                                             ));
         ImGui.set_function("DragInt"						, sol::overload(
                                                                 sol::resolve<std::tuple<int, bool>(const std::string&, int)>(DragInt),
@@ -2335,22 +2345,22 @@ namespace sol_ImGui
         ImGui.set_function("SliderFloat"					, sol::overload(
                                                                 sol::resolve<std::tuple<float, bool>(const std::string&, float, float, float)>(SliderFloat),
                                                                 sol::resolve<std::tuple<float, bool>(const std::string&, float, float, float, const std::string&)>(SliderFloat),
-                                                                sol::resolve<std::tuple<float, bool>(const std::string&, float, float, float, const std::string&, float)>(SliderFloat)
+                                                                sol::resolve<std::tuple<float, bool>(const std::string&, float, float, float, const std::string&, int)>(SliderFloat)
                                                             ));
         ImGui.set_function("SliderFloat2"					, sol::overload(
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float)>(SliderFloat2),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float, const std::string&)>(SliderFloat2),
-                                                                sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float, const std::string&, float)>(SliderFloat2)
+                                                                sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float, const std::string&, int)>(SliderFloat2)
                                                             ));
         ImGui.set_function("SliderFloat3"					, sol::overload(
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float)>(SliderFloat3),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float, const std::string&)>(SliderFloat3),
-                                                                sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float, const std::string&, float)>(SliderFloat3)
+                                                                sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float, const std::string&, int)>(SliderFloat3)
                                                             ));
         ImGui.set_function("SliderFloat4"					, sol::overload(
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float)>(SliderFloat4),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float, const std::string&)>(SliderFloat4),
-                                                                sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float, const std::string&, float)>(SliderFloat4)
+                                                                sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float, const std::string&, int)>(SliderFloat4)
                                                             ));
         ImGui.set_function("SliderAngle"					, sol::overload(
                                                                 sol::resolve<std::tuple<float, bool>(const std::string&, float)>(SliderAngle),
@@ -2377,7 +2387,7 @@ namespace sol_ImGui
         ImGui.set_function("VSliderFloat"					, sol::overload(
                                                                 sol::resolve<std::tuple<float, bool>(const std::string&, float, float, float, float, float)>(VSliderFloat),
                                                                 sol::resolve<std::tuple<float, bool>(const std::string&, float, float, float, float, float, const std::string&)>(VSliderFloat),
-                                                                sol::resolve<std::tuple<float, bool>(const std::string&, float, float, float, float, float, const std::string&, float)>(VSliderFloat)
+                                                                sol::resolve<std::tuple<float, bool>(const std::string&, float, float, float, float, float, const std::string&, int)>(VSliderFloat)
                                                             ));
         ImGui.set_function("VSliderInt"						, sol::overload(
                                                                 sol::resolve<std::tuple<int, bool>(const std::string&, float, float, int, int, int)>(VSliderInt),
@@ -2708,7 +2718,7 @@ namespace sol_ImGui
         ImGui.set_function("ColorConvertRGBtoHSV"			, ColorConvertRGBtoHSV);
         ImGui.set_function("ColorConvertHSVtoRGB"			, ColorConvertHSVtoRGB);
 #pragma endregion Color Utilities
-        
+
 #ifdef SOL_IMGUI_ENABLE_INPUT_FUNCTIONS
 #pragma region Inputs Utilities: Keyboard
         ImGui.set_function("GetKeyIndex"					, GetKeyIndex);
@@ -2760,7 +2770,7 @@ namespace sol_ImGui
                                                             ));
 #pragma endregion Inputs Utilities: Mouse
 #endif // SOL_IMGUI_ENABLE_INPUT_FUNCTIONS
-        
+
 #pragma region Clipboard Utilities
         ImGui.set_function("GetClipboardText"				, GetClipboardText);
         ImGui.set_function("SetClipboardText"				, SetClipboardText);

--- a/src/sol_imgui/sol_imgui.h
+++ b/src/sol_imgui/sol_imgui.h
@@ -1540,6 +1540,37 @@ namespace sol_ImGui
     inline bool IsPopupOpen(const std::string& str_id)                                  { return ImGui::IsPopupOpen(str_id.c_str()); }
     inline bool IsPopupOpen(const std::string& str_id, int popup_flags)                 { return ImGui::IsPopupOpen(str_id.c_str(), popup_flags); }
 
+    //Tables
+    inline bool BeginTable(const std::string& str_id, int columns)                                                                          { return ImGui::BeginTable(str_id.c_str(), columns); }
+    inline bool BeginTable(const std::string& str_id, int columns, int flags)                                                               { return ImGui::BeginTable(str_id.c_str(), columns, static_cast<ImGuiTableFlags>(flags)); }
+    inline bool BeginTable(const std::string& str_id, int columns, int flags, float outer_sizeX, float outer_sizeY)                         { return ImGui::BeginTable(str_id.c_str(), columns, static_cast<ImGuiTableFlags>(flags), { outer_sizeX, outer_sizeY }); }
+    inline bool BeginTable(const std::string& str_id, int columns, int flags, float outer_sizeX, float outer_sizeY, float inner_width)      { return ImGui::BeginTable(str_id.c_str(), columns, static_cast<ImGuiTableFlags>(flags), { outer_sizeX, outer_sizeY }, inner_width); }
+    inline void EndTable()                                                                                                                  { ImGui::EndTable(); }
+    inline void TableNextRow()                                                                                                              { ImGui::TableNextRow(); }
+    inline void TableNextRow(int flags)                                                                                                     { ImGui::TableNextRow(static_cast<ImGuiTableRowFlags>(flags)); }
+    inline void TableNextRow(int flags, float min_row_height)                                                                               { ImGui::TableNextRow(static_cast<ImGuiTableRowFlags>(flags), min_row_height); }
+    inline bool TableNextColumn()                                                                                                           { return ImGui::TableNextColumn(); }
+    inline bool TableSetColumnIndex(int column_n)                                                                                           { return ImGui::TableSetColumnIndex(column_n); }
+    inline void TableSetupColumn(const std::string& label)                                                                                  { ImGui::TableSetupColumn(label.c_str()); }
+    inline void TableSetupColumn(const std::string& label, int flags)                                                                       { ImGui::TableSetupColumn(label.c_str(), static_cast<ImGuiTableColumnFlags>(flags)); }
+    inline void TableSetupColumn(const std::string& label, int flags, float init_width_or_weight)                                           { ImGui::TableSetupColumn(label.c_str(), static_cast<ImGuiTableColumnFlags>(flags), init_width_or_weight); }
+    inline void TableSetupColumn(const std::string& label, int flags, float init_width_or_weight, int user_id)                              { ImGui::TableSetupColumn(label.c_str(), static_cast<ImGuiTableColumnFlags>(flags), init_width_or_weight, ImU32(user_id)); }
+    inline void TableSetupScrollFreeze(int cols, int rows)                                                                                  { ImGui::TableSetupScrollFreeze(cols, rows); }
+    inline void TableHeadersRow()                                                                                                           { ImGui::TableHeadersRow(); }
+    inline void TableHeader(const std::string& label)                                                                                       { ImGui::TableHeader(label.c_str()); }
+    inline ImGuiTableSortSpecs* TableGetSortSpecs()                                                                                         { return ImGui::TableGetSortSpecs(); }
+    inline int TableGetColumnCount()                                                                                                        { return ImGui::TableGetColumnCount(); }
+    inline int TableGetColumnIndex()                                                                                                        { return ImGui::TableGetColumnIndex(); }
+    inline int TableGetRowIndex()                                                                                                           { return ImGui::TableGetRowIndex(); }
+    inline std::string TableGetColumnName()                                                                                                 { return std::string(ImGui::TableGetColumnName()); }
+    inline std::string TableGetColumnName(int column_n)                                                                                     { return std::string(ImGui::TableGetColumnName(column_n)); }
+    inline ImGuiTableColumnFlags TableGetColumnFlags()                                                                                      { return ImGui::TableGetColumnFlags(); }
+    inline ImGuiTableColumnFlags TableGetColumnFlags(int column_n)                                                                          { return ImGui::TableGetColumnFlags(column_n); }
+    inline void TableSetBgColor(int target, int color)                                                                                      { ImGui::TableSetBgColor(static_cast<ImGuiTableBgTarget>(target), ImU32(color)); }
+    inline void TableSetBgColor(int target, float colR, float colG, float colB, float colA)                                                 { ImGui::TableSetBgColor(static_cast<ImGuiTableBgTarget>(target), ImGui::ColorConvertFloat4ToU32({ colR, colG, colB, colA })); }
+    inline void TableSetBgColor(int target, int color, int column_n)                                                                        { ImGui::TableSetBgColor(static_cast<ImGuiTableBgTarget>(target), ImU32(color), column_n); }
+    inline void TableSetBgColor(int target, float colR, float colG, float colB, float colA, int column_n)                                   { ImGui::TableSetBgColor(static_cast<ImGuiTableBgTarget>(target), ImGui::ColorConvertFloat4ToU32({ colR, colG, colB, colA }), column_n); }
+
     // Columns
     inline void Columns()                                                        { ImGui::Columns(); }
     inline void Columns(int count)                                               { ImGui::Columns(count); }
@@ -1725,11 +1756,10 @@ namespace sol_ImGui
             "NoNavInputs"                    , ImGuiWindowFlags_NoNavInputs,
             "NoNavFocus"                     , ImGuiWindowFlags_NoNavFocus,
             "UnsavedDocument"                , ImGuiWindowFlags_UnsavedDocument,
-
             "NoNav"                          , ImGuiWindowFlags_NoNav,
             "NoDecoration"                   , ImGuiWindowFlags_NoDecoration,
             "NoInputs"                       , ImGuiWindowFlags_NoInputs,
-
+            // [Internal]
             "NavFlattened"                   , ImGuiWindowFlags_NavFlattened,
             "ChildWindow"                    , ImGuiWindowFlags_ChildWindow,
             "Tooltip"                        , ImGuiWindowFlags_Tooltip,
@@ -1910,6 +1940,7 @@ namespace sol_ImGui
             "CharsScientific"                , ImGuiInputTextFlags_CharsScientific,
             "CallbackResize"                 , ImGuiInputTextFlags_CallbackResize,
             "CallbackEdit"                   , ImGuiInputTextFlags_CallbackEdit,
+            // [Internal]
             "Multiline"                      , ImGuiInputTextFlags_Multiline,
             "NoMarkEdited"                   , ImGuiInputTextFlags_NoMarkEdited
         );
@@ -2009,6 +2040,105 @@ namespace sol_ImGui
             "AnyPopup"                       , ImGuiPopupFlags_AnyPopup
         );
 #pragma endregion Popup Flags
+
+#pragma region Table Flags
+        lua.new_enum("ImGuiTableFlags",
+            // Features
+            "None"                           , ImGuiTableFlags_None,
+            "Resizable"                      , ImGuiTableFlags_Resizable,
+            "Reorderable"                    , ImGuiTableFlags_Reorderable,
+            "Hideable"                       , ImGuiTableFlags_Hideable,
+            "Sortable"                       , ImGuiTableFlags_Sortable,
+            "NoSavedSettings"                , ImGuiTableFlags_NoSavedSettings,
+            "ContextMenuInBody"              , ImGuiTableFlags_ContextMenuInBody,
+            // Decorations
+            "RowBg"                          , ImGuiTableFlags_RowBg,
+            "BordersInnerH"                  , ImGuiTableFlags_BordersInnerH,
+            "BordersOuterH"                  , ImGuiTableFlags_BordersOuterH,
+            "BordersInnerV"                  , ImGuiTableFlags_BordersInnerV,
+            "BordersOuterV"                  , ImGuiTableFlags_BordersOuterV,
+            "BordersH"                       , ImGuiTableFlags_BordersH,
+            "BordersV"                       , ImGuiTableFlags_BordersV,
+            "BordersInner"                   , ImGuiTableFlags_BordersInner,
+            "BordersOuter"                   , ImGuiTableFlags_BordersOuter,
+            "Borders"                        , ImGuiTableFlags_Borders,
+            "NoBordersInBody"                , ImGuiTableFlags_NoBordersInBody,
+            "NoBordersInBodyUntilResize"     , ImGuiTableFlags_NoBordersInBodyUntilResize,
+            // Sizing Policy (read above for defaults)
+            "SizingFixedFit"                 , ImGuiTableFlags_SizingFixedFit,
+            "SizingFixedSame"                , ImGuiTableFlags_SizingFixedSame,
+            "SizingStretchProp"              , ImGuiTableFlags_SizingStretchProp,
+            "SizingStretchSame"              , ImGuiTableFlags_SizingStretchSame,
+            // Sizing Extra Options
+            "NoHostExtendX"                  , ImGuiTableFlags_NoHostExtendX,
+            "NoHostExtendY"                  , ImGuiTableFlags_NoHostExtendY,
+            "NoKeepColumnsVisible"           , ImGuiTableFlags_NoKeepColumnsVisible,
+            "PreciseWidths"                  , ImGuiTableFlags_PreciseWidths,
+            // Clipping
+            "NoClip"                         , ImGuiTableFlags_NoClip,
+            // Padding
+            "PadOuterX"                      , ImGuiTableFlags_PadOuterX,
+            "NoPadOuterX"                    , ImGuiTableFlags_NoPadOuterX,
+            "NoPadInnerX"                    , ImGuiTableFlags_NoPadInnerX,
+            // Scrolling
+            "ScrollX"                        , ImGuiTableFlags_ScrollX,
+            "ScrollY"                        , ImGuiTableFlags_ScrollY,
+            // Sorting
+            "SortMulti"                      , ImGuiTableFlags_SortMulti,
+            "SortTristate"                   , ImGuiTableFlags_SortTristate,
+            // [Internal] Combinations and masks
+            "SizingMask"                     , ImGuiTableFlags_SizingMask_
+        );
+#pragma endregion Table Flags
+
+#pragma region TableColumn Flags
+        lua.new_enum("ImGuiTableColumnFlags",
+        // Input configuration flags
+            "None"                           , ImGuiTableColumnFlags_None,
+            "DefaultHide"                    , ImGuiTableColumnFlags_DefaultHide,
+            "DefaultSort"                    , ImGuiTableColumnFlags_DefaultSort,
+            "WidthStretch"                   , ImGuiTableColumnFlags_WidthStretch,
+            "WidthFixed"                     , ImGuiTableColumnFlags_WidthFixed,
+            "NoResize"                       , ImGuiTableColumnFlags_NoResize,
+            "NoReorder"                      , ImGuiTableColumnFlags_NoReorder,
+            "NoHide"                         , ImGuiTableColumnFlags_NoHide,
+            "NoClip"                         , ImGuiTableColumnFlags_NoClip,
+            "NoSort"                         , ImGuiTableColumnFlags_NoSort,
+            "NoSortAscending"                , ImGuiTableColumnFlags_NoSortAscending,
+            "NoSortDescending"               , ImGuiTableColumnFlags_NoSortDescending,
+            "NoHeaderWidth"                  , ImGuiTableColumnFlags_NoHeaderWidth,
+            "PreferSortAscending"            , ImGuiTableColumnFlags_PreferSortAscending,
+            "PreferSortDescending"           , ImGuiTableColumnFlags_PreferSortDescending,
+            "IndentEnable"                   , ImGuiTableColumnFlags_IndentEnable,
+            "IndentDisable"                  , ImGuiTableColumnFlags_IndentDisable,
+            // Output status flags, read-only via TableGetColumnFlags()
+            "IsEnabled"                      , ImGuiTableColumnFlags_IsEnabled,
+            "IsVisible"                      , ImGuiTableColumnFlags_IsVisible,
+            "IsSorted"                       , ImGuiTableColumnFlags_IsSorted,
+            "IsHovered"                      , ImGuiTableColumnFlags_IsHovered,
+            // [Internal] Combinations and masks
+            "WidthMask_"                     , ImGuiTableColumnFlags_WidthMask_,
+            "IndentMask_"                    , ImGuiTableColumnFlags_IndentMask_,
+            "StatusMask_"                    , ImGuiTableColumnFlags_StatusMask_,
+            "NoDirectResize_"                , ImGuiTableColumnFlags_NoDirectResize_
+        );
+#pragma endregion TableColumn Flags
+
+#pragma region TableRow Flags
+        lua.new_enum("ImGuiTableRowFlags",
+            "None"                           , ImGuiTableRowFlags_None,
+            "Headers"                        , ImGuiTableRowFlags_Headers
+        );
+#pragma endregion TableRow Flags
+
+#pragma region TableBg Target
+        lua.new_enum("ImGuiTableBgTarget",
+            "None"                           , ImGuiTableBgTarget_None,
+            "RowBg0"                         , ImGuiTableBgTarget_RowBg0,
+            "RowBg1"                         , ImGuiTableBgTarget_RowBg1,
+            "CellBg"                         , ImGuiTableBgTarget_CellBg
+        );
+#pragma endregion TableBg Target
 
 #pragma region TabBar Flags
         lua.new_enum("ImGuiTabBarFlags",
@@ -2688,6 +2818,50 @@ namespace sol_ImGui
                                                                 sol::resolve<bool(const std::string&, int)>(IsPopupOpen)
                                                             ));
 #pragma endregion Popups, Modals
+
+#pragma region Tables
+        ImGui.set_function("BeginTable"              , sol::overload(
+                                                                      sol::resolve<bool(const std::string&, int)>(BeginTable),
+                                                                      sol::resolve<bool(const std::string&, int, int)>(BeginTable),
+                                                                      sol::resolve<bool(const std::string&, int, int, float, float)>(BeginTable),
+                                                                      sol::resolve<bool(const std::string&, int, int, float, float, float)>(BeginTable)
+                                                                    ));
+        ImGui.set_function("EndTable"                , EndTable);
+        ImGui.set_function("TableNextRow"            , sol::overload(
+                                                                      sol::resolve<void()>(TableNextRow),
+                                                                      sol::resolve<void(int)>(TableNextRow),
+                                                                      sol::resolve<void(int, float)>(TableNextRow)
+                                                                    ));
+        ImGui.set_function("TableNextColumn"         , TableNextColumn);
+        ImGui.set_function("TableSetColumnIndex"     , TableSetColumnIndex);
+        ImGui.set_function("TableSetupColumn"        , sol::overload(
+                                                                      sol::resolve<void(const std::string&)>(TableSetupColumn),
+                                                                      sol::resolve<void(const std::string&, int)>(TableSetupColumn),
+                                                                      sol::resolve<void(const std::string&, int, float)>(TableSetupColumn),
+                                                                      sol::resolve<void(const std::string&, int, float, int)>(TableSetupColumn)
+                                                                    ));
+        ImGui.set_function("TableSetupScrollFreeze"  , TableSetupScrollFreeze);
+        ImGui.set_function("TableHeadersRow"         , TableHeadersRow);
+        ImGui.set_function("TableHeader"             , TableHeader);
+        ImGui.set_function("TableGetSortSpecs"       , TableGetSortSpecs);
+        ImGui.set_function("TableGetColumnCount"     , TableGetColumnCount);
+        ImGui.set_function("TableGetColumnIndex"     , TableGetColumnIndex);
+        ImGui.set_function("TableGetRowIndex"        , TableGetRowIndex);
+        ImGui.set_function("TableGetColumnName"      , sol::overload(
+                                                                      sol::resolve<std::string()>(TableGetColumnName),
+                                                                      sol::resolve<std::string(int)>(TableGetColumnName)
+                                                                    ));
+        ImGui.set_function("TableGetColumnFlags"     , sol::overload(
+                                                                      sol::resolve<int()>(TableGetColumnFlags),
+                                                                      sol::resolve<int(int)>(TableGetColumnFlags)
+                                                                    ));
+        ImGui.set_function("TableSetBgColor"         , sol::overload(
+                                                                      sol::resolve<void(int, int)>(TableSetBgColor),
+                                                                      sol::resolve<void(int, float, float, float, float)>(TableSetBgColor),
+                                                                      sol::resolve<void(int, int, int)>(TableSetBgColor),
+                                                                      sol::resolve<void(int, float, float, float, float, int)>(TableSetBgColor)
+                                                                    ));
+#pragma endregion Tables
 
 #pragma region Columns
         ImGui.set_function("Columns"            , sol::overload(

--- a/src/sol_imgui/sol_imgui.h
+++ b/src/sol_imgui/sol_imgui.h
@@ -3,7 +3,7 @@
 namespace sol_ImGui
 {
     // Windows
-    inline bool Begin(const std::string& name)															{ return ImGui::Begin(name.c_str()); }
+    inline bool Begin(const std::string& name)                              { return ImGui::Begin(name.c_str()); }
     inline std::tuple<bool, bool> Begin(const std::string& name, bool open)
     {
         if (!open) return std::make_tuple(false, false);
@@ -31,173 +31,173 @@ namespace sol_ImGui
 
         return std::make_tuple(open, shouldDraw);
     }
-    inline void End()																					{ ImGui::End(); }
+    inline void End()                                               { ImGui::End(); }
 
     // Child Windows
-    inline bool BeginChild(const std::string& name)														{ return ImGui::BeginChild(name.c_str()); }
-    inline bool BeginChild(const std::string& name, float sizeX)										{ return ImGui::BeginChild(name.c_str(), { sizeX, 0 }); }
-    inline bool BeginChild(const std::string& name, float sizeX, float sizeY)							{ return ImGui::BeginChild(name.c_str(), { sizeX, sizeY }); }
-    inline bool BeginChild(const std::string& name, float sizeX, float sizeY, bool border)				{ return ImGui::BeginChild(name.c_str(), { sizeX, sizeY }, border); }
-    inline bool BeginChild(const std::string& name, float sizeX, float sizeY, bool border, int flags)	{ return ImGui::BeginChild(name.c_str(), { sizeX, sizeY }, border, static_cast<ImGuiWindowFlags>(flags)); }
-    inline void EndChild()																				{ ImGui::EndChild(); }
+    inline bool BeginChild(const std::string& name)                                                       { return ImGui::BeginChild(name.c_str()); }
+    inline bool BeginChild(const std::string& name, float sizeX)                                          { return ImGui::BeginChild(name.c_str(), { sizeX, 0 }); }
+    inline bool BeginChild(const std::string& name, float sizeX, float sizeY)                             { return ImGui::BeginChild(name.c_str(), { sizeX, sizeY }); }
+    inline bool BeginChild(const std::string& name, float sizeX, float sizeY, bool border)                { return ImGui::BeginChild(name.c_str(), { sizeX, sizeY }, border); }
+    inline bool BeginChild(const std::string& name, float sizeX, float sizeY, bool border, int flags)     { return ImGui::BeginChild(name.c_str(), { sizeX, sizeY }, border, static_cast<ImGuiWindowFlags>(flags)); }
+    inline void EndChild()                                                                                { ImGui::EndChild(); }
 
     // Windows Utilities
-    inline bool IsWindowAppearing()																		{ return ImGui::IsWindowAppearing(); }
-    inline bool IsWindowCollapsed()																		{ return ImGui::IsWindowCollapsed(); }
-    inline bool IsWindowFocused()																		{ return ImGui::IsWindowFocused(); }
-    inline bool IsWindowFocused(int flags)																{ return ImGui::IsWindowFocused(static_cast<ImGuiFocusedFlags>(flags)); }
-    inline bool IsWindowHovered()																		{ return ImGui::IsWindowHovered(); }
-    inline bool IsWindowHovered(int flags)																{ return ImGui::IsWindowHovered(static_cast<ImGuiHoveredFlags>(flags)); }
-    inline ImDrawList* GetWindowDrawList()																{ return nullptr; /* TODO: GetWindowDrawList() ==> UNSUPPORTED */ }
-    inline std::tuple<float, float> GetWindowPos()														{ const auto vec2{ ImGui::GetWindowPos() };  return std::make_tuple(vec2.x, vec2.y); }
-    inline std::tuple<float, float> GetWindowSize()														{ const auto vec2{ ImGui::GetWindowSize() };  return std::make_tuple(vec2.x, vec2.y); }
-    inline float GetWindowWidth()																		{ return ImGui::GetWindowWidth(); }
-    inline float GetWindowHeight()																		{ return ImGui::GetWindowHeight(); }
+    inline bool IsWindowAppearing()                                  { return ImGui::IsWindowAppearing(); }
+    inline bool IsWindowCollapsed()                                  { return ImGui::IsWindowCollapsed(); }
+    inline bool IsWindowFocused()                                    { return ImGui::IsWindowFocused(); }
+    inline bool IsWindowFocused(int flags)                           { return ImGui::IsWindowFocused(static_cast<ImGuiFocusedFlags>(flags)); }
+    inline bool IsWindowHovered()                                    { return ImGui::IsWindowHovered(); }
+    inline bool IsWindowHovered(int flags)                           { return ImGui::IsWindowHovered(static_cast<ImGuiHoveredFlags>(flags)); }
+    inline ImDrawList* GetWindowDrawList()                           { return nullptr; /* TODO: GetWindowDrawList() ==> UNSUPPORTED */ }
+    inline std::tuple<float, float> GetWindowPos()                   { const auto vec2{ ImGui::GetWindowPos() };  return std::make_tuple(vec2.x, vec2.y); }
+    inline std::tuple<float, float> GetWindowSize()                  { const auto vec2{ ImGui::GetWindowSize() };  return std::make_tuple(vec2.x, vec2.y); }
+    inline float GetWindowWidth()                                    { return ImGui::GetWindowWidth(); }
+    inline float GetWindowHeight()                                   { return ImGui::GetWindowHeight(); }
 
     // Prefer using SetNext...
-    inline void SetNextWindowPos(float posX, float posY)												{ ImGui::SetNextWindowPos({ posX, posY }); }
-    inline void SetNextWindowPos(float posX, float posY, int cond)										{ ImGui::SetNextWindowPos({ posX, posY }, static_cast<ImGuiCond>(cond)); }
-    inline void SetNextWindowPos(float posX, float posY, int cond, float pivotX, float pivotY)			{ ImGui::SetNextWindowPos({ posX, posY }, static_cast<ImGuiCond>(cond), { pivotX, pivotY }); }
-    inline void SetNextWindowSize(float sizeX, float sizeY)												{ ImGui::SetNextWindowSize({ sizeX, sizeY }); }
-    inline void SetNextWindowSize(float sizeX, float sizeY, int cond)									{ ImGui::SetNextWindowSize({ sizeX, sizeY }, static_cast<ImGuiCond>(cond)); }
-    inline void SetNextWindowSizeConstraints(float minX, float minY, float maxX, float maxY)			{ ImGui::SetNextWindowSizeConstraints({ minX, minY }, { maxX, maxY }); }
-    inline void SetNextWindowContentSize(float sizeX, float sizeY)										{ ImGui::SetNextWindowContentSize({ sizeX, sizeY }); }
-    inline void SetNextWindowCollapsed(bool collapsed)													{ ImGui::SetNextWindowCollapsed(collapsed); }
-    inline void SetNextWindowCollapsed(bool collapsed, int cond)										{ ImGui::SetNextWindowCollapsed(collapsed, static_cast<ImGuiCond>(cond)); }
-    inline void SetNextWindowFocus()																	{ ImGui::SetNextWindowFocus(); }
-    inline void SetNextWindowBgAlpha(float alpha)														{ ImGui::SetNextWindowBgAlpha(alpha); }
-    inline void SetWindowPos(float posX, float posY)													{ ImGui::SetWindowPos({ posX, posY }); }
-    inline void SetWindowPos(float posX, float posY, int cond)											{ ImGui::SetWindowPos({ posX, posY }, static_cast<ImGuiCond>(cond)); }
-    inline void SetWindowSize(float sizeX, float sizeY)													{ ImGui::SetWindowSize({ sizeX, sizeY }); }
-    inline void SetWindowSize(float sizeX, float sizeY, int cond)										{ ImGui::SetWindowSize({ sizeX, sizeY }, static_cast<ImGuiCond>(cond)); }
-    inline void SetWindowCollapsed(bool collapsed)														{ ImGui::SetWindowCollapsed(collapsed); }
-    inline void SetWindowCollapsed(bool collapsed, int cond)											{ ImGui::SetWindowCollapsed(collapsed, static_cast<ImGuiCond>(cond)); }
-    inline void SetWindowFocus()																		{ ImGui::SetWindowFocus(); }
-    inline void SetWindowFontScale(float scale)															{ ImGui::SetWindowFontScale(scale); }
-    inline void SetWindowPos(const std::string& name, float posX, float posY)							{ ImGui::SetWindowPos(name.c_str(), { posX, posY }); }
-    inline void SetWindowPos(const std::string& name, float posX, float posY, int cond)					{ ImGui::SetWindowPos(name.c_str(), { posX, posY }, static_cast<ImGuiCond>(cond)); }
-    inline void SetWindowSize(const std::string& name, float sizeX, float sizeY)						{ ImGui::SetWindowSize(name.c_str(), { sizeX, sizeY }); }
-    inline void SetWindowSize(const std::string& name, float sizeX, float sizeY, int cond)				{ ImGui::SetWindowSize(name.c_str(), { sizeX, sizeY }, static_cast<ImGuiCond>(cond)); }
-    inline void SetWindowCollapsed(const std::string& name, bool collapsed)								{ ImGui::SetWindowCollapsed(name.c_str(), collapsed); }
-    inline void SetWindowCollapsed(const std::string& name, bool collapsed, int cond)					{ ImGui::SetWindowCollapsed(name.c_str(), collapsed, static_cast<ImGuiCond>(cond)); }
-    inline void SetWindowFocus(const std::string& name)													{ ImGui::SetWindowFocus(name.c_str()); }
+    inline void SetNextWindowPos(float posX, float posY)                                              { ImGui::SetNextWindowPos({ posX, posY }); }
+    inline void SetNextWindowPos(float posX, float posY, int cond)                                    { ImGui::SetNextWindowPos({ posX, posY }, static_cast<ImGuiCond>(cond)); }
+    inline void SetNextWindowPos(float posX, float posY, int cond, float pivotX, float pivotY)        { ImGui::SetNextWindowPos({ posX, posY }, static_cast<ImGuiCond>(cond), { pivotX, pivotY }); }
+    inline void SetNextWindowSize(float sizeX, float sizeY)                                           { ImGui::SetNextWindowSize({ sizeX, sizeY }); }
+    inline void SetNextWindowSize(float sizeX, float sizeY, int cond)                                 { ImGui::SetNextWindowSize({ sizeX, sizeY }, static_cast<ImGuiCond>(cond)); }
+    inline void SetNextWindowSizeConstraints(float minX, float minY, float maxX, float maxY)          { ImGui::SetNextWindowSizeConstraints({ minX, minY }, { maxX, maxY }); }
+    inline void SetNextWindowContentSize(float sizeX, float sizeY)                                    { ImGui::SetNextWindowContentSize({ sizeX, sizeY }); }
+    inline void SetNextWindowCollapsed(bool collapsed)                                                { ImGui::SetNextWindowCollapsed(collapsed); }
+    inline void SetNextWindowCollapsed(bool collapsed, int cond)                                      { ImGui::SetNextWindowCollapsed(collapsed, static_cast<ImGuiCond>(cond)); }
+    inline void SetNextWindowFocus()                                                                  { ImGui::SetNextWindowFocus(); }
+    inline void SetNextWindowBgAlpha(float alpha)                                                     { ImGui::SetNextWindowBgAlpha(alpha); }
+    inline void SetWindowPos(float posX, float posY)                                                  { ImGui::SetWindowPos({ posX, posY }); }
+    inline void SetWindowPos(float posX, float posY, int cond)                                        { ImGui::SetWindowPos({ posX, posY }, static_cast<ImGuiCond>(cond)); }
+    inline void SetWindowSize(float sizeX, float sizeY)                                               { ImGui::SetWindowSize({ sizeX, sizeY }); }
+    inline void SetWindowSize(float sizeX, float sizeY, int cond)                                     { ImGui::SetWindowSize({ sizeX, sizeY }, static_cast<ImGuiCond>(cond)); }
+    inline void SetWindowCollapsed(bool collapsed)                                                    { ImGui::SetWindowCollapsed(collapsed); }
+    inline void SetWindowCollapsed(bool collapsed, int cond)                                          { ImGui::SetWindowCollapsed(collapsed, static_cast<ImGuiCond>(cond)); }
+    inline void SetWindowFocus()                                                                      { ImGui::SetWindowFocus(); }
+    inline void SetWindowFontScale(float scale)                                                       { ImGui::SetWindowFontScale(scale); }
+    inline void SetWindowPos(const std::string& name, float posX, float posY)                         { ImGui::SetWindowPos(name.c_str(), { posX, posY }); }
+    inline void SetWindowPos(const std::string& name, float posX, float posY, int cond)               { ImGui::SetWindowPos(name.c_str(), { posX, posY }, static_cast<ImGuiCond>(cond)); }
+    inline void SetWindowSize(const std::string& name, float sizeX, float sizeY)                      { ImGui::SetWindowSize(name.c_str(), { sizeX, sizeY }); }
+    inline void SetWindowSize(const std::string& name, float sizeX, float sizeY, int cond)            { ImGui::SetWindowSize(name.c_str(), { sizeX, sizeY }, static_cast<ImGuiCond>(cond)); }
+    inline void SetWindowCollapsed(const std::string& name, bool collapsed)                           { ImGui::SetWindowCollapsed(name.c_str(), collapsed); }
+    inline void SetWindowCollapsed(const std::string& name, bool collapsed, int cond)                 { ImGui::SetWindowCollapsed(name.c_str(), collapsed, static_cast<ImGuiCond>(cond)); }
+    inline void SetWindowFocus(const std::string& name)                                               { ImGui::SetWindowFocus(name.c_str()); }
 
     // Content Region
-    inline std::tuple<float, float> GetContentRegionMax()												{ const auto vec2{ ImGui::GetContentRegionMax() };  return std::make_tuple(vec2.x, vec2.y); }
-    inline std::tuple<float, float> GetContentRegionAvail()												{ const auto vec2{ ImGui::GetContentRegionAvail() };  return std::make_tuple(vec2.x, vec2.y); }
-    inline std::tuple<float, float> GetWindowContentRegionMin()											{ const auto vec2{ ImGui::GetWindowContentRegionMin() };  return std::make_tuple(vec2.x, vec2.y); }
-    inline std::tuple<float, float> GetWindowContentRegionMax()											{ const auto vec2{ ImGui::GetWindowContentRegionMax() };  return std::make_tuple(vec2.x, vec2.y); }
-    inline float GetWindowContentRegionWidth()															{ return ImGui::GetWindowContentRegionWidth(); }
+    inline std::tuple<float, float> GetContentRegionMax()                            { const auto vec2{ ImGui::GetContentRegionMax() };  return std::make_tuple(vec2.x, vec2.y); }
+    inline std::tuple<float, float> GetContentRegionAvail()                          { const auto vec2{ ImGui::GetContentRegionAvail() };  return std::make_tuple(vec2.x, vec2.y); }
+    inline std::tuple<float, float> GetWindowContentRegionMin()                      { const auto vec2{ ImGui::GetWindowContentRegionMin() };  return std::make_tuple(vec2.x, vec2.y); }
+    inline std::tuple<float, float> GetWindowContentRegionMax()                      { const auto vec2{ ImGui::GetWindowContentRegionMax() };  return std::make_tuple(vec2.x, vec2.y); }
+    inline float GetWindowContentRegionWidth()                                       { return ImGui::GetWindowContentRegionWidth(); }
 
     // Windows Scrolling
-    inline float GetScrollX()																			{ return ImGui::GetScrollX(); }
-    inline float GetScrollY()																			{ return ImGui::GetScrollY(); }
-    inline float GetScrollMaxX()																		{ return ImGui::GetScrollMaxX(); }
-    inline float GetScrollMaxY()																		{ return ImGui::GetScrollMaxY(); }
-    inline void SetScrollX(float scrollX)																{ ImGui::SetScrollX(scrollX); }
-    inline void SetScrollY(float scrollY)																{ ImGui::SetScrollY(scrollY); }
-    inline void SetScrollHereX()																		{ ImGui::SetScrollHereX(); }
-    inline void SetScrollHereX(float centerXRatio)														{ ImGui::SetScrollHereX(centerXRatio); }
-    inline void SetScrollHereY()																		{ ImGui::SetScrollHereY(); }
-    inline void SetScrollHereY(float centerYRatio)														{ ImGui::SetScrollHereY(centerYRatio); }
-    inline void SetScrollFromPosX(float localX)															{ ImGui::SetScrollFromPosX(localX); }
-    inline void SetScrollFromPosX(float localX, float centerXRatio)										{ ImGui::SetScrollFromPosX(localX, centerXRatio); }
-    inline void SetScrollFromPosY(float localY)															{ ImGui::SetScrollFromPosY(localY); }
-    inline void SetScrollFromPosY(float localY, float centerYRatio)										{ ImGui::SetScrollFromPosY(localY, centerYRatio); }
+    inline float GetScrollX()                                          { return ImGui::GetScrollX(); }
+    inline float GetScrollY()                                          { return ImGui::GetScrollY(); }
+    inline float GetScrollMaxX()                                       { return ImGui::GetScrollMaxX(); }
+    inline float GetScrollMaxY()                                       { return ImGui::GetScrollMaxY(); }
+    inline void SetScrollX(float scrollX)                              { ImGui::SetScrollX(scrollX); }
+    inline void SetScrollY(float scrollY)                              { ImGui::SetScrollY(scrollY); }
+    inline void SetScrollHereX()                                       { ImGui::SetScrollHereX(); }
+    inline void SetScrollHereX(float centerXRatio)                     { ImGui::SetScrollHereX(centerXRatio); }
+    inline void SetScrollHereY()                                       { ImGui::SetScrollHereY(); }
+    inline void SetScrollHereY(float centerYRatio)                     { ImGui::SetScrollHereY(centerYRatio); }
+    inline void SetScrollFromPosX(float localX)                        { ImGui::SetScrollFromPosX(localX); }
+    inline void SetScrollFromPosX(float localX, float centerXRatio)    { ImGui::SetScrollFromPosX(localX, centerXRatio); }
+    inline void SetScrollFromPosY(float localY)                        { ImGui::SetScrollFromPosY(localY); }
+    inline void SetScrollFromPosY(float localY, float centerYRatio)    { ImGui::SetScrollFromPosY(localY, centerYRatio); }
 
     // Parameters stacks (shared)
 #ifdef SOL_IMGUI_ENABLE_FONT_MANIPULATORS
-    inline void PushFont(ImFont* pFont)																	{ ImGui::PushFont(pFont); }
-    inline void PopFont()																				{ ImGui::PopFont(); }
+    inline void PushFont(ImFont* pFont)                                  { ImGui::PushFont(pFont); }
+    inline void PopFont()                                                { ImGui::PopFont(); }
 #endif // SOL_IMGUI_ENABLE_FONT_MANIPULATORS
-    inline void PushStyleColor(int idx, int col)														{ ImGui::PushStyleColor(static_cast<ImGuiCol>(idx), ImU32(col)); }
-    inline void PushStyleColor(int idx, float colR, float colG, float colB, float colA)					{ ImGui::PushStyleColor(static_cast<ImGuiCol>(idx), { colR, colG, colB, colA }); }
-    inline void PopStyleColor()																			{ ImGui::PopStyleColor(); }
-    inline void PopStyleColor(int count)																{ ImGui::PopStyleColor(count); }
-    inline void PushStyleVar(int idx, float val)														{ ImGui::PushStyleVar(static_cast<ImGuiStyleVar>(idx), val); }
-    inline void PushStyleVar(int idx, float valX, float valY)											{ ImGui::PushStyleVar(static_cast<ImGuiStyleVar>(idx), { valX, valY }); }
-    inline void PopStyleVar()																			{ ImGui::PopStyleVar(); }
-    inline void PopStyleVar(int count)																	{ ImGui::PopStyleVar(count); }
-    inline std::tuple<float, float, float, float> GetStyleColorVec4(int idx)							{ const auto col{ ImGui::GetStyleColorVec4(static_cast<ImGuiCol>(idx)) };	return std::make_tuple(col.x, col.y, col.z, col.w); }
+    inline void PushStyleColor(int idx, int col)                                                 { ImGui::PushStyleColor(static_cast<ImGuiCol>(idx), ImU32(col)); }
+    inline void PushStyleColor(int idx, float colR, float colG, float colB, float colA)          { ImGui::PushStyleColor(static_cast<ImGuiCol>(idx), { colR, colG, colB, colA }); }
+    inline void PopStyleColor()                                                                  { ImGui::PopStyleColor(); }
+    inline void PopStyleColor(int count)                                                         { ImGui::PopStyleColor(count); }
+    inline void PushStyleVar(int idx, float val)                                                 { ImGui::PushStyleVar(static_cast<ImGuiStyleVar>(idx), val); }
+    inline void PushStyleVar(int idx, float valX, float valY)                                    { ImGui::PushStyleVar(static_cast<ImGuiStyleVar>(idx), { valX, valY }); }
+    inline void PopStyleVar()                                                                    { ImGui::PopStyleVar(); }
+    inline void PopStyleVar(int count)                                                           { ImGui::PopStyleVar(count); }
+    inline std::tuple<float, float, float, float> GetStyleColorVec4(int idx)                     { const auto col{ ImGui::GetStyleColorVec4(static_cast<ImGuiCol>(idx)) };  return std::make_tuple(col.x, col.y, col.z, col.w); }
 #ifdef SOL_IMGUI_ENABLE_FONT_MANIPULATORS
-    inline ImFont* GetFont()																			{ return ImGui::GetFont(); }
+    inline ImFont* GetFont()                                                                     { return ImGui::GetFont(); }
 #endif // SOL_IMGUI_ENABLE_FONT_MANIPULATORS
-    inline float GetFontSize()																			{ return ImGui::GetFontSize(); }
-    inline std::tuple<float, float> GetFontTexUvWhitePixel()               { const auto vec2{ ImGui::GetFontTexUvWhitePixel() }; return std::make_tuple(vec2.x, vec2.y); }
-    inline int GetColorU32(int idx, float alphaMul)                        { return ImGui::GetColorU32(static_cast<ImGuiCol>(idx), alphaMul); }
-    inline int GetColorU32(float colR, float colG, float colB, float colA) { return ImGui::GetColorU32({ colR, colG, colB, colA }); }
-    inline int GetColorU32(int col)                                        { return ImGui::GetColorU32(ImU32(col)); }
+    inline float GetFontSize()                                                                   { return ImGui::GetFontSize(); }
+    inline std::tuple<float, float> GetFontTexUvWhitePixel()                                     { const auto vec2{ ImGui::GetFontTexUvWhitePixel() }; return std::make_tuple(vec2.x, vec2.y); }
+    inline int GetColorU32(int idx, float alphaMul)                                              { return ImGui::GetColorU32(static_cast<ImGuiCol>(idx), alphaMul); }
+    inline int GetColorU32(float colR, float colG, float colB, float colA)                       { return ImGui::GetColorU32({ colR, colG, colB, colA }); }
+    inline int GetColorU32(int col)                                                              { return ImGui::GetColorU32(ImU32(col)); }
 
     // Parameters stacks (current window)
-    inline void PushItemWidth(float itemWidth)															{ ImGui::PushItemWidth(itemWidth); }
-    inline void PopItemWidth()																			{ ImGui::PopItemWidth(); }
-    inline void SetNextItemWidth(float itemWidth)														{ ImGui::SetNextItemWidth(itemWidth); }
-    inline float CalcItemWidth()																		{ return ImGui::CalcItemWidth(); }
-    inline void PushTextWrapPos()																		{ ImGui::PushTextWrapPos(); }
-    inline void PushTextWrapPos(float wrapLocalPosX)													{ ImGui::PushTextWrapPos(wrapLocalPosX); }
-    inline void PopTextWrapPos()																		{ ImGui::PopTextWrapPos(); }
-    inline void PushAllowKeyboardFocus(bool allowKeyboardFocus)											{ ImGui::PushAllowKeyboardFocus(allowKeyboardFocus); }
-    inline void PopAllowKeyboardFocus()																	{ ImGui::PopAllowKeyboardFocus(); }
-    inline void PushButtonRepeat(bool repeat)															{ ImGui::PushButtonRepeat(repeat); }
-    inline void PopButtonRepeat()																		{ ImGui::PopButtonRepeat(); }
+    inline void PushItemWidth(float itemWidth)                                 { ImGui::PushItemWidth(itemWidth); }
+    inline void PopItemWidth()                                                 { ImGui::PopItemWidth(); }
+    inline void SetNextItemWidth(float itemWidth)                              { ImGui::SetNextItemWidth(itemWidth); }
+    inline float CalcItemWidth()                                               { return ImGui::CalcItemWidth(); }
+    inline void PushTextWrapPos()                                              { ImGui::PushTextWrapPos(); }
+    inline void PushTextWrapPos(float wrapLocalPosX)                           { ImGui::PushTextWrapPos(wrapLocalPosX); }
+    inline void PopTextWrapPos()                                               { ImGui::PopTextWrapPos(); }
+    inline void PushAllowKeyboardFocus(bool allowKeyboardFocus)                { ImGui::PushAllowKeyboardFocus(allowKeyboardFocus); }
+    inline void PopAllowKeyboardFocus()                                        { ImGui::PopAllowKeyboardFocus(); }
+    inline void PushButtonRepeat(bool repeat)                                  { ImGui::PushButtonRepeat(repeat); }
+    inline void PopButtonRepeat()                                              { ImGui::PopButtonRepeat(); }
 
     // Cursor / Layout
-    inline void Separator()																				{ ImGui::Separator(); }
-    inline void SameLine()																				{ ImGui::SameLine(); }
-    inline void SameLine(float offsetFromStartX)														{ ImGui::SameLine(offsetFromStartX); }
-    inline void SameLine(float offsetFromStartX, float spacing)											{ ImGui::SameLine(offsetFromStartX, spacing); }
-    inline void NewLine()																				{ ImGui::NewLine(); }
-    inline void Spacing()																				{ ImGui::Spacing(); }
-    inline void Dummy(float sizeX, float sizeY)															{ ImGui::Dummy({ sizeX, sizeY }); }
-    inline void Indent()																				{ ImGui::Indent(); }
-    inline void Indent(float indentW)																	{ ImGui::Indent(indentW); }
-    inline void Unindent()																				{ ImGui::Unindent(); }
-    inline void Unindent(float indentW)																	{ ImGui::Unindent(indentW); }
-    inline void BeginGroup()																			{ ImGui::BeginGroup(); }
-    inline void EndGroup()																				{ ImGui::EndGroup(); }
-    inline std::tuple<float, float> GetCursorPos()														{ const auto vec2{ ImGui::GetCursorPos() };  return std::make_tuple(vec2.x, vec2.y); }
-    inline float GetCursorPosX()																		{ return ImGui::GetCursorPosX(); }
-    inline float GetCursorPosY()																		{ return ImGui::GetCursorPosY(); }
-    inline void SetCursorPos(float localX, float localY)												{ ImGui::SetCursorPos({ localX, localY }); }
-    inline void SetCursorPosX(float localX)																{ ImGui::SetCursorPosX(localX); }
-    inline void SetCursorPosY(float localY)																{ ImGui::SetCursorPosY(localY); }
-    inline std::tuple<float, float> GetCursorStartPos()													{ const auto vec2{ ImGui::GetCursorStartPos() };  return std::make_tuple(vec2.x, vec2.y); }
-    inline std::tuple<float, float> GetCursorScreenPos()												{ const auto vec2{ ImGui::GetCursorScreenPos() };  return std::make_tuple(vec2.x, vec2.y); }
-    inline void SetCursorScreenPos(float posX, float posY)												{ ImGui::SetCursorScreenPos({ posX, posY }); }
-    inline void AlignTextToFramePadding()																{ ImGui::AlignTextToFramePadding(); }
-    inline float GetTextLineHeight()																	{ return ImGui::GetTextLineHeight(); }
-    inline float GetTextLineHeightWithSpacing()															{ return ImGui::GetTextLineHeightWithSpacing(); }
-    inline float GetFrameHeight()																		{ return ImGui::GetFrameHeight(); }
-    inline float GetFrameHeightWithSpacing()															{ return ImGui::GetFrameHeightWithSpacing(); }
+    inline void Separator()                                                    { ImGui::Separator(); }
+    inline void SameLine()                                                     { ImGui::SameLine(); }
+    inline void SameLine(float offsetFromStartX)                               { ImGui::SameLine(offsetFromStartX); }
+    inline void SameLine(float offsetFromStartX, float spacing)                { ImGui::SameLine(offsetFromStartX, spacing); }
+    inline void NewLine()                                                      { ImGui::NewLine(); }
+    inline void Spacing()                                                      { ImGui::Spacing(); }
+    inline void Dummy(float sizeX, float sizeY)                                { ImGui::Dummy({ sizeX, sizeY }); }
+    inline void Indent()                                                       { ImGui::Indent(); }
+    inline void Indent(float indentW)                                          { ImGui::Indent(indentW); }
+    inline void Unindent()                                                     { ImGui::Unindent(); }
+    inline void Unindent(float indentW)                                        { ImGui::Unindent(indentW); }
+    inline void BeginGroup()                                                   { ImGui::BeginGroup(); }
+    inline void EndGroup()                                                     { ImGui::EndGroup(); }
+    inline std::tuple<float, float> GetCursorPos()                             { const auto vec2{ ImGui::GetCursorPos() };  return std::make_tuple(vec2.x, vec2.y); }
+    inline float GetCursorPosX()                                               { return ImGui::GetCursorPosX(); }
+    inline float GetCursorPosY()                                               { return ImGui::GetCursorPosY(); }
+    inline void SetCursorPos(float localX, float localY)                       { ImGui::SetCursorPos({ localX, localY }); }
+    inline void SetCursorPosX(float localX)                                    { ImGui::SetCursorPosX(localX); }
+    inline void SetCursorPosY(float localY)                                    { ImGui::SetCursorPosY(localY); }
+    inline std::tuple<float, float> GetCursorStartPos()                        { const auto vec2{ ImGui::GetCursorStartPos() };  return std::make_tuple(vec2.x, vec2.y); }
+    inline std::tuple<float, float> GetCursorScreenPos()                       { const auto vec2{ ImGui::GetCursorScreenPos() };  return std::make_tuple(vec2.x, vec2.y); }
+    inline void SetCursorScreenPos(float posX, float posY)                     { ImGui::SetCursorScreenPos({ posX, posY }); }
+    inline void AlignTextToFramePadding()                                      { ImGui::AlignTextToFramePadding(); }
+    inline float GetTextLineHeight()                                           { return ImGui::GetTextLineHeight(); }
+    inline float GetTextLineHeightWithSpacing()                                { return ImGui::GetTextLineHeightWithSpacing(); }
+    inline float GetFrameHeight()                                              { return ImGui::GetFrameHeight(); }
+    inline float GetFrameHeightWithSpacing()                                   { return ImGui::GetFrameHeightWithSpacing(); }
 
     // ID stack / scopes
-    inline void PushID(const std::string& stringID)														{ ImGui::PushID(stringID.c_str()); }
-    inline void PushID(const std::string& stringIDBegin, const std::string& stringIDEnd)				{ ImGui::PushID(stringIDBegin.c_str(), stringIDEnd.c_str()); }
-    inline void PushID(const void*)																		{ /* TODO: PushID(void*) ==> UNSUPPORTED */ }
-    inline void PushID(int intID)																		{ ImGui::PushID(intID); }
-    inline void PopID()																					{ ImGui::PopID(); }
-    inline int GetID(const std::string& stringID)														{ return ImGui::GetID(stringID.c_str()); }
-    inline int GetID(const std::string& stringIDBegin, const std::string& stringIDEnd)					{ return ImGui::GetID(stringIDBegin.c_str(), stringIDEnd.c_str()); }
-    inline int GetID(const void*)																		{ return 0;  /* TODO: GetID(void*) ==> UNSUPPORTED */ }
+    inline void PushID(const std::string& stringID)                                             { ImGui::PushID(stringID.c_str()); }
+    inline void PushID(const std::string& stringIDBegin, const std::string& stringIDEnd)        { ImGui::PushID(stringIDBegin.c_str(), stringIDEnd.c_str()); }
+    inline void PushID(const void*)                                                             { /* TODO: PushID(void*) ==> UNSUPPORTED */ }
+    inline void PushID(int intID)                                                               { ImGui::PushID(intID); }
+    inline void PopID()                                                                         { ImGui::PopID(); }
+    inline int GetID(const std::string& stringID)                                               { return ImGui::GetID(stringID.c_str()); }
+    inline int GetID(const std::string& stringIDBegin, const std::string& stringIDEnd)          { return ImGui::GetID(stringIDBegin.c_str(), stringIDEnd.c_str()); }
+    inline int GetID(const void*)                                                               { return 0;  /* TODO: GetID(void*) ==> UNSUPPORTED */ }
 
     // Widgets: Text
-    inline void TextUnformatted(const std::string& text)												{ ImGui::TextUnformatted(text.c_str()); }
-    inline void TextUnformatted(const std::string& text, const std::string& textEnd)					{ ImGui::TextUnformatted(text.c_str(), textEnd.c_str()); }
-    inline void Text(const std::string& text)															{ ImGui::Text(text.c_str()); }
-    inline void TextColored(float colR, float colG, float colB, float colA, const std::string& text)	{ ImGui::TextColored({ colR, colG, colB, colA }, text.c_str()); }
-    inline void TextDisabled(const std::string& text)													{ ImGui::TextDisabled(text.c_str()); }
-    inline void TextWrapped(const std::string text)														{ ImGui::TextWrapped(text.c_str()); }
-    inline void LabelText(const std::string& label, const std::string& text)							{ ImGui::LabelText(label.c_str(), text.c_str()); }
-    inline void BulletText(const std::string& text)														{ ImGui::BulletText(text.c_str()); }
+    inline void TextUnformatted(const std::string& text)                                               { ImGui::TextUnformatted(text.c_str()); }
+    inline void TextUnformatted(const std::string& text, const std::string& textEnd)                   { ImGui::TextUnformatted(text.c_str(), textEnd.c_str()); }
+    inline void Text(const std::string& text)                                                          { ImGui::Text(text.c_str()); }
+    inline void TextColored(float colR, float colG, float colB, float colA, const std::string& text)   { ImGui::TextColored({ colR, colG, colB, colA }, text.c_str()); }
+    inline void TextDisabled(const std::string& text)                                                  { ImGui::TextDisabled(text.c_str()); }
+    inline void TextWrapped(const std::string text)                                                    { ImGui::TextWrapped(text.c_str()); }
+    inline void LabelText(const std::string& label, const std::string& text)                           { ImGui::LabelText(label.c_str(), text.c_str()); }
+    inline void BulletText(const std::string& text)                                                    { ImGui::BulletText(text.c_str()); }
 
     // Widgets: Main
-    inline bool Button(const std::string& label)														{ return ImGui::Button(label.c_str()); }
-    inline bool Button(const std::string& label, float sizeX, float sizeY)								{ return ImGui::Button(label.c_str(), { sizeX, sizeY }); }
-    inline bool SmallButton(const std::string& label)													{ return ImGui::SmallButton(label.c_str()); }
-    inline bool InvisibleButton(const std::string& stringID, float sizeX, float sizeY)					{ return ImGui::InvisibleButton(stringID.c_str(), { sizeX, sizeY }); }
-    inline bool ArrowButton(const std::string& stringID, int dir)										{ return ImGui::ArrowButton(stringID.c_str(), static_cast<ImGuiDir>(dir)); }
-    inline void Image()																					{ /* TODO: Image(...) ==> UNSUPPORTED */ }
-    inline void ImageButton()																			{ /* TODO: ImageButton(...) ==> UNSUPPORTED */ }
+    inline bool Button(const std::string& label)                                                { return ImGui::Button(label.c_str()); }
+    inline bool Button(const std::string& label, float sizeX, float sizeY)                      { return ImGui::Button(label.c_str(), { sizeX, sizeY }); }
+    inline bool SmallButton(const std::string& label)                                           { return ImGui::SmallButton(label.c_str()); }
+    inline bool InvisibleButton(const std::string& stringID, float sizeX, float sizeY)          { return ImGui::InvisibleButton(stringID.c_str(), { sizeX, sizeY }); }
+    inline bool ArrowButton(const std::string& stringID, int dir)                               { return ImGui::ArrowButton(stringID.c_str(), static_cast<ImGuiDir>(dir)); }
+    inline void Image()                                                                         { /* TODO: Image(...) ==> UNSUPPORTED */ }
+    inline void ImageButton()                                                                   { /* TODO: ImageButton(...) ==> UNSUPPORTED */ }
     inline std::tuple<bool, bool> Checkbox(const std::string& label, bool v)
     {
         bool value{ v };
@@ -205,18 +205,18 @@ namespace sol_ImGui
 
         return std::make_tuple(value, pressed);
     }
-    inline bool CheckboxFlags()																			{ return false; /* TODO: CheckboxFlags(...) ==> UNSUPPORTED */ }
-    inline bool RadioButton(const std::string& label, bool active)										{ return ImGui::RadioButton(label.c_str(), active); }
-    inline std::tuple<int, bool> RadioButton(const std::string& label, int v, int vButton)				{ bool ret{ ImGui::RadioButton(label.c_str(), &v, vButton) }; return std::make_tuple(v, ret); }
-    inline void ProgressBar(float fraction)																{ ImGui::ProgressBar(fraction); }
-    inline void ProgressBar(float fraction, float sizeX, float sizeY)									{ ImGui::ProgressBar(fraction, { sizeX, sizeY }); }
-    inline void ProgressBar(float fraction, float sizeX, float sizeY, const std::string& overlay)		{ ImGui::ProgressBar(fraction, { sizeX, sizeY }, overlay.c_str()); }
-    inline void Bullet()																				{ ImGui::Bullet(); }
+    inline bool CheckboxFlags()                                                                      { return false; /* TODO: CheckboxFlags(...) ==> UNSUPPORTED */ }
+    inline bool RadioButton(const std::string& label, bool active)                                   { return ImGui::RadioButton(label.c_str(), active); }
+    inline std::tuple<int, bool> RadioButton(const std::string& label, int v, int vButton)           { bool ret{ ImGui::RadioButton(label.c_str(), &v, vButton) }; return std::make_tuple(v, ret); }
+    inline void ProgressBar(float fraction)                                                          { ImGui::ProgressBar(fraction); }
+    inline void ProgressBar(float fraction, float sizeX, float sizeY)                                { ImGui::ProgressBar(fraction, { sizeX, sizeY }); }
+    inline void ProgressBar(float fraction, float sizeX, float sizeY, const std::string& overlay)    { ImGui::ProgressBar(fraction, { sizeX, sizeY }, overlay.c_str()); }
+    inline void Bullet()                                                                             { ImGui::Bullet(); }
 
     // Widgets: Combo Box
-    inline bool BeginCombo(const std::string& label, const std::string& previewValue)					{ return ImGui::BeginCombo(label.c_str(), previewValue.c_str()); }
-    inline bool BeginCombo(const std::string& label, const std::string& previewValue, int flags)		{ return ImGui::BeginCombo(label.c_str(), previewValue.c_str(), static_cast<ImGuiComboFlags>(flags)); }
-    inline void EndCombo()																				{ ImGui::EndCombo(); }
+    inline bool BeginCombo(const std::string& label, const std::string& previewValue)                { return ImGui::BeginCombo(label.c_str(), previewValue.c_str()); }
+    inline bool BeginCombo(const std::string& label, const std::string& previewValue, int flags)     { return ImGui::BeginCombo(label.c_str(), previewValue.c_str(), static_cast<ImGuiComboFlags>(flags)); }
+    inline void EndCombo()                                                                           { ImGui::EndCombo(); }
     inline std::tuple<int, bool> Combo(const std::string& label, int currentItem, const sol::table& items, int itemsCount)
     {
         std::vector<std::string> strings;
@@ -262,16 +262,16 @@ namespace sol_ImGui
     // TODO: 3rd Combo from ImGui not Supported
 
     // Widgets: Drags
-    inline std::tuple<float, bool> DragFloat(const std::string& label, float v)																											{ bool used = ImGui::DragFloat(label.c_str(), &v); return std::make_tuple(v, used); }
-    inline std::tuple<float, bool> DragFloat(const std::string& label, float v, float v_speed)																							{ bool used = ImGui::DragFloat(label.c_str(), &v, v_speed); return std::make_tuple(v, used); }
-    inline std::tuple<float, bool> DragFloat(const std::string& label, float v, float v_speed, float v_min)																				{ bool used = ImGui::DragFloat(label.c_str(), &v, v_speed, v_min); return std::make_tuple(v, used); }
-    inline std::tuple<float, bool> DragFloat(const std::string& label, float v, float v_speed, float v_min, float v_max)																{ bool used = ImGui::DragFloat(label.c_str(), &v, v_speed, v_min, v_max); return std::make_tuple(v, used); }
-    inline std::tuple<float, bool> DragFloat(const std::string& label, float v, float v_speed, float v_min, float v_max, const std::string& format)										{ bool used = ImGui::DragFloat(label.c_str(), &v, v_speed, v_min, v_max, format.c_str()); return std::make_tuple(v, used); }
-    inline std::tuple<float, bool> DragFloat(const std::string& label, float v, float v_speed, float v_min, float v_max, const std::string& format, int flags)						{ bool used = ImGui::DragFloat(label.c_str(), &v, v_speed, v_min, v_max, format.c_str(), static_cast<ImGuiSliderFlags>(flags)); return std::make_tuple(v, used); }
+    inline std::tuple<float, bool> DragFloat(const std::string& label, float v)                                                                                     { bool used = ImGui::DragFloat(label.c_str(), &v); return std::make_tuple(v, used); }
+    inline std::tuple<float, bool> DragFloat(const std::string& label, float v, float v_speed)                                                                      { bool used = ImGui::DragFloat(label.c_str(), &v, v_speed); return std::make_tuple(v, used); }
+    inline std::tuple<float, bool> DragFloat(const std::string& label, float v, float v_speed, float v_min)                                                         { bool used = ImGui::DragFloat(label.c_str(), &v, v_speed, v_min); return std::make_tuple(v, used); }
+    inline std::tuple<float, bool> DragFloat(const std::string& label, float v, float v_speed, float v_min, float v_max)                                            { bool used = ImGui::DragFloat(label.c_str(), &v, v_speed, v_min, v_max); return std::make_tuple(v, used); }
+    inline std::tuple<float, bool> DragFloat(const std::string& label, float v, float v_speed, float v_min, float v_max, const std::string& format)                 { bool used = ImGui::DragFloat(label.c_str(), &v, v_speed, v_min, v_max, format.c_str()); return std::make_tuple(v, used); }
+    inline std::tuple<float, bool> DragFloat(const std::string& label, float v, float v_speed, float v_min, float v_max, const std::string& format, int flags)      { bool used = ImGui::DragFloat(label.c_str(), &v, v_speed, v_min, v_max, format.c_str(), static_cast<ImGuiSliderFlags>(flags)); return std::make_tuple(v, used); }
     inline std::tuple<sol::as_table_t<std::vector<float>>, bool> DragFloat2(const std::string& label, const sol::table& v)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[2] = { float(v1), float(v2) };
         bool used = ImGui::DragFloat2(label.c_str(), value);
 
@@ -283,8 +283,8 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<float>>, bool> DragFloat2(const std::string& label, const sol::table& v, float v_speed)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[2] = { float(v1), float(v2) };
         bool used = ImGui::DragFloat2(label.c_str(), value, v_speed);
 
@@ -296,8 +296,8 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<float>>, bool> DragFloat2(const std::string& label, const sol::table& v, float v_speed, float v_min)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[2] = { float(v1), float(v2) };
         bool used = ImGui::DragFloat2(label.c_str(), value, v_speed, v_min);
 
@@ -309,8 +309,8 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<float>>, bool> DragFloat2(const std::string& label, const sol::table& v, float v_speed, float v_min, float v_max)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[2] = { float(v1), float(v2) };
         bool used = ImGui::DragFloat2(label.c_str(), value, v_speed, v_min, v_max);
 
@@ -322,8 +322,8 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<float>>, bool> DragFloat2(const std::string& label, const sol::table& v, float v_speed, float v_min, float v_max, const std::string& format)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[2] = { float(v1), float(v2) };
         bool used = ImGui::DragFloat2(label.c_str(), value, v_speed, v_min, v_max, format.c_str());
 
@@ -335,8 +335,8 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<float>>, bool> DragFloat2(const std::string& label, const sol::table& v, float v_speed, float v_min, float v_max, const std::string& format, int flags)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[2] = { float(v1), float(v2) };
         bool used = ImGui::DragFloat2(label.c_str(), value, v_speed, v_min, v_max, format.c_str(), static_cast<ImGuiSliderFlags>(flags));
 
@@ -348,9 +348,9 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<float>>, bool> DragFloat3(const std::string& label, const sol::table& v)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[3] = { float(v1), float(v2), float(v3) };
         bool used = ImGui::DragFloat3(label.c_str(), value);
 
@@ -362,9 +362,9 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<float>>, bool> DragFloat3(const std::string& label, const sol::table& v, float v_speed)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[3] = { float(v1), float(v2), float(v3) };
         bool used = ImGui::DragFloat3(label.c_str(), value, v_speed);
 
@@ -376,9 +376,9 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<float>>, bool> DragFloat3(const std::string& label, const sol::table& v, float v_speed, float v_min)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[3] = { float(v1), float(v2), float(v3) };
         bool used = ImGui::DragFloat3(label.c_str(), value, v_speed, v_min);
 
@@ -390,9 +390,9 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<float>>, bool> DragFloat3(const std::string& label, const sol::table& v, float v_speed, float v_min, float v_max)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[3] = { float(v1), float(v2), float(v3) };
         bool used = ImGui::DragFloat3(label.c_str(), value, v_speed, v_min, v_max);
 
@@ -404,9 +404,9 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<float>>, bool> DragFloat3(const std::string& label, const sol::table& v, float v_speed, float v_min, float v_max, const std::string& format)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[3] = { float(v1), float(v2), float(v3) };
         bool used = ImGui::DragFloat3(label.c_str(), value, v_speed, v_min, v_max, format.c_str());
 
@@ -418,9 +418,9 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<float>>, bool> DragFloat3(const std::string& label, const sol::table& v, float v_speed, float v_min, float v_max, const std::string& format, int flags)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[3] = { float(v1), float(v2), float(v3) };
         bool used = ImGui::DragFloat3(label.c_str(), value, v_speed, v_min, v_max, format.c_str(), static_cast<ImGuiSliderFlags>(flags));
 
@@ -432,10 +432,10 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<float>>, bool> DragFloat4(const std::string& label, const sol::table& v)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[4] = { float(v1), float(v2), float(v3), float(v4) };
         bool used = ImGui::DragFloat4(label.c_str(), value);
 
@@ -447,10 +447,10 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<float>>, bool> DragFloat4(const std::string& label, const sol::table& v, float v_speed)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[4] = { float(v1), float(v2), float(v3), float(v4) };
         bool used = ImGui::DragFloat4(label.c_str(), value, v_speed);
 
@@ -462,10 +462,10 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<float>>, bool> DragFloat4(const std::string& label, const sol::table& v, float v_speed, float v_min)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[4] = { float(v1), float(v2), float(v3), float(v4) };
         bool used = ImGui::DragFloat4(label.c_str(), value, v_speed, v_min);
 
@@ -477,10 +477,10 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<float>>, bool> DragFloat4(const std::string& label, const sol::table& v, float v_speed, float v_min, float v_max)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[4] = { float(v1), float(v2), float(v3), float(v4) };
         bool used = ImGui::DragFloat4(label.c_str(), value, v_speed, v_min, v_max);
 
@@ -492,10 +492,10 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<float>>, bool> DragFloat4(const std::string& label, const sol::table& v, float v_speed, float v_min, float v_max, const std::string& format)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[4] = { float(v1), float(v2), float(v3), float(v4) };
         bool used = ImGui::DragFloat4(label.c_str(), value, v_speed, v_min, v_max, format.c_str());
 
@@ -507,10 +507,10 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<float>>, bool> DragFloat4(const std::string& label, const sol::table& v, float v_speed, float v_min, float v_max, const std::string& format, int flags)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[4] = { float(v1), float(v2), float(v3), float(v4) };
         bool used = ImGui::DragFloat4(label.c_str(), value, v_speed, v_min, v_max, format.c_str(), static_cast<ImGuiSliderFlags>(flags));
 
@@ -520,16 +520,16 @@ namespace sol_ImGui
 
         return std::make_tuple(float4, used);
     }
-    inline void DragFloatRange2()																																						{ /* TODO: DragFloatRange2(...) ==> UNSUPPORTED */ }
-    inline std::tuple<int, bool> DragInt(const std::string& label, int v)																												{ bool used = ImGui::DragInt(label.c_str(), &v); return std::make_tuple(v, used); }
-    inline std::tuple<int, bool> DragInt(const std::string& label, int v, float v_speed)																								{ bool used = ImGui::DragInt(label.c_str(), &v, v_speed); return std::make_tuple(v, used); }
-    inline std::tuple<int, bool> DragInt(const std::string& label, int v, float v_speed, int v_min)																						{ bool used = ImGui::DragInt(label.c_str(), &v, v_speed, v_min); return std::make_tuple(v, used); }
-    inline std::tuple<int, bool> DragInt(const std::string& label, int v, float v_speed, int v_min, int v_max)																			{ bool used = ImGui::DragInt(label.c_str(), &v, v_speed, v_min, v_max); return std::make_tuple(v, used); }
-    inline std::tuple<int, bool> DragInt(const std::string& label, int v, float v_speed, int v_min, int v_max, const std::string& format)												{ bool used = ImGui::DragInt(label.c_str(), &v, v_speed, v_min, v_max, format.c_str()); return std::make_tuple(v, used); }
+    inline void DragFloatRange2()                                                                                                          { /* TODO: DragFloatRange2(...) ==> UNSUPPORTED */ }
+    inline std::tuple<int, bool> DragInt(const std::string& label, int v)                                                                  { bool used = ImGui::DragInt(label.c_str(), &v); return std::make_tuple(v, used); }
+    inline std::tuple<int, bool> DragInt(const std::string& label, int v, float v_speed)                                                   { bool used = ImGui::DragInt(label.c_str(), &v, v_speed); return std::make_tuple(v, used); }
+    inline std::tuple<int, bool> DragInt(const std::string& label, int v, float v_speed, int v_min)                                        { bool used = ImGui::DragInt(label.c_str(), &v, v_speed, v_min); return std::make_tuple(v, used); }
+    inline std::tuple<int, bool> DragInt(const std::string& label, int v, float v_speed, int v_min, int v_max)                             { bool used = ImGui::DragInt(label.c_str(), &v, v_speed, v_min, v_max); return std::make_tuple(v, used); }
+    inline std::tuple<int, bool> DragInt(const std::string& label, int v, float v_speed, int v_min, int v_max, const std::string& format)  { bool used = ImGui::DragInt(label.c_str(), &v, v_speed, v_min, v_max, format.c_str()); return std::make_tuple(v, used); }
     inline std::tuple<sol::as_table_t<std::vector<int>>, bool> DragInt2(const std::string& label, const sol::table& v)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         int value[2] = { int(v1), int(v2) };
         bool used = ImGui::DragInt2(label.c_str(), value);
 
@@ -541,8 +541,8 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<int>>, bool> DragInt2(const std::string& label, const sol::table& v, float v_speed)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         int value[2] = { int(v1), int(v2) };
         bool used = ImGui::DragInt2(label.c_str(), value, v_speed);
 
@@ -554,8 +554,8 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<int>>, bool> DragInt2(const std::string& label, const sol::table& v, float v_speed, int v_min)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         int value[2] = { int(v1), int(v2) };
         bool used = ImGui::DragInt2(label.c_str(), value, v_speed, v_min);
 
@@ -567,8 +567,8 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<int>>, bool> DragInt2(const std::string& label, const sol::table& v, float v_speed, int v_min, int v_max)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         int value[2] = { int(v1), int(v2) };
         bool used = ImGui::DragInt2(label.c_str(), value, v_speed, v_min, v_max);
 
@@ -580,8 +580,8 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<int>>, bool> DragInt2(const std::string& label, const sol::table& v, float v_speed, int v_min, int v_max, const std::string& format)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         int value[2] = { int(v1), int(v2) };
         bool used = ImGui::DragInt2(label.c_str(), value, v_speed, v_min, v_max, format.c_str());
 
@@ -593,9 +593,9 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<int>>, bool> DragInt3(const std::string& label, const sol::table& v)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         int value[3] = { int(v1), int(v2), int(v3) };
         bool used = ImGui::DragInt3(label.c_str(), value);
 
@@ -607,9 +607,9 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<int>>, bool> DragInt3(const std::string& label, const sol::table& v, float v_speed)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         int value[3] = { int(v1), int(v2), int(v3) };
         bool used = ImGui::DragInt3(label.c_str(), value, v_speed);
 
@@ -621,9 +621,9 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<int>>, bool> DragInt3(const std::string& label, const sol::table& v, float v_speed, int v_min)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         int value[3] = { int(v1), int(v2), int(v3) };
         bool used = ImGui::DragInt3(label.c_str(), value, v_speed, v_min);
 
@@ -635,9 +635,9 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<int>>, bool> DragInt3(const std::string& label, const sol::table& v, float v_speed, int v_min, int v_max)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         int value[3] = { int(v1), int(v2), int(v3) };
         bool used = ImGui::DragInt3(label.c_str(), value, v_speed, v_min, v_max);
 
@@ -649,9 +649,9 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<int>>, bool> DragInt3(const std::string& label, const sol::table& v, float v_speed, int v_min, int v_max, const std::string& format)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         int value[3] = { int(v1), int(v2), int(v3) };
         bool used = ImGui::DragInt3(label.c_str(), value, v_speed, v_min, v_max, format.c_str());
 
@@ -663,10 +663,10 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<int>>, bool> DragInt4(const std::string& label, const sol::table& v)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         int value[4] = { int(v1), int(v2), int(v3), int(v4) };
         bool used = ImGui::DragInt4(label.c_str(), value);
 
@@ -678,10 +678,10 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<int>>, bool> DragInt4(const std::string& label, const sol::table& v, float v_speed)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         int value[4] = { int(v1), int(v2), int(v3), int(v4) };
         bool used = ImGui::DragInt4(label.c_str(), value, v_speed);
 
@@ -693,10 +693,10 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<int>>, bool> DragInt4(const std::string& label, const sol::table& v, float v_speed, int v_min)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         int value[4] = { int(v1), int(v2), int(v3), int(v4) };
         bool used = ImGui::DragInt4(label.c_str(), value, v_speed, v_min);
 
@@ -708,10 +708,10 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<int>>, bool> DragInt4(const std::string& label, const sol::table& v, float v_speed, int v_min, int v_max)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-            v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         int value[4] = { int(v1), int(v2), int(v3), int(v4) };
         bool used = ImGui::DragInt4(label.c_str(), value, v_speed, v_min, v_max);
 
@@ -723,10 +723,10 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<int>>, bool> DragInt4(const std::string& label, const sol::table& v, float v_speed, int v_min, int v_max, const std::string& format)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         int value[4] = { int(v1), int(v2), int(v3), int(v4) };
         bool used = ImGui::DragInt4(label.c_str(), value, v_speed, v_min, v_max, format.c_str());
 
@@ -736,18 +736,18 @@ namespace sol_ImGui
 
         return std::make_tuple(int4, used);
     }
-    inline void DragIntRange2()																																							{ /* TODO: DragIntRange2(...) ==> UNSUPPORTED */ }
-    inline void DragScalar()																																							{ /* TODO: DragScalar(...) ==> UNSUPPORTED */ }
-    inline void DragScalarN()																																							{ /* TODO: DragScalarN(...) ==> UNSUPPORTED */ }
+    inline void DragIntRange2()                                                                               { /* TODO: DragIntRange2(...) ==> UNSUPPORTED */ }
+    inline void DragScalar()                                                                                  { /* TODO: DragScalar(...) ==> UNSUPPORTED */ }
+    inline void DragScalarN()                                                                                 { /* TODO: DragScalarN(...) ==> UNSUPPORTED */ }
 
     // Widgets: Sliders
-    inline std::tuple<float, bool> SliderFloat(const std::string& label, float v, float v_min, float v_max)																				{ bool used = ImGui::SliderFloat(label.c_str(), &v, v_min, v_max); return std::make_tuple(v, used); }
-    inline std::tuple<float, bool> SliderFloat(const std::string& label, float v, float v_min, float v_max, const std::string& format)													{ bool used = ImGui::SliderFloat(label.c_str(), &v, v_min, v_max, format.c_str()); return std::make_tuple(v, used); }
-    inline std::tuple<float, bool> SliderFloat(const std::string& label, float v, float v_min, float v_max, const std::string& format, int flags)										{ bool used = ImGui::SliderFloat(label.c_str(), &v, v_min, v_max, format.c_str(), static_cast<ImGuiSliderFlags>(flags)); return std::make_tuple(v, used); }
+    inline std::tuple<float, bool> SliderFloat(const std::string& label, float v, float v_min, float v_max)                                              { bool used = ImGui::SliderFloat(label.c_str(), &v, v_min, v_max); return std::make_tuple(v, used); }
+    inline std::tuple<float, bool> SliderFloat(const std::string& label, float v, float v_min, float v_max, const std::string& format)                   { bool used = ImGui::SliderFloat(label.c_str(), &v, v_min, v_max, format.c_str()); return std::make_tuple(v, used); }
+    inline std::tuple<float, bool> SliderFloat(const std::string& label, float v, float v_min, float v_max, const std::string& format, int flags)        { bool used = ImGui::SliderFloat(label.c_str(), &v, v_min, v_max, format.c_str(), static_cast<ImGuiSliderFlags>(flags)); return std::make_tuple(v, used); }
     inline std::tuple<sol::as_table_t<std::vector<float>>, bool> SliderFloat2(const std::string& label, const sol::table& v, float v_min, float v_max)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[2] = { float(v1), float(v2) };
         bool used = ImGui::SliderFloat2(label.c_str(), value, v_min, v_max);
 
@@ -759,8 +759,8 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<float>>, bool> SliderFloat2(const std::string& label, const sol::table& v, float v_min, float v_max, const std::string& format)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[2] = { float(v1), float(v2) };
         bool used = ImGui::SliderFloat2(label.c_str(), value, v_min, v_max, format.c_str());
 
@@ -772,8 +772,8 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<float>>, bool> SliderFloat2(const std::string& label, const sol::table& v, float v_min, float v_max, const std::string& format, int flags)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[2] = { float(v1), float(v2) };
         bool used = ImGui::SliderFloat2(label.c_str(), value, v_min, v_max, format.c_str(), static_cast<ImGuiSliderFlags>(flags));
 
@@ -785,9 +785,9 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<float>>, bool> SliderFloat3(const std::string& label, const sol::table& v, float v_min, float v_max)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[3] = { float(v1), float(v2), float(v3) };
         bool used = ImGui::SliderFloat3(label.c_str(), value, v_min, v_max);
 
@@ -799,9 +799,9 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<float>>, bool> SliderFloat3(const std::string& label, const sol::table& v, float v_min, float v_max, const std::string& format)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[3] = { float(v1), float(v2), float(v3) };
         bool used = ImGui::SliderFloat3(label.c_str(), value, v_min, v_max, format.c_str());
 
@@ -813,9 +813,9 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<float>>, bool> SliderFloat3(const std::string& label, const sol::table& v, float v_min, float v_max, const std::string& format, int flags)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[3] = { float(v1), float(v2), float(v3) };
         bool used = ImGui::SliderFloat3(label.c_str(), value, v_min, v_max, format.c_str(), static_cast<ImGuiSliderFlags>(flags));
 
@@ -827,10 +827,10 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<float>>, bool> SliderFloat4(const std::string& label, const sol::table& v, float v_min, float v_max)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[4] = { float(v1), float(v2), float(v3), float(v4) };
         bool used = ImGui::SliderFloat4(label.c_str(), value, v_min, v_max);
 
@@ -842,10 +842,10 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<float>>, bool> SliderFloat4(const std::string& label, const sol::table& v, float v_min, float v_max, const std::string& format)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[4] = { float(v1), float(v2), float(v3), float(v4) };
         bool used = ImGui::SliderFloat4(label.c_str(), value, v_min, v_max, format.c_str());
 
@@ -857,10 +857,10 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<float>>, bool> SliderFloat4(const std::string& label, const sol::table& v, float v_min, float v_max, const std::string& format, int flags)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[4] = { float(v1), float(v2), float(v3), float(v4) };
         bool used = ImGui::SliderFloat4(label.c_str(), value, v_min, v_max, format.c_str(), static_cast<ImGuiSliderFlags>(flags));
 
@@ -870,16 +870,16 @@ namespace sol_ImGui
 
         return std::make_tuple(float4, used);
     }
-    inline std::tuple<float, bool> SliderAngle(const std::string& label, float v_rad)																									{ bool used = ImGui::SliderAngle(label.c_str(), &v_rad); return std::make_tuple(v_rad, used); }
-    inline std::tuple<float, bool> SliderAngle(const std::string& label, float v_rad, float v_degrees_min)																				{ bool used = ImGui::SliderAngle(label.c_str(), &v_rad, v_degrees_min); return std::make_tuple(v_rad, used); }
-    inline std::tuple<float, bool> SliderAngle(const std::string& label, float v_rad, float v_degrees_min, float v_degrees_max)															{ bool used = ImGui::SliderAngle(label.c_str(), &v_rad, v_degrees_min, v_degrees_max); return std::make_tuple(v_rad, used); }
-    inline std::tuple<float, bool> SliderAngle(const std::string& label, float v_rad, float v_degrees_min, float v_degrees_max, const std::string& format)								{ bool used = ImGui::SliderAngle(label.c_str(), &v_rad, v_degrees_min, v_degrees_max, format.c_str()); return std::make_tuple(v_rad, used); }
-    inline std::tuple<int, bool> SliderInt(const std::string& label, int v, int v_min, int v_max)																						{ bool used = ImGui::SliderInt(label.c_str(), &v, v_min, v_max); return std::make_tuple(v, used); }
-    inline std::tuple<int, bool> SliderInt(const std::string& label, int v, int v_min, int v_max, const std::string& format)															{ bool used = ImGui::SliderInt(label.c_str(), &v, v_min, v_max, format.c_str()); return std::make_tuple(v, used); }
+    inline std::tuple<float, bool> SliderAngle(const std::string& label, float v_rad)                                                                         { bool used = ImGui::SliderAngle(label.c_str(), &v_rad); return std::make_tuple(v_rad, used); }
+    inline std::tuple<float, bool> SliderAngle(const std::string& label, float v_rad, float v_degrees_min)                                                    { bool used = ImGui::SliderAngle(label.c_str(), &v_rad, v_degrees_min); return std::make_tuple(v_rad, used); }
+    inline std::tuple<float, bool> SliderAngle(const std::string& label, float v_rad, float v_degrees_min, float v_degrees_max)                               { bool used = ImGui::SliderAngle(label.c_str(), &v_rad, v_degrees_min, v_degrees_max); return std::make_tuple(v_rad, used); }
+    inline std::tuple<float, bool> SliderAngle(const std::string& label, float v_rad, float v_degrees_min, float v_degrees_max, const std::string& format)    { bool used = ImGui::SliderAngle(label.c_str(), &v_rad, v_degrees_min, v_degrees_max, format.c_str()); return std::make_tuple(v_rad, used); }
+    inline std::tuple<int, bool> SliderInt(const std::string& label, int v, int v_min, int v_max)                                                             { bool used = ImGui::SliderInt(label.c_str(), &v, v_min, v_max); return std::make_tuple(v, used); }
+    inline std::tuple<int, bool> SliderInt(const std::string& label, int v, int v_min, int v_max, const std::string& format)                                  { bool used = ImGui::SliderInt(label.c_str(), &v, v_min, v_max, format.c_str()); return std::make_tuple(v, used); }
     inline std::tuple<sol::as_table_t<std::vector<int>>, bool> SliderInt2(const std::string& label, const sol::table& v, int v_min, int v_max)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         int value[2] = { int(v1), int(v2) };
         bool used = ImGui::SliderInt2(label.c_str(), value, v_min, v_max);
 
@@ -891,8 +891,8 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<int>>, bool> SliderInt2(const std::string& label, const sol::table& v, int v_min, int v_max, const std::string& format)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         int value[2] = { int(v1), int(v2) };
         bool used = ImGui::SliderInt2(label.c_str(), value, v_min, v_max, format.c_str());
 
@@ -904,9 +904,9 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<int>>, bool> SliderInt3(const std::string& label, const sol::table& v, int v_min, int v_max)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         int value[3] = { int(v1), int(v2), int(v3) };
         bool used = ImGui::SliderInt3(label.c_str(), value, v_min, v_max);
 
@@ -918,9 +918,9 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<int>>, bool> SliderInt3(const std::string& label, const sol::table& v, int v_min, int v_max, const std::string& format)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         int value[3] = { int(v1), int(v2), int(v3) };
         bool used = ImGui::SliderInt3(label.c_str(), value, v_min, v_max, format.c_str());
 
@@ -932,10 +932,10 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<int>>, bool> SliderInt4(const std::string& label, const sol::table& v, int v_min, int v_max)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         int value[4] = { int(v1), int(v2), int(v3), int(v4) };
         bool used = ImGui::SliderInt4(label.c_str(), value, v_min, v_max);
 
@@ -947,10 +947,10 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<int>>, bool> SliderInt4(const std::string& label, const sol::table& v, int v_min, int v_max, const std::string& format)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         int value[4] = { int(v1), int(v2), int(v3), int(v4) };
         bool used = ImGui::SliderInt4(label.c_str(), value, v_min, v_max, format.c_str());
 
@@ -960,32 +960,32 @@ namespace sol_ImGui
 
         return std::make_tuple(int4, used);
     }
-    inline void SliderScalar()																																							{ /* TODO: SliderScalar(...) ==> UNSUPPORTED */ }
-    inline void SliderScalarN()																																							{ /* TODO: SliderScalarN(...) ==> UNSUPPORTED */ }
-    inline std::tuple<float, bool> VSliderFloat(const std::string& label, float sizeX, float sizeY, float v, float v_min, float v_max)													{ bool used = ImGui::VSliderFloat(label.c_str(), { sizeX, sizeY }, &v, v_min, v_max); return std::make_tuple(v, used); }
-    inline std::tuple<float, bool> VSliderFloat(const std::string& label, float sizeX, float sizeY, float v, float v_min, float v_max, const std::string& format)						{ bool used = ImGui::VSliderFloat(label.c_str(), { sizeX, sizeY }, &v, v_min, v_max, format.c_str()); return std::make_tuple(v, used); }
-    inline std::tuple<float, bool> VSliderFloat(const std::string& label, float sizeX, float sizeY, float v, float v_min, float v_max, const std::string& format, int flags)			{ bool used = ImGui::VSliderFloat(label.c_str(), { sizeX, sizeY }, &v, v_min, v_max, format.c_str(), static_cast<ImGuiSliderFlags>(flags)); return std::make_tuple(v, used); }
-    inline std::tuple<int, bool> VSliderInt(const std::string& label, float sizeX, float sizeY, int v, int v_min, int v_max)															{ bool used = ImGui::VSliderInt(label.c_str(), { sizeX, sizeY }, &v, v_min, v_max); return std::make_tuple(v, used); }
-    inline std::tuple<int, bool> VSliderInt(const std::string& label, float sizeX, float sizeY, int v, int v_min, int v_max, const std::string& format)									{ bool used = ImGui::VSliderInt(label.c_str(), { sizeX, sizeY }, &v, v_min, v_max, format.c_str()); return std::make_tuple(v, used); }
-    inline void VSliderScalar()																																							{ /* TODO: VSliderScalar(...) ==> UNSUPPORTED */ }
+    inline void SliderScalar()                                                                                                                                                    { /* TODO: SliderScalar(...) ==> UNSUPPORTED */ }
+    inline void SliderScalarN()                                                                                                                                                   { /* TODO: SliderScalarN(...) ==> UNSUPPORTED */ }
+    inline std::tuple<float, bool> VSliderFloat(const std::string& label, float sizeX, float sizeY, float v, float v_min, float v_max)                                            { bool used = ImGui::VSliderFloat(label.c_str(), { sizeX, sizeY }, &v, v_min, v_max); return std::make_tuple(v, used); }
+    inline std::tuple<float, bool> VSliderFloat(const std::string& label, float sizeX, float sizeY, float v, float v_min, float v_max, const std::string& format)                 { bool used = ImGui::VSliderFloat(label.c_str(), { sizeX, sizeY }, &v, v_min, v_max, format.c_str()); return std::make_tuple(v, used); }
+    inline std::tuple<float, bool> VSliderFloat(const std::string& label, float sizeX, float sizeY, float v, float v_min, float v_max, const std::string& format, int flags)      { bool used = ImGui::VSliderFloat(label.c_str(), { sizeX, sizeY }, &v, v_min, v_max, format.c_str(), static_cast<ImGuiSliderFlags>(flags)); return std::make_tuple(v, used); }
+    inline std::tuple<int, bool> VSliderInt(const std::string& label, float sizeX, float sizeY, int v, int v_min, int v_max)                                                      { bool used = ImGui::VSliderInt(label.c_str(), { sizeX, sizeY }, &v, v_min, v_max); return std::make_tuple(v, used); }
+    inline std::tuple<int, bool> VSliderInt(const std::string& label, float sizeX, float sizeY, int v, int v_min, int v_max, const std::string& format)                           { bool used = ImGui::VSliderInt(label.c_str(), { sizeX, sizeY }, &v, v_min, v_max, format.c_str()); return std::make_tuple(v, used); }
+    inline void VSliderScalar()                                                                                                                                                   { /* TODO: VSliderScalar(...) ==> UNSUPPORTED */ }
 
     // Widgets: Input with Keyboard
-    inline std::tuple<std::string, bool> InputText(const std::string& label, std::string text, unsigned int buf_size)																	{ text.resize(buf_size); bool selected = ImGui::InputText(label.c_str(), &text[0], buf_size); return std::make_tuple(text.c_str(), selected); }
-    inline std::tuple<std::string, bool> InputText(const std::string& label, std::string text, unsigned int buf_size, int flags)														{ text.resize(buf_size); bool selected = ImGui::InputText(label.c_str(), &text[0], buf_size, static_cast<ImGuiInputTextFlags>(flags)); return std::make_tuple(text.c_str(), selected); }
-    inline std::tuple<std::string, bool> InputTextMultiline(const std::string& label, std::string text, unsigned int buf_size)															{ text.resize(buf_size); bool selected = ImGui::InputTextMultiline(label.c_str(), &text[0], buf_size); return std::make_tuple(text.c_str(), selected); }
-    inline std::tuple<std::string, bool> InputTextMultiline(const std::string& label, std::string text, unsigned int buf_size, float sizeX, float sizeY)								{ text.resize(buf_size); bool selected = ImGui::InputTextMultiline(label.c_str(), &text[0], buf_size, { sizeX, sizeY }); return std::make_tuple(text.c_str(), selected); }
-    inline std::tuple<std::string, bool> InputTextMultiline(const std::string& label, std::string text, unsigned int buf_size, float sizeX, float sizeY, int flags)						{ text.resize(buf_size); bool selected = ImGui::InputTextMultiline(label.c_str(), &text[0], buf_size, { sizeX, sizeY }, static_cast<ImGuiInputTextFlags>(flags)); return std::make_tuple(text.c_str(), selected); }
-    inline std::tuple<std::string, bool> InputTextWithHint(const std::string& label, const std::string& hint, std::string text, unsigned int buf_size)									{ text.resize(buf_size); bool selected = ImGui::InputTextWithHint(label.c_str(), hint.c_str(), &text[0], buf_size); return std::make_tuple(text.c_str(), selected); }
-    inline std::tuple<std::string, bool> InputTextWithHint(const std::string& label, const std::string& hint, std::string text, unsigned int buf_size, int flags)						{ text.resize(buf_size); bool selected = ImGui::InputTextWithHint(label.c_str(), hint.c_str(), &text[0], buf_size, static_cast<ImGuiInputTextFlags>(flags)); return std::make_tuple(text.c_str(), selected); }
-    inline std::tuple<float, bool> InputFloat(const std::string& label, float v)																										{ bool selected = ImGui::InputFloat(label.c_str(), &v); return std::make_tuple(v, selected); }
-    inline std::tuple<float, bool> InputFloat(const std::string& label, float v, float step)																							{ bool selected = ImGui::InputFloat(label.c_str(), &v, step); return std::make_tuple(v, selected); }
-    inline std::tuple<float, bool> InputFloat(const std::string& label, float v, float step, float step_fast)																			{ bool selected = ImGui::InputFloat(label.c_str(), &v, step, step_fast); return std::make_tuple(v, selected); }
-    inline std::tuple<float, bool> InputFloat(const std::string& label, float v, float step, float step_fast, const std::string& format)												{ bool selected = ImGui::InputFloat(label.c_str(), &v, step, step_fast, format.c_str()); return std::make_tuple(v, selected); }
-    inline std::tuple<float, bool> InputFloat(const std::string& label, float v, float step, float step_fast, const std::string& format, int flags)										{ bool selected = ImGui::InputFloat(label.c_str(), &v, step, step_fast, format.c_str(), static_cast<ImGuiInputTextFlags>(flags)); return std::make_tuple(v, selected); }
+    inline std::tuple<std::string, bool> InputText(const std::string& label, std::string text, unsigned int buf_size)                                                   { text.resize(buf_size); bool selected = ImGui::InputText(label.c_str(), &text[0], buf_size); return std::make_tuple(text.c_str(), selected); }
+    inline std::tuple<std::string, bool> InputText(const std::string& label, std::string text, unsigned int buf_size, int flags)                                        { text.resize(buf_size); bool selected = ImGui::InputText(label.c_str(), &text[0], buf_size, static_cast<ImGuiInputTextFlags>(flags)); return std::make_tuple(text.c_str(), selected); }
+    inline std::tuple<std::string, bool> InputTextMultiline(const std::string& label, std::string text, unsigned int buf_size)                                          { text.resize(buf_size); bool selected = ImGui::InputTextMultiline(label.c_str(), &text[0], buf_size); return std::make_tuple(text.c_str(), selected); }
+    inline std::tuple<std::string, bool> InputTextMultiline(const std::string& label, std::string text, unsigned int buf_size, float sizeX, float sizeY)                { text.resize(buf_size); bool selected = ImGui::InputTextMultiline(label.c_str(), &text[0], buf_size, { sizeX, sizeY }); return std::make_tuple(text.c_str(), selected); }
+    inline std::tuple<std::string, bool> InputTextMultiline(const std::string& label, std::string text, unsigned int buf_size, float sizeX, float sizeY, int flags)     { text.resize(buf_size); bool selected = ImGui::InputTextMultiline(label.c_str(), &text[0], buf_size, { sizeX, sizeY }, static_cast<ImGuiInputTextFlags>(flags)); return std::make_tuple(text.c_str(), selected); }
+    inline std::tuple<std::string, bool> InputTextWithHint(const std::string& label, const std::string& hint, std::string text, unsigned int buf_size)                  { text.resize(buf_size); bool selected = ImGui::InputTextWithHint(label.c_str(), hint.c_str(), &text[0], buf_size); return std::make_tuple(text.c_str(), selected); }
+    inline std::tuple<std::string, bool> InputTextWithHint(const std::string& label, const std::string& hint, std::string text, unsigned int buf_size, int flags)       { text.resize(buf_size); bool selected = ImGui::InputTextWithHint(label.c_str(), hint.c_str(), &text[0], buf_size, static_cast<ImGuiInputTextFlags>(flags)); return std::make_tuple(text.c_str(), selected); }
+    inline std::tuple<float, bool> InputFloat(const std::string& label, float v)                                                                                        { bool selected = ImGui::InputFloat(label.c_str(), &v); return std::make_tuple(v, selected); }
+    inline std::tuple<float, bool> InputFloat(const std::string& label, float v, float step)                                                                            { bool selected = ImGui::InputFloat(label.c_str(), &v, step); return std::make_tuple(v, selected); }
+    inline std::tuple<float, bool> InputFloat(const std::string& label, float v, float step, float step_fast)                                                           { bool selected = ImGui::InputFloat(label.c_str(), &v, step, step_fast); return std::make_tuple(v, selected); }
+    inline std::tuple<float, bool> InputFloat(const std::string& label, float v, float step, float step_fast, const std::string& format)                                { bool selected = ImGui::InputFloat(label.c_str(), &v, step, step_fast, format.c_str()); return std::make_tuple(v, selected); }
+    inline std::tuple<float, bool> InputFloat(const std::string& label, float v, float step, float step_fast, const std::string& format, int flags)                     { bool selected = ImGui::InputFloat(label.c_str(), &v, step, step_fast, format.c_str(), static_cast<ImGuiInputTextFlags>(flags)); return std::make_tuple(v, selected); }
     inline std::tuple <sol::as_table_t<std::vector<float>>, bool> InputFloat2(const std::string& label, const sol::table& v)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[2] = { float(v1), float(v2) };
         bool used = ImGui::InputFloat2(label.c_str(), value);
 
@@ -997,8 +997,8 @@ namespace sol_ImGui
     }
     inline std::tuple <sol::as_table_t<std::vector<float>>, bool> InputFloat2(const std::string& label, const sol::table& v, const std::string& format)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[2] = { float(v1), float(v2) };
         bool used = ImGui::InputFloat2(label.c_str(), value, format.c_str());
 
@@ -1010,8 +1010,8 @@ namespace sol_ImGui
     }
     inline std::tuple <sol::as_table_t<std::vector<float>>, bool> InputFloat2(const std::string& label, const sol::table& v, const std::string& format, int flags)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[2] = { float(v1), float(v2) };
         bool used = ImGui::InputFloat2(label.c_str(), value, format.c_str(), static_cast<ImGuiInputTextFlags>(flags));
 
@@ -1023,9 +1023,9 @@ namespace sol_ImGui
     }
     inline std::tuple <sol::as_table_t<std::vector<float>>, bool> InputFloat3(const std::string& label, const sol::table& v)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[3] = { float(v1), float(v2), float(v3) };
         bool used = ImGui::InputFloat3(label.c_str(), value);
 
@@ -1037,9 +1037,9 @@ namespace sol_ImGui
     }
     inline std::tuple <sol::as_table_t<std::vector<float>>, bool> InputFloat3(const std::string& label, const sol::table& v, const std::string& format)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[3] = { float(v1), float(v2), float(v3) };
         bool used = ImGui::InputFloat3(label.c_str(), value, format.c_str());
 
@@ -1051,9 +1051,9 @@ namespace sol_ImGui
     }
     inline std::tuple <sol::as_table_t<std::vector<float>>, bool> InputFloat3(const std::string& label, const sol::table& v, const std::string& format, int flags)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[3] = { float(v1), float(v2), float(v3) };
         bool used = ImGui::InputFloat3(label.c_str(), value, format.c_str(), static_cast<ImGuiInputTextFlags>(flags));
 
@@ -1065,10 +1065,10 @@ namespace sol_ImGui
     }
     inline std::tuple <sol::as_table_t<std::vector<float>>, bool> InputFloat4(const std::string& label, const sol::table& v)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[4] = { float(v1), float(v2), float(v3), float(v4) };
         bool used = ImGui::InputFloat4(label.c_str(), value);
 
@@ -1080,10 +1080,10 @@ namespace sol_ImGui
     }
     inline std::tuple <sol::as_table_t<std::vector<float>>, bool> InputFloat4(const std::string& label, const sol::table& v, const std::string& format)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-            v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[4] = { float(v1), float(v2), float(v3), float(v4) };
         bool used = ImGui::InputFloat4(label.c_str(), value, format.c_str());
 
@@ -1095,10 +1095,10 @@ namespace sol_ImGui
     }
     inline std::tuple <sol::as_table_t<std::vector<float>>, bool> InputFloat4(const std::string& label, const sol::table& v, const std::string& format, int flags)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float value[4] = { float(v1), float(v2), float(v3), float(v4) };
         bool used = ImGui::InputFloat4(label.c_str(), value, format.c_str(), static_cast<ImGuiInputTextFlags>(flags));
 
@@ -1108,14 +1108,14 @@ namespace sol_ImGui
 
         return std::make_tuple(float4, used);
     }
-    inline std::tuple<int, bool> InputInt(const std::string& label, int v)																												{ bool selected = ImGui::InputInt(label.c_str(), &v); return std::make_tuple(v, selected); }
-    inline std::tuple<int, bool> InputInt(const std::string& label, int v, int step)																									{ bool selected = ImGui::InputInt(label.c_str(), &v, step); return std::make_tuple(v, selected); }
-    inline std::tuple<int, bool> InputInt(const std::string& label, int v, int step, int step_fast)																						{ bool selected = ImGui::InputInt(label.c_str(), &v, step, step_fast); return std::make_tuple(v, selected); }
-    inline std::tuple<int, bool> InputInt(const std::string& label, int v, int step, int step_fast, int flags)																			{ bool selected = ImGui::InputInt(label.c_str(), &v, step, step_fast, static_cast<ImGuiInputTextFlags>(flags)); return std::make_tuple(v, selected); }
+    inline std::tuple<int, bool> InputInt(const std::string& label, int v)                                                        { bool selected = ImGui::InputInt(label.c_str(), &v); return std::make_tuple(v, selected); }
+    inline std::tuple<int, bool> InputInt(const std::string& label, int v, int step)                                              { bool selected = ImGui::InputInt(label.c_str(), &v, step); return std::make_tuple(v, selected); }
+    inline std::tuple<int, bool> InputInt(const std::string& label, int v, int step, int step_fast)                               { bool selected = ImGui::InputInt(label.c_str(), &v, step, step_fast); return std::make_tuple(v, selected); }
+    inline std::tuple<int, bool> InputInt(const std::string& label, int v, int step, int step_fast, int flags)                    { bool selected = ImGui::InputInt(label.c_str(), &v, step, step_fast, static_cast<ImGuiInputTextFlags>(flags)); return std::make_tuple(v, selected); }
     inline std::tuple <sol::as_table_t<std::vector<int>>, bool> InputInt2(const std::string& label, const sol::table& v)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         int value[2] = { int(v1), int(v2) };
         bool used = ImGui::InputInt2(label.c_str(), value);
 
@@ -1127,8 +1127,8 @@ namespace sol_ImGui
     }
     inline std::tuple <sol::as_table_t<std::vector<int>>, bool> InputInt2(const std::string& label, const sol::table& v, int flags)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         int value[2] = { int(v1), int(v2) };
         bool used = ImGui::InputInt2(label.c_str(), value, static_cast<ImGuiInputTextFlags>(flags));
 
@@ -1140,9 +1140,9 @@ namespace sol_ImGui
     }
     inline std::tuple <sol::as_table_t<std::vector<int>>, bool> InputInt3(const std::string& label, const sol::table& v)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         int value[3] = { int(v1), int(v2), int(v3) };
         bool used = ImGui::InputInt3(label.c_str(), value);
 
@@ -1154,9 +1154,9 @@ namespace sol_ImGui
     }
     inline std::tuple <sol::as_table_t<std::vector<int>>, bool> InputInt3(const std::string& label, const sol::table& v, int flags)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         int value[3] = { int(v1), int(v2), int(v3) };
         bool used = ImGui::InputInt3(label.c_str(), value, static_cast<ImGuiInputTextFlags>(flags));
 
@@ -1168,10 +1168,10 @@ namespace sol_ImGui
     }
     inline std::tuple <sol::as_table_t<std::vector<int>>, bool> InputInt4(const std::string& label, const sol::table& v)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         int value[4] = { int(v1), int(v2), int(v3), int(v4) };
         bool used = ImGui::InputInt4(label.c_str(), value);
 
@@ -1183,10 +1183,10 @@ namespace sol_ImGui
     }
     inline std::tuple <sol::as_table_t<std::vector<int>>, bool> InputInt4(const std::string& label, const sol::table& v, int flags)
     {
-        const lua_Number	v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         int value[4] = { int(v1), int(v2), int(v3), int(v4) };
         bool used = ImGui::InputInt4(label.c_str(), value, static_cast<ImGuiInputTextFlags>(flags));
 
@@ -1196,18 +1196,18 @@ namespace sol_ImGui
 
         return std::make_tuple(int4, used);
     }
-    inline std::tuple<double, bool> InputDouble(const std::string& label, double v)																										{ bool selected = ImGui::InputDouble(label.c_str(), &v); return std::make_tuple(v, selected); }
-    inline std::tuple<double, bool> InputDouble(const std::string& label, double v, double step)																						{ bool selected = ImGui::InputDouble(label.c_str(), &v, step); return std::make_tuple(v, selected); }
-    inline std::tuple<double, bool> InputDouble(const std::string& label, double v, double step, double step_fast)																		{ bool selected = ImGui::InputDouble(label.c_str(), &v, step, step_fast); return std::make_tuple(v, selected); }
-    inline std::tuple<double, bool> InputDouble(const std::string& label, double v, double step, double step_fast, const std::string& format)											{ bool selected = ImGui::InputDouble(label.c_str(), &v, step, step_fast, format.c_str()); return std::make_tuple(v, selected); }
-    inline std::tuple<double, bool> InputDouble(const std::string& label, double v, double step, double step_fast, const std::string& format, int flags)								{ bool selected = ImGui::InputDouble(label.c_str(), &v, step, step_fast, format.c_str(), static_cast<ImGuiInputTextFlags>(flags)); return std::make_tuple(v, selected); }
-    inline void InputScalar()																																							{ /* TODO: InputScalar(...) ==> UNSUPPORTED */ }
-    inline void InputScalarN()																																							{ /* TODO: InputScalarN(...) ==> UNSUPPORTED */ }
+    inline std::tuple<double, bool> InputDouble(const std::string& label, double v)                                                                          { bool selected = ImGui::InputDouble(label.c_str(), &v); return std::make_tuple(v, selected); }
+    inline std::tuple<double, bool> InputDouble(const std::string& label, double v, double step)                                                             { bool selected = ImGui::InputDouble(label.c_str(), &v, step); return std::make_tuple(v, selected); }
+    inline std::tuple<double, bool> InputDouble(const std::string& label, double v, double step, double step_fast)                                           { bool selected = ImGui::InputDouble(label.c_str(), &v, step, step_fast); return std::make_tuple(v, selected); }
+    inline std::tuple<double, bool> InputDouble(const std::string& label, double v, double step, double step_fast, const std::string& format)                { bool selected = ImGui::InputDouble(label.c_str(), &v, step, step_fast, format.c_str()); return std::make_tuple(v, selected); }
+    inline std::tuple<double, bool> InputDouble(const std::string& label, double v, double step, double step_fast, const std::string& format, int flags)     { bool selected = ImGui::InputDouble(label.c_str(), &v, step, step_fast, format.c_str(), static_cast<ImGuiInputTextFlags>(flags)); return std::make_tuple(v, selected); }
+    inline void InputScalar()                                                                                                                                { /* TODO: InputScalar(...) ==> UNSUPPORTED */ }
+    inline void InputScalarN()                                                                                                                               { /* TODO: InputScalarN(...) ==> UNSUPPORTED */ }
 
     // Widgets: Color Editor / Picker
     inline std::tuple<sol::as_table_t<std::vector<float>>, bool> ColorEdit3(const std::string& label, const sol::table& col)
     {
-        const lua_Number	r{ col[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+        const lua_Number  r{ col[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
             g{ col[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
             b{ col[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float color[3] = { float(r), float(g), float(b) };
@@ -1221,9 +1221,9 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<float>>, bool> ColorEdit3(const std::string& label, const sol::table& col, int flags)
     {
-        const lua_Number	r{ col[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            g{ col[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            b{ col[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  r{ col[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          g{ col[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          b{ col[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float color[3] = { float(r), float(g), float(b) };
         bool used = ImGui::ColorEdit3(label.c_str(), color, static_cast<ImGuiColorEditFlags>(flags));
 
@@ -1235,10 +1235,10 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<float>>, bool> ColorEdit4(const std::string& label, const sol::table& col)
     {
-        const lua_Number	r{ col[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            g{ col[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            b{ col[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            a{ col[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  r{ col[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          g{ col[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          b{ col[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          a{ col[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float color[4] = { float(r), float(g), float(b), float(a) };
         bool used = ImGui::ColorEdit4(label.c_str(), color);
 
@@ -1250,10 +1250,10 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<float>>, bool> ColorEdit4(const std::string& label, const sol::table& col, int flags)
     {
-        const lua_Number	r{ col[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            g{ col[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            b{ col[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            a{ col[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  r{ col[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          g{ col[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          b{ col[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          a{ col[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float color[4] = { float(r), float(g), float(b), float(a) };
         bool used = ImGui::ColorEdit4(label.c_str(), color, static_cast<ImGuiColorEditFlags>(flags));
 
@@ -1265,9 +1265,9 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<float>>, bool> ColorPicker3(const std::string& label, const sol::table& col)
     {
-        const lua_Number	r{ col[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            g{ col[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            b{ col[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  r{ col[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          g{ col[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          b{ col[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float color[3] = { float(r), float(g), float(b) };
         bool used = ImGui::ColorPicker3(label.c_str(), color);
 
@@ -1279,9 +1279,9 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<float>>, bool> ColorPicker3(const std::string& label, const sol::table& col, int flags)
     {
-        const lua_Number	r{ col[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            g{ col[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            b{ col[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  r{ col[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          g{ col[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          b{ col[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float color[3] = { float(r), float(g), float(b) };
         bool used = ImGui::ColorPicker3(label.c_str(), color, static_cast<ImGuiColorEditFlags>(flags));
 
@@ -1293,10 +1293,10 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<float>>, bool> ColorPicker4(const std::string& label, const sol::table& col)
     {
-        const lua_Number	r{ col[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            g{ col[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            b{ col[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            a{ col[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  r{ col[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          g{ col[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          b{ col[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          a{ col[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float color[4] = { float(r), float(g), float(b), float(a) };
         bool used = ImGui::ColorPicker4(label.c_str(), color);
 
@@ -1308,10 +1308,10 @@ namespace sol_ImGui
     }
     inline std::tuple<sol::as_table_t<std::vector<float>>, bool> ColorPicker4(const std::string& label, const sol::table& col, int flags)
     {
-        const lua_Number	r{ col[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            g{ col[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            b{ col[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            a{ col[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  r{ col[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          g{ col[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          b{ col[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          a{ col[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         float color[4] = { float(r), float(g), float(b), float(a) };
         bool used = ImGui::ColorPicker4(label.c_str(), color, static_cast<ImGuiColorEditFlags>(flags));
 
@@ -1323,58 +1323,58 @@ namespace sol_ImGui
     }
     inline bool ColorButton(const std::string& desc_id, const sol::table& col)
     {
-        const lua_Number	r{ col[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            g{ col[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            b{ col[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            a{ col[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  r{ col[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          g{ col[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          b{ col[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          a{ col[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         const ImVec4 color{ float(r), float(g), float(b), float(a) };
         return ImGui::ColorButton(desc_id.c_str(), color);
     }
     inline bool ColorButton(const std::string& desc_id, const sol::table& col, int flags)
     {
-        const lua_Number	r{ col[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            g{ col[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            b{ col[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            a{ col[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  r{ col[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          g{ col[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          b{ col[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          a{ col[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         const ImVec4 color{ float(r), float(g), float(b), float(a) };
         return ImGui::ColorButton(desc_id.c_str(), color, static_cast<ImGuiColorEditFlags>(flags));
     }
     inline bool ColorButton(const std::string& desc_id, const sol::table& col, int flags, float sizeX, float sizeY)
     {
-        const lua_Number	r{ col[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            g{ col[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            b{ col[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            a{ col[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  r{ col[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          g{ col[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          b{ col[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          a{ col[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         const ImVec4 color{ float(r), float(g), float(b), float(a) };
         return ImGui::ColorButton(desc_id.c_str(), color, static_cast<ImGuiColorEditFlags>(flags), { sizeX, sizeY });
     }
-    inline void SetColorEditOptions(int flags)																																			{ ImGui::SetColorEditOptions(static_cast<ImGuiColorEditFlags>(flags)); }
+    inline void SetColorEditOptions(int flags)                                                                     { ImGui::SetColorEditOptions(static_cast<ImGuiColorEditFlags>(flags)); }
 
     // Widgets: Trees
-    inline bool TreeNode(const std::string& label)														{ return ImGui::TreeNode(label.c_str()); }
-    inline bool TreeNode(const std::string& label, const std::string& fmt)								{ return ImGui::TreeNode(label.c_str(), fmt.c_str()); }
+    inline bool TreeNode(const std::string& label)                                                                 { return ImGui::TreeNode(label.c_str()); }
+    inline bool TreeNode(const std::string& label, const std::string& fmt)                                         { return ImGui::TreeNode(label.c_str(), fmt.c_str()); }
     /* TODO: TreeNodeV(...) (2) ==> UNSUPPORTED */
-    inline bool TreeNodeEx(const std::string& label)													{ return ImGui::TreeNodeEx(label.c_str()); }
-    inline bool TreeNodeEx(const std::string& label, int flags)											{ return ImGui::TreeNodeEx(label.c_str(), static_cast<ImGuiTreeNodeFlags>(flags)); }
-    inline bool TreeNodeEx(const std::string& label, int flags, const std::string& fmt)					{ return ImGui::TreeNodeEx(label.c_str(), static_cast<ImGuiTreeNodeFlags>(flags), fmt.c_str()); }
+    inline bool TreeNodeEx(const std::string& label)                                                               { return ImGui::TreeNodeEx(label.c_str()); }
+    inline bool TreeNodeEx(const std::string& label, int flags)                                                    { return ImGui::TreeNodeEx(label.c_str(), static_cast<ImGuiTreeNodeFlags>(flags)); }
+    inline bool TreeNodeEx(const std::string& label, int flags, const std::string& fmt)                            { return ImGui::TreeNodeEx(label.c_str(), static_cast<ImGuiTreeNodeFlags>(flags), fmt.c_str()); }
     /* TODO: TreeNodeExV(...) (2) ==> UNSUPPORTED */
-    inline void TreePush(const std::string& str_id)														{ ImGui::TreePush(str_id.c_str()); }
+    inline void TreePush(const std::string& str_id)                                                                { ImGui::TreePush(str_id.c_str()); }
     /* TODO: TreePush(const void*) ==> UNSUPPORTED */
-    inline void TreePop()																				{ ImGui::TreePop(); }
-    inline float GetTreeNodeToLabelSpacing()															{ return ImGui::GetTreeNodeToLabelSpacing(); }
-    inline bool CollapsingHeader(const std::string& label)												{ return ImGui::CollapsingHeader(label.c_str()); }
-    inline bool CollapsingHeader(const std::string& label, int flags)									{ return ImGui::CollapsingHeader(label.c_str(), static_cast<ImGuiTreeNodeFlags>(flags)); }
-    inline std::tuple<bool, bool> CollapsingHeader(const std::string& label, bool open)					{ bool notCollapsed = ImGui::CollapsingHeader(label.c_str(), &open); return std::make_tuple(open, notCollapsed); }
-    inline std::tuple<bool, bool> CollapsingHeader(const std::string& label, bool open, int flags)		{ bool notCollapsed = ImGui::CollapsingHeader(label.c_str(), &open, static_cast<ImGuiTreeNodeFlags>(flags)); return std::make_tuple(open, notCollapsed); }
-    inline void SetNextItemOpen(bool is_open)															{ ImGui::SetNextItemOpen(is_open); }
-    inline void SetNextItemOpen(bool is_open, int cond)													{ ImGui::SetNextItemOpen(is_open, static_cast<ImGuiCond>(cond)); }
+    inline void TreePop()                                                                                          { ImGui::TreePop(); }
+    inline float GetTreeNodeToLabelSpacing()                                                                       { return ImGui::GetTreeNodeToLabelSpacing(); }
+    inline bool CollapsingHeader(const std::string& label)                                                         { return ImGui::CollapsingHeader(label.c_str()); }
+    inline bool CollapsingHeader(const std::string& label, int flags)                                              { return ImGui::CollapsingHeader(label.c_str(), static_cast<ImGuiTreeNodeFlags>(flags)); }
+    inline std::tuple<bool, bool> CollapsingHeader(const std::string& label, bool open)                            { bool notCollapsed = ImGui::CollapsingHeader(label.c_str(), &open); return std::make_tuple(open, notCollapsed); }
+    inline std::tuple<bool, bool> CollapsingHeader(const std::string& label, bool open, int flags)                 { bool notCollapsed = ImGui::CollapsingHeader(label.c_str(), &open, static_cast<ImGuiTreeNodeFlags>(flags)); return std::make_tuple(open, notCollapsed); }
+    inline void SetNextItemOpen(bool is_open)                                                                      { ImGui::SetNextItemOpen(is_open); }
+    inline void SetNextItemOpen(bool is_open, int cond)                                                            { ImGui::SetNextItemOpen(is_open, static_cast<ImGuiCond>(cond)); }
 
     // Widgets: Selectables
     // TODO: Only one of Selectable variations is possible due to same parameters for Lua
-    inline bool Selectable(const std::string& label)													{ return ImGui::Selectable(label.c_str()); }
-    inline bool Selectable(const std::string& label, bool selected)										{ ImGui::Selectable(label.c_str(), &selected); return selected; }
-    inline bool Selectable(const std::string& label, bool selected, int flags)							{ ImGui::Selectable(label.c_str(), &selected, static_cast<ImGuiSelectableFlags>(flags)); return selected; }
-    inline bool Selectable(const std::string& label, bool selected, int flags, float sizeX, float sizeY){ ImGui::Selectable(label.c_str(), &selected, static_cast<ImGuiSelectableFlags>(flags), { sizeX, sizeY }); return selected; }
+    inline bool Selectable(const std::string& label)                                                               { return ImGui::Selectable(label.c_str()); }
+    inline bool Selectable(const std::string& label, bool selected)                                                { ImGui::Selectable(label.c_str(), &selected); return selected; }
+    inline bool Selectable(const std::string& label, bool selected, int flags)                                     { ImGui::Selectable(label.c_str(), &selected, static_cast<ImGuiSelectableFlags>(flags)); return selected; }
+    inline bool Selectable(const std::string& label, bool selected, int flags, float sizeX, float sizeY)           { ImGui::Selectable(label.c_str(), &selected, static_cast<ImGuiSelectableFlags>(flags), { sizeX, sizeY }); return selected; }
 
     // Widgets: List Boxes
     inline std::tuple<int, bool> ListBox(const std::string& label, int current_item, const sol::table& items, int items_count)
@@ -1409,148 +1409,148 @@ namespace sol_ImGui
         bool clicked = ImGui::ListBox(label.c_str(), &current_item, cstrings.data(), items_count, height_in_items);
         return std::make_tuple(current_item, clicked);
     }
-    inline bool ListBoxHeader(const std::string& label, float sizeX, float sizeY)						{ return ImGui::ListBoxHeader(label.c_str(), { sizeX, sizeY }); }
-    inline bool ListBoxHeader(const std::string& label, int items_count)								{ return ImGui::ListBoxHeader(label.c_str(), items_count); }
-    inline bool ListBoxHeader(const std::string& label, int items_count, int height_in_items)			{ return ImGui::ListBoxHeader(label.c_str(), items_count, height_in_items); }
-    inline void ListBoxFooter()																			{ ImGui::ListBoxFooter(); }
+    inline bool ListBoxHeader(const std::string& label, float sizeX, float sizeY)                    { return ImGui::ListBoxHeader(label.c_str(), { sizeX, sizeY }); }
+    inline bool ListBoxHeader(const std::string& label, int items_count)                             { return ImGui::ListBoxHeader(label.c_str(), items_count); }
+    inline bool ListBoxHeader(const std::string& label, int items_count, int height_in_items)        { return ImGui::ListBoxHeader(label.c_str(), items_count, height_in_items); }
+    inline void ListBoxFooter()                                                                      { ImGui::ListBoxFooter(); }
 
     // Widgets: Data Plotting
     /* TODO: Widgets Data Plotting ==> UNSUPPORTED (barely used and quite long functions) */
 
     // Widgets: Value() helpers
-    inline void Value(const std::string& prefix, bool b)												{ ImGui::Value(prefix.c_str(), b); }
-    inline void Value(const std::string& prefix, int v)													{ ImGui::Value(prefix.c_str(), v); }
-    inline void Value(const std::string& prefix, unsigned int v)										{ ImGui::Value(prefix.c_str(), v); }
-    inline void Value(const std::string& prefix, float v)												{ ImGui::Value(prefix.c_str(), v); }
-    inline void Value(const std::string& prefix, float v, const std::string& float_format)				{ ImGui::Value(prefix.c_str(), v, float_format.c_str()); }
+    inline void Value(const std::string& prefix, bool b)                                            { ImGui::Value(prefix.c_str(), b); }
+    inline void Value(const std::string& prefix, int v)                                             { ImGui::Value(prefix.c_str(), v); }
+    inline void Value(const std::string& prefix, unsigned int v)                                    { ImGui::Value(prefix.c_str(), v); }
+    inline void Value(const std::string& prefix, float v)                                           { ImGui::Value(prefix.c_str(), v); }
+    inline void Value(const std::string& prefix, float v, const std::string& float_format)          { ImGui::Value(prefix.c_str(), v, float_format.c_str()); }
 
     // Widgets: Menus
-    inline bool BeginMenuBar()																			{ return ImGui::BeginMenuBar(); }
-    inline void EndMenuBar()																			{ ImGui::EndMenuBar(); }
-    inline bool BeginMainMenuBar()																		{ return ImGui::BeginMainMenuBar(); }
-    inline void EndMainMenuBar()																		{ ImGui::EndMainMenuBar(); }
-    inline bool BeginMenu(const std::string& label)														{ return ImGui::BeginMenu(label.c_str()); }
-    inline bool BeginMenu(const std::string& label, bool enabled)										{ return ImGui::BeginMenu(label.c_str(), enabled); }
-    inline void EndMenu()																				{ ImGui::EndMenu(); }
-    inline bool MenuItem(const std::string& label)																					{ return ImGui::MenuItem(label.c_str()); }
-    inline bool MenuItem(const std::string& label, const std::string& shortcut)														{ return ImGui::MenuItem(label.c_str(), shortcut.c_str()); }
-    inline std::tuple<bool, bool> MenuItem(const std::string& label, const std::string& shortcut, bool selected)					{ bool activated = ImGui::MenuItem(label.c_str(), shortcut.c_str(), &selected); return std::make_tuple(selected, activated); }
-    inline std::tuple<bool, bool> MenuItem(const std::string& label, const std::string& shortcut, bool selected, bool enabled)		{ bool activated = ImGui::MenuItem(label.c_str(), shortcut.c_str(), &selected, enabled); return std::make_tuple(selected, activated); }
+    inline bool BeginMenuBar()                                                                                                    { return ImGui::BeginMenuBar(); }
+    inline void EndMenuBar()                                                                                                      { ImGui::EndMenuBar(); }
+    inline bool BeginMainMenuBar()                                                                                                { return ImGui::BeginMainMenuBar(); }
+    inline void EndMainMenuBar()                                                                                                  { ImGui::EndMainMenuBar(); }
+    inline bool BeginMenu(const std::string& label)                                                                               { return ImGui::BeginMenu(label.c_str()); }
+    inline bool BeginMenu(const std::string& label, bool enabled)                                                                 { return ImGui::BeginMenu(label.c_str(), enabled); }
+    inline void EndMenu()                                                                                                         { ImGui::EndMenu(); }
+    inline bool MenuItem(const std::string& label)                                                                                { return ImGui::MenuItem(label.c_str()); }
+    inline bool MenuItem(const std::string& label, const std::string& shortcut)                                                   { return ImGui::MenuItem(label.c_str(), shortcut.c_str()); }
+    inline std::tuple<bool, bool> MenuItem(const std::string& label, const std::string& shortcut, bool selected)                  { bool activated = ImGui::MenuItem(label.c_str(), shortcut.c_str(), &selected); return std::make_tuple(selected, activated); }
+    inline std::tuple<bool, bool> MenuItem(const std::string& label, const std::string& shortcut, bool selected, bool enabled)    { bool activated = ImGui::MenuItem(label.c_str(), shortcut.c_str(), &selected, enabled); return std::make_tuple(selected, activated); }
 
     // Tooltips
-    inline void BeginTooltip()																			{ ImGui::BeginTooltip(); }
-    inline void EndTooltip()																			{ ImGui::EndTooltip(); }
-    inline void SetTooltip(const std::string& fmt)														{ ImGui::SetTooltip(fmt.c_str()); }
-    inline void SetTooltipV()																			{ /* TODO: SetTooltipV(...) ==> UNSUPPORTED */ }
+    inline void BeginTooltip()                                                 { ImGui::BeginTooltip(); }
+    inline void EndTooltip()                                                   { ImGui::EndTooltip(); }
+    inline void SetTooltip(const std::string& fmt)                             { ImGui::SetTooltip(fmt.c_str()); }
+    inline void SetTooltipV()                                                  { /* TODO: SetTooltipV(...) ==> UNSUPPORTED */ }
 
     // Popups, Modals
-    inline bool BeginPopup(const std::string& str_id)													{ return ImGui::BeginPopup(str_id.c_str()); }
-    inline bool BeginPopup(const std::string& str_id, int flags)										{ return ImGui::BeginPopup(str_id.c_str(), static_cast<ImGuiWindowFlags>(flags)); }
-    inline bool BeginPopupModal(const std::string& name)												{ return ImGui::BeginPopupModal(name.c_str()); }
-    inline bool BeginPopupModal(const std::string& name, bool open)										{ return ImGui::BeginPopupModal(name.c_str(), &open); }
-    inline bool BeginPopupModal(const std::string& name, bool open, int flags)							{ return ImGui::BeginPopupModal(name.c_str(), &open, static_cast<ImGuiWindowFlags>(flags)); }
-    inline void EndPopup()																				{ ImGui::EndPopup(); }
-    inline void OpenPopup(const std::string& str_id)													{ ImGui::OpenPopup(str_id.c_str()); }
-    inline void OpenPopup(const std::string& str_id, int popup_flags)									{ ImGui::OpenPopup(str_id.c_str(), static_cast<ImGuiPopupFlags>(popup_flags)); }
-    inline void CloseCurrentPopup()																		{ ImGui::CloseCurrentPopup(); }
-    inline bool BeginPopupContextItem()																	{ return ImGui::BeginPopupContextItem(); }
-    inline bool BeginPopupContextItem(const std::string& str_id)										{ return ImGui::BeginPopupContextItem(str_id.c_str()); }
-    inline bool BeginPopupContextItem(const std::string& str_id, int popup_flags)						{ return ImGui::BeginPopupContextItem(str_id.c_str(), static_cast<ImGuiPopupFlags>(popup_flags)); }
-    inline bool BeginPopupContextWindow()																{ return ImGui::BeginPopupContextWindow(); }
-    inline bool BeginPopupContextWindow(const std::string& str_id)										{ return ImGui::BeginPopupContextWindow(str_id.c_str()); }
-    inline bool BeginPopupContextWindow(const std::string& str_id, int popup_flags)						{ return ImGui::BeginPopupContextWindow(str_id.c_str(), static_cast<ImGuiPopupFlags>(popup_flags)); }
-    inline bool BeginPopupContextVoid()																	{ return ImGui::BeginPopupContextVoid(); }
-    inline bool BeginPopupContextVoid(const std::string& str_id)										{ return ImGui::BeginPopupContextVoid(str_id.c_str()); }
-    inline bool BeginPopupContextVoid(const std::string& str_id, int popup_flags)						{ return ImGui::BeginPopupContextVoid(str_id.c_str(), static_cast<ImGuiPopupFlags>(popup_flags)); }
-    inline bool IsPopupOpen(const std::string& str_id)													{ return ImGui::IsPopupOpen(str_id.c_str()); }
-    inline bool IsPopupOpen(const std::string& str_id, int popup_flags)									{ return ImGui::IsPopupOpen(str_id.c_str(), popup_flags); }
+    inline bool BeginPopup(const std::string& str_id)                                   { return ImGui::BeginPopup(str_id.c_str()); }
+    inline bool BeginPopup(const std::string& str_id, int flags)                        { return ImGui::BeginPopup(str_id.c_str(), static_cast<ImGuiWindowFlags>(flags)); }
+    inline bool BeginPopupModal(const std::string& name)                                { return ImGui::BeginPopupModal(name.c_str()); }
+    inline bool BeginPopupModal(const std::string& name, bool open)                     { return ImGui::BeginPopupModal(name.c_str(), &open); }
+    inline bool BeginPopupModal(const std::string& name, bool open, int flags)          { return ImGui::BeginPopupModal(name.c_str(), &open, static_cast<ImGuiWindowFlags>(flags)); }
+    inline void EndPopup()                                                              { ImGui::EndPopup(); }
+    inline void OpenPopup(const std::string& str_id)                                    { ImGui::OpenPopup(str_id.c_str()); }
+    inline void OpenPopup(const std::string& str_id, int popup_flags)                   { ImGui::OpenPopup(str_id.c_str(), static_cast<ImGuiPopupFlags>(popup_flags)); }
+    inline void CloseCurrentPopup()                                                     { ImGui::CloseCurrentPopup(); }
+    inline bool BeginPopupContextItem()                                                 { return ImGui::BeginPopupContextItem(); }
+    inline bool BeginPopupContextItem(const std::string& str_id)                        { return ImGui::BeginPopupContextItem(str_id.c_str()); }
+    inline bool BeginPopupContextItem(const std::string& str_id, int popup_flags)       { return ImGui::BeginPopupContextItem(str_id.c_str(), static_cast<ImGuiPopupFlags>(popup_flags)); }
+    inline bool BeginPopupContextWindow()                                               { return ImGui::BeginPopupContextWindow(); }
+    inline bool BeginPopupContextWindow(const std::string& str_id)                      { return ImGui::BeginPopupContextWindow(str_id.c_str()); }
+    inline bool BeginPopupContextWindow(const std::string& str_id, int popup_flags)     { return ImGui::BeginPopupContextWindow(str_id.c_str(), static_cast<ImGuiPopupFlags>(popup_flags)); }
+    inline bool BeginPopupContextVoid()                                                 { return ImGui::BeginPopupContextVoid(); }
+    inline bool BeginPopupContextVoid(const std::string& str_id)                        { return ImGui::BeginPopupContextVoid(str_id.c_str()); }
+    inline bool BeginPopupContextVoid(const std::string& str_id, int popup_flags)       { return ImGui::BeginPopupContextVoid(str_id.c_str(), static_cast<ImGuiPopupFlags>(popup_flags)); }
+    inline bool IsPopupOpen(const std::string& str_id)                                  { return ImGui::IsPopupOpen(str_id.c_str()); }
+    inline bool IsPopupOpen(const std::string& str_id, int popup_flags)                 { return ImGui::IsPopupOpen(str_id.c_str(), popup_flags); }
 
     // Columns
-    inline void Columns()																				{ ImGui::Columns(); }
-    inline void Columns(int count)																		{ ImGui::Columns(count); }
-    inline void Columns(int count, const std::string& id)												{ ImGui::Columns(count, id.c_str()); }
-    inline void Columns(int count, const std::string& id, bool border)									{ ImGui::Columns(count, id.c_str(), border); }
-    inline void NextColumn()																			{ ImGui::NextColumn(); }
-    inline int GetColumnIndex()																			{ return ImGui::GetColumnIndex(); }
-    inline float GetColumnWidth()																		{ return ImGui::GetColumnWidth(); }
-    inline float GetColumnWidth(int column_index)														{ return ImGui::GetColumnWidth(column_index); }
-    inline void SetColumnWidth(int column_index, float width)											{ ImGui::SetColumnWidth(column_index, width); }
-    inline float GetColumnOffset()																		{ return ImGui::GetColumnOffset(); }
-    inline float GetColumnOffset(int column_index)														{ return ImGui::GetColumnOffset(column_index); }
-    inline void SetColumnOffset(int column_index, float offset_x)										{ ImGui::SetColumnOffset(column_index, offset_x); }
-    inline int GetColumnsCount()																		{ return ImGui::GetColumnsCount(); }
+    inline void Columns()                                                        { ImGui::Columns(); }
+    inline void Columns(int count)                                               { ImGui::Columns(count); }
+    inline void Columns(int count, const std::string& id)                        { ImGui::Columns(count, id.c_str()); }
+    inline void Columns(int count, const std::string& id, bool border)           { ImGui::Columns(count, id.c_str(), border); }
+    inline void NextColumn()                                                     { ImGui::NextColumn(); }
+    inline int GetColumnIndex()                                                  { return ImGui::GetColumnIndex(); }
+    inline float GetColumnWidth()                                                { return ImGui::GetColumnWidth(); }
+    inline float GetColumnWidth(int column_index)                                { return ImGui::GetColumnWidth(column_index); }
+    inline void SetColumnWidth(int column_index, float width)                    { ImGui::SetColumnWidth(column_index, width); }
+    inline float GetColumnOffset()                                               { return ImGui::GetColumnOffset(); }
+    inline float GetColumnOffset(int column_index)                               { return ImGui::GetColumnOffset(column_index); }
+    inline void SetColumnOffset(int column_index, float offset_x)                { ImGui::SetColumnOffset(column_index, offset_x); }
+    inline int GetColumnsCount()                                                 { return ImGui::GetColumnsCount(); }
 
     // Tab Bars, Tabs
-    inline bool BeginTabBar(const std::string& str_id)													{ return ImGui::BeginTabBar(str_id.c_str()); }
-    inline bool BeginTabBar(const std::string& str_id, int flags)										{ return ImGui::BeginTabBar(str_id.c_str(), static_cast<ImGuiTabBarFlags>(flags)); }
-    inline void EndTabBar()																				{ ImGui::EndTabBar(); }
-    inline bool BeginTabItem(const std::string& label)													{ return ImGui::BeginTabItem(label.c_str()); }
-    inline std::tuple<bool, bool> BeginTabItem(const std::string& label, bool open)						{ bool selected = ImGui::BeginTabItem(label.c_str(), &open); return std::make_tuple(open, selected); }
-    inline std::tuple<bool, bool> BeginTabItem(const std::string& label, bool open, int flags)			{ bool selected = ImGui::BeginTabItem(label.c_str(), &open, static_cast<ImGuiTabItemFlags>(flags)); return std::make_tuple(open, selected); }
-    inline void EndTabItem()																			{ ImGui::EndTabItem(); }
-    inline void SetTabItemClosed(const std::string& tab_or_docked_window_label)							{ ImGui::SetTabItemClosed(tab_or_docked_window_label.c_str()); }
+    inline bool BeginTabBar(const std::string& str_id)                                              { return ImGui::BeginTabBar(str_id.c_str()); }
+    inline bool BeginTabBar(const std::string& str_id, int flags)                                   { return ImGui::BeginTabBar(str_id.c_str(), static_cast<ImGuiTabBarFlags>(flags)); }
+    inline void EndTabBar()                                                                         { ImGui::EndTabBar(); }
+    inline bool BeginTabItem(const std::string& label)                                              { return ImGui::BeginTabItem(label.c_str()); }
+    inline std::tuple<bool, bool> BeginTabItem(const std::string& label, bool open)                 { bool selected = ImGui::BeginTabItem(label.c_str(), &open); return std::make_tuple(open, selected); }
+    inline std::tuple<bool, bool> BeginTabItem(const std::string& label, bool open, int flags)      { bool selected = ImGui::BeginTabItem(label.c_str(), &open, static_cast<ImGuiTabItemFlags>(flags)); return std::make_tuple(open, selected); }
+    inline void EndTabItem()                                                                        { ImGui::EndTabItem(); }
+    inline void SetTabItemClosed(const std::string& tab_or_docked_window_label)                     { ImGui::SetTabItemClosed(tab_or_docked_window_label.c_str()); }
 
     // Logging
-    inline void LogToTTY()																				{ ImGui::LogToTTY(); }
-    inline void LogToTTY(int auto_open_depth)															{ ImGui::LogToTTY(auto_open_depth); }
-    inline void LogToFile()																				{ ImGui::LogToFile(); }
-    inline void LogToFile(int auto_open_depth)															{ ImGui::LogToFile(auto_open_depth); }
-    inline void LogToFile(int auto_open_depth, const std::string& filename)								{ ImGui::LogToFile(auto_open_depth, filename.c_str()); }
-    inline void LogToClipboard()																		{ ImGui::LogToClipboard(); }
-    inline void LogToClipboard(int auto_open_depth)														{ ImGui::LogToClipboard(auto_open_depth); }
-    inline void LogFinish()																				{ ImGui::LogFinish(); }
-    inline void LogButtons()																			{ ImGui::LogButtons(); }
-    inline void LogText(const std::string& fmt)															{ ImGui::LogText(fmt.c_str()); }
+    inline void LogToTTY()                                                       { ImGui::LogToTTY(); }
+    inline void LogToTTY(int auto_open_depth)                                    { ImGui::LogToTTY(auto_open_depth); }
+    inline void LogToFile()                                                      { ImGui::LogToFile(); }
+    inline void LogToFile(int auto_open_depth)                                   { ImGui::LogToFile(auto_open_depth); }
+    inline void LogToFile(int auto_open_depth, const std::string& filename)      { ImGui::LogToFile(auto_open_depth, filename.c_str()); }
+    inline void LogToClipboard()                                                 { ImGui::LogToClipboard(); }
+    inline void LogToClipboard(int auto_open_depth)                              { ImGui::LogToClipboard(auto_open_depth); }
+    inline void LogFinish()                                                      { ImGui::LogFinish(); }
+    inline void LogButtons()                                                     { ImGui::LogButtons(); }
+    inline void LogText(const std::string& fmt)                                  { ImGui::LogText(fmt.c_str()); }
 
     // Drag and Drop
     // TODO: Drag and Drop ==> UNSUPPORTED
 
     // Clipping
-    inline void PushClipRect(float min_x, float min_y, float max_x, float max_y, bool intersect_current) { ImGui::PushClipRect({ min_x, min_y }, { max_x, max_y }, intersect_current); }
-    inline void PopClipRect()																			{ ImGui::PopClipRect(); }
+    inline void PushClipRect(float min_x, float min_y, float max_x, float max_y, bool intersect_current)   { ImGui::PushClipRect({ min_x, min_y }, { max_x, max_y }, intersect_current); }
+    inline void PopClipRect()                                                                              { ImGui::PopClipRect(); }
 
     // Focus, Activation
-    inline void SetItemDefaultFocus()																	{ ImGui::SetItemDefaultFocus(); }
-    inline void SetKeyboardFocusHere()																	{ ImGui::SetKeyboardFocusHere(); }
-    inline void SetKeyboardFocusHere(int offset)														{ ImGui::SetKeyboardFocusHere(offset); }
+    inline void SetItemDefaultFocus()                                          { ImGui::SetItemDefaultFocus(); }
+    inline void SetKeyboardFocusHere()                                         { ImGui::SetKeyboardFocusHere(); }
+    inline void SetKeyboardFocusHere(int offset)                               { ImGui::SetKeyboardFocusHere(offset); }
 
     // Item/Widgets Utilities
-    inline bool IsItemHovered()																			{ return ImGui::IsItemHovered(); }
-    inline bool IsItemHovered(int flags)																{ return ImGui::IsItemHovered(static_cast<ImGuiHoveredFlags>(flags)); }
-    inline bool IsItemActive()																			{ return ImGui::IsItemActive(); }
-    inline bool IsItemFocused()																			{ return ImGui::IsItemFocused(); }
-    inline bool IsItemClicked()																			{ return ImGui::IsItemClicked(); }
-    inline bool IsItemClicked(int mouse_button)															{ return ImGui::IsItemClicked(static_cast<ImGuiMouseButton>(mouse_button)); }
-    inline bool IsItemVisible()																			{ return ImGui::IsItemVisible(); }
-    inline bool IsItemEdited()																			{ return ImGui::IsItemEdited(); }
-    inline bool IsItemActivated()																		{ return ImGui::IsItemActivated(); }
-    inline bool IsItemDeactivated()																		{ return ImGui::IsItemDeactivated(); }
-    inline bool IsItemDeactivatedAfterEdit()															{ return ImGui::IsItemDeactivatedAfterEdit(); }
-    inline bool IsItemToggledOpen()																		{ return ImGui::IsItemToggledOpen(); }
-    inline bool IsAnyItemHovered()																		{ return ImGui::IsAnyItemHovered(); }
-    inline bool IsAnyItemActive()																		{ return ImGui::IsAnyItemActive(); }
-    inline bool IsAnyItemFocused()																		{ return ImGui::IsAnyItemFocused(); }
-    inline std::tuple<float, float> GetItemRectMin()													{ const auto vec2{ ImGui::GetItemRectMin() }; return std::make_tuple(vec2.x, vec2.y); }
-    inline std::tuple<float, float> GetItemRectMax()													{ const auto vec2{ ImGui::GetItemRectMax() }; return std::make_tuple(vec2.x, vec2.y); }
-    inline std::tuple<float, float> GetItemRectSize()													{ const auto vec2{ ImGui::GetItemRectSize() }; return std::make_tuple(vec2.x, vec2.y); }
-    inline void SetItemAllowOverlap()																	{ ImGui::SetItemAllowOverlap(); }
+    inline bool IsItemHovered()                                                { return ImGui::IsItemHovered(); }
+    inline bool IsItemHovered(int flags)                                       { return ImGui::IsItemHovered(static_cast<ImGuiHoveredFlags>(flags)); }
+    inline bool IsItemActive()                                                 { return ImGui::IsItemActive(); }
+    inline bool IsItemFocused()                                                { return ImGui::IsItemFocused(); }
+    inline bool IsItemClicked()                                                { return ImGui::IsItemClicked(); }
+    inline bool IsItemClicked(int mouse_button)                                { return ImGui::IsItemClicked(static_cast<ImGuiMouseButton>(mouse_button)); }
+    inline bool IsItemVisible()                                                { return ImGui::IsItemVisible(); }
+    inline bool IsItemEdited()                                                 { return ImGui::IsItemEdited(); }
+    inline bool IsItemActivated()                                              { return ImGui::IsItemActivated(); }
+    inline bool IsItemDeactivated()                                            { return ImGui::IsItemDeactivated(); }
+    inline bool IsItemDeactivatedAfterEdit()                                   { return ImGui::IsItemDeactivatedAfterEdit(); }
+    inline bool IsItemToggledOpen()                                            { return ImGui::IsItemToggledOpen(); }
+    inline bool IsAnyItemHovered()                                             { return ImGui::IsAnyItemHovered(); }
+    inline bool IsAnyItemActive()                                              { return ImGui::IsAnyItemActive(); }
+    inline bool IsAnyItemFocused()                                             { return ImGui::IsAnyItemFocused(); }
+    inline std::tuple<float, float> GetItemRectMin()                           { const auto vec2{ ImGui::GetItemRectMin() }; return std::make_tuple(vec2.x, vec2.y); }
+    inline std::tuple<float, float> GetItemRectMax()                           { const auto vec2{ ImGui::GetItemRectMax() }; return std::make_tuple(vec2.x, vec2.y); }
+    inline std::tuple<float, float> GetItemRectSize()                          { const auto vec2{ ImGui::GetItemRectSize() }; return std::make_tuple(vec2.x, vec2.y); }
+    inline void SetItemAllowOverlap()                                          { ImGui::SetItemAllowOverlap(); }
 
     // Miscellaneous Utilities
-    inline bool IsRectVisible(float sizeX, float sizeY)													{ return ImGui::IsRectVisible({ sizeX, sizeY }); }
-    inline bool IsRectVisible(float minX, float minY, float maxX, float maxY)							{ return ImGui::IsRectVisible({ minX, minY }, { maxX, maxY }); }
-    inline double GetTime()																				{ return ImGui::GetTime(); }
-    inline int GetFrameCount()																			{ return ImGui::GetFrameCount(); }
+    inline bool IsRectVisible(float sizeX, float sizeY)                                    { return ImGui::IsRectVisible({ sizeX, sizeY }); }
+    inline bool IsRectVisible(float minX, float minY, float maxX, float maxY)              { return ImGui::IsRectVisible({ minX, minY }, { maxX, maxY }); }
+    inline double GetTime()                                                                { return ImGui::GetTime(); }
+    inline int GetFrameCount()                                                             { return ImGui::GetFrameCount(); }
     /* TODO: GetBackgroundDrawList(), GetForeGroundDrawList(), GetDrawListSharedData() ==> UNSUPPORTED */
-    inline std::string GetStyleColorName(int idx)														{ return std::string(ImGui::GetStyleColorName(static_cast<ImGuiCol>(idx))); }
+    inline std::string GetStyleColorName(int idx)                                          { return std::string(ImGui::GetStyleColorName(static_cast<ImGuiCol>(idx))); }
     /* TODO: SetStateStorage(), GetStateStorage(), CalcListClipping() ==> UNSUPPORTED */
-    inline bool BeginChildFrame(unsigned int id, float sizeX, float sizeY)								{ return ImGui::BeginChildFrame(id, { sizeX, sizeY }); }
-    inline bool BeginChildFrame(unsigned int id, float sizeX, float sizeY, int flags)					{ return ImGui::BeginChildFrame(id, { sizeX, sizeY }, static_cast<ImGuiWindowFlags>(flags)); }
-    inline void EndChildFrame()																			{ return ImGui::EndChildFrame(); }
+    inline bool BeginChildFrame(unsigned int id, float sizeX, float sizeY)                 { return ImGui::BeginChildFrame(id, { sizeX, sizeY }); }
+    inline bool BeginChildFrame(unsigned int id, float sizeX, float sizeY, int flags)      { return ImGui::BeginChildFrame(id, { sizeX, sizeY }, static_cast<ImGuiWindowFlags>(flags)); }
+    inline void EndChildFrame()                                                            { return ImGui::EndChildFrame(); }
 
     // Text Utilities
-    inline std::tuple<float, float> CalcTextSize(const std::string& text)																					{ const auto vec2{ ImGui::CalcTextSize(text.c_str()) }; return std::make_tuple(vec2.x, vec2.y); }
-    inline std::tuple<float, float> CalcTextSize(const std::string& text, bool hide_text_after_double_hash)					{ const auto vec2{ ImGui::CalcTextSize(text.c_str(), nullptr, hide_text_after_double_hash) }; return std::make_tuple(vec2.x, vec2.y); }
-    inline std::tuple<float, float> CalcTextSize(const std::string& text, bool hide_text_after_double_hash, float wrap_width)	{ const auto vec2{ ImGui::CalcTextSize(text.c_str(), nullptr, hide_text_after_double_hash, wrap_width) }; return std::make_tuple(vec2.x, vec2.y); }
+    inline std::tuple<float, float> CalcTextSize(const std::string& text)                                                      { const auto vec2{ ImGui::CalcTextSize(text.c_str()) }; return std::make_tuple(vec2.x, vec2.y); }
+    inline std::tuple<float, float> CalcTextSize(const std::string& text, bool hide_text_after_double_hash)                    { const auto vec2{ ImGui::CalcTextSize(text.c_str(), nullptr, hide_text_after_double_hash) }; return std::make_tuple(vec2.x, vec2.y); }
+    inline std::tuple<float, float> CalcTextSize(const std::string& text, bool hide_text_after_double_hash, float wrap_width)  { const auto vec2{ ImGui::CalcTextSize(text.c_str(), nullptr, hide_text_after_double_hash, wrap_width) }; return std::make_tuple(vec2.x, vec2.y); }
 
     // Color Utilities
     inline sol::as_table_t<std::vector<float>> ColorConvertU32ToFloat4(unsigned int in)
@@ -1564,10 +1564,10 @@ namespace sol_ImGui
     }
     inline unsigned int ColorConvertFloat4ToU32(const sol::table& rgba)
     {
-        const lua_Number	r{ rgba[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            g{ rgba[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            b{ rgba[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
-                            a{ rgba[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        const lua_Number  r{ rgba[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          g{ rgba[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          b{ rgba[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          a{ rgba[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
 
         return ImGui::ColorConvertFloat4ToU32({ float(r), float(g), float(b), float(a) });
     }
@@ -1586,435 +1586,435 @@ namespace sol_ImGui
 
 #ifdef SOL_IMGUI_ENABLE_INPUT_FUNCTIONS
     // Inputs Utilities: Keyboard
-    inline int GetKeyIndex(int imgui_key)																{ return ImGui::GetKeyIndex(static_cast<ImGuiKey>(imgui_key)); }
-    inline bool IsKeyDown(int user_key_index)															{ return ImGui::IsKeyDown(user_key_index); }
-    inline bool IsKeyPressed(int user_key_index)														{ return ImGui::IsKeyPressed(user_key_index); }
-    inline bool IsKeyPressed(int user_key_index, bool repeat)											{ return ImGui::IsKeyPressed(user_key_index, repeat); }
-    inline bool IsKeyReleased(int user_key_index)														{ return ImGui::IsKeyReleased(user_key_index); }
-    inline int GetKeyPressedAmount(int key_index, float repeat_delay, float rate)						{ return ImGui::GetKeyPressedAmount(key_index, repeat_delay, rate); }
-    inline void CaptureKeyboardFromApp()																{ ImGui::CaptureKeyboardFromApp(); }
-    inline void CaptureKeyboardFromApp(bool want_capture_keyboard_value)								{ ImGui::CaptureKeyboardFromApp(want_capture_keyboard_value); }
+    inline int GetKeyIndex(int imgui_key)                                           { return ImGui::GetKeyIndex(static_cast<ImGuiKey>(imgui_key)); }
+    inline bool IsKeyDown(int user_key_index)                                       { return ImGui::IsKeyDown(user_key_index); }
+    inline bool IsKeyPressed(int user_key_index)                                    { return ImGui::IsKeyPressed(user_key_index); }
+    inline bool IsKeyPressed(int user_key_index, bool repeat)                       { return ImGui::IsKeyPressed(user_key_index, repeat); }
+    inline bool IsKeyReleased(int user_key_index)                                   { return ImGui::IsKeyReleased(user_key_index); }
+    inline int GetKeyPressedAmount(int key_index, float repeat_delay, float rate)   { return ImGui::GetKeyPressedAmount(key_index, repeat_delay, rate); }
+    inline void CaptureKeyboardFromApp()                                            { ImGui::CaptureKeyboardFromApp(); }
+    inline void CaptureKeyboardFromApp(bool want_capture_keyboard_value)            { ImGui::CaptureKeyboardFromApp(want_capture_keyboard_value); }
 
     // Inputs Utilities: Mouse
-    inline bool IsMouseDown(int button)																	{ return ImGui::IsMouseDown(static_cast<ImGuiMouseButton>(button)); }
-    inline bool IsMouseClicked(int button)																{ return ImGui::IsMouseClicked(static_cast<ImGuiMouseButton>(button)); }
-    inline bool IsMouseClicked(int button, bool repeat)													{ return ImGui::IsMouseClicked(static_cast<ImGuiMouseButton>(button), repeat); }
-    inline bool IsMouseReleased(int button)																{ return ImGui::IsMouseReleased(static_cast<ImGuiMouseButton>(button)); }
-    inline bool IsMouseDoubleClicked(int button)														{ return ImGui::IsMouseDoubleClicked(static_cast<ImGuiMouseButton>(button)); }
-    inline bool IsMouseHoveringRect(float min_x, float min_y, float max_x, float max_y)					{ return ImGui::IsMouseHoveringRect({ min_x, min_y }, { max_x, max_y }); }
-    inline bool IsMouseHoveringRect(float min_x, float min_y, float max_x, float max_y, bool clip)		{ return ImGui::IsMouseHoveringRect({ min_x, min_y }, { max_x, max_y }, clip); }
-    inline bool IsMousePosValid()																		{ return false; /* TODO: IsMousePosValid() ==> UNSUPPORTED */ }
-    inline bool IsAnyMouseDown()																		{ return ImGui::IsAnyMouseDown(); }
-    inline std::tuple<float, float> GetMousePos()														{ const auto vec2{ ImGui::GetMousePos() }; return std::make_tuple(vec2.x, vec2.y); }
-    inline std::tuple<float, float> GetMousePosOnOpeningCurrentPopup()									{ const auto vec2{ ImGui::GetMousePosOnOpeningCurrentPopup() }; return std::make_tuple(vec2.x, vec2.y); }
-    inline bool IsMouseDragging(int button)																{ return ImGui::IsMouseDragging(static_cast<ImGuiMouseButton>(button)); }
-    inline bool IsMouseDragging(int button, float lock_threshold)										{ return ImGui::IsMouseDragging(static_cast<ImGuiMouseButton>(button), lock_threshold); }
-    inline std::tuple<float, float> GetMouseDragDelta()													{ const auto vec2{ ImGui::GetMouseDragDelta() }; return std::make_tuple(vec2.x, vec2.y); }
-    inline std::tuple<float, float> GetMouseDragDelta(int button)										{ const auto vec2{ ImGui::GetMouseDragDelta(static_cast<ImGuiMouseButton>(button)) }; return std::make_tuple(vec2.x, vec2.y); }
-    inline std::tuple<float, float> GetMouseDragDelta(int button, float lock_threshold)					{ const auto vec2{ ImGui::GetMouseDragDelta(static_cast<ImGuiMouseButton>(button), lock_threshold) }; return std::make_tuple(vec2.x, vec2.y); }
-    inline void ResetMouseDragDelta()																	{ ImGui::ResetMouseDragDelta(); }
-    inline void ResetMouseDragDelta(int button)															{ ImGui::ResetMouseDragDelta(static_cast<ImGuiMouseButton>(button)); }
-    inline int GetMouseCursor()																			{ return ImGui::GetMouseCursor(); }
-    inline void SetMouseCursor(int cursor_type)															{ ImGui::SetMouseCursor(static_cast<ImGuiMouseCursor>(cursor_type)); }
-    inline void CaptureMouseFromApp()																	{ ImGui::CaptureMouseFromApp(); }
-    inline void CaptureMouseFromApp(bool want_capture_mouse_value)										{ ImGui::CaptureMouseFromApp(want_capture_mouse_value); }
+    inline bool IsMouseDown(int button)                                                               { return ImGui::IsMouseDown(static_cast<ImGuiMouseButton>(button)); }
+    inline bool IsMouseClicked(int button)                                                            { return ImGui::IsMouseClicked(static_cast<ImGuiMouseButton>(button)); }
+    inline bool IsMouseClicked(int button, bool repeat)                                               { return ImGui::IsMouseClicked(static_cast<ImGuiMouseButton>(button), repeat); }
+    inline bool IsMouseReleased(int button)                                                           { return ImGui::IsMouseReleased(static_cast<ImGuiMouseButton>(button)); }
+    inline bool IsMouseDoubleClicked(int button)                                                      { return ImGui::IsMouseDoubleClicked(static_cast<ImGuiMouseButton>(button)); }
+    inline bool IsMouseHoveringRect(float min_x, float min_y, float max_x, float max_y)               { return ImGui::IsMouseHoveringRect({ min_x, min_y }, { max_x, max_y }); }
+    inline bool IsMouseHoveringRect(float min_x, float min_y, float max_x, float max_y, bool clip)    { return ImGui::IsMouseHoveringRect({ min_x, min_y }, { max_x, max_y }, clip); }
+    inline bool IsMousePosValid()                                                                     { return false; /* TODO: IsMousePosValid() ==> UNSUPPORTED */ }
+    inline bool IsAnyMouseDown()                                                                      { return ImGui::IsAnyMouseDown(); }
+    inline std::tuple<float, float> GetMousePos()                                                     { const auto vec2{ ImGui::GetMousePos() }; return std::make_tuple(vec2.x, vec2.y); }
+    inline std::tuple<float, float> GetMousePosOnOpeningCurrentPopup()                                { const auto vec2{ ImGui::GetMousePosOnOpeningCurrentPopup() }; return std::make_tuple(vec2.x, vec2.y); }
+    inline bool IsMouseDragging(int button)                                                           { return ImGui::IsMouseDragging(static_cast<ImGuiMouseButton>(button)); }
+    inline bool IsMouseDragging(int button, float lock_threshold)                                     { return ImGui::IsMouseDragging(static_cast<ImGuiMouseButton>(button), lock_threshold); }
+    inline std::tuple<float, float> GetMouseDragDelta()                                               { const auto vec2{ ImGui::GetMouseDragDelta() }; return std::make_tuple(vec2.x, vec2.y); }
+    inline std::tuple<float, float> GetMouseDragDelta(int button)                                     { const auto vec2{ ImGui::GetMouseDragDelta(static_cast<ImGuiMouseButton>(button)) }; return std::make_tuple(vec2.x, vec2.y); }
+    inline std::tuple<float, float> GetMouseDragDelta(int button, float lock_threshold)               { const auto vec2{ ImGui::GetMouseDragDelta(static_cast<ImGuiMouseButton>(button), lock_threshold) }; return std::make_tuple(vec2.x, vec2.y); }
+    inline void ResetMouseDragDelta()                                                                 { ImGui::ResetMouseDragDelta(); }
+    inline void ResetMouseDragDelta(int button)                                                       { ImGui::ResetMouseDragDelta(static_cast<ImGuiMouseButton>(button)); }
+    inline int GetMouseCursor()                                                                       { return ImGui::GetMouseCursor(); }
+    inline void SetMouseCursor(int cursor_type)                                                       { ImGui::SetMouseCursor(static_cast<ImGuiMouseCursor>(cursor_type)); }
+    inline void CaptureMouseFromApp()                                                                 { ImGui::CaptureMouseFromApp(); }
+    inline void CaptureMouseFromApp(bool want_capture_mouse_value)                                    { ImGui::CaptureMouseFromApp(want_capture_mouse_value); }
 #endif // SOL_IMGUI_ENABLE_INPUT_FUNCTIONS
 
     // Clipboard Utilities
-    inline std::string GetClipboardText()																{ return std::string(ImGui::GetClipboardText()); }
-    inline void SetClipboardText(const std::string& text)												{ ImGui::SetClipboardText(text.c_str()); }
+    inline std::string GetClipboardText()                                                             { return std::string(ImGui::GetClipboardText()); }
+    inline void SetClipboardText(const std::string& text)                                             { ImGui::SetClipboardText(text.c_str()); }
 
     inline void InitEnums(sol::state& lua)
     {
 #pragma region Window Flags
         lua.new_enum("ImGuiWindowFlags",
-            "None"						, ImGuiWindowFlags_None,
-            "NoTitleBar"				, ImGuiWindowFlags_NoTitleBar,
-            "NoResize"					, ImGuiWindowFlags_NoResize,
-            "NoMove"					, ImGuiWindowFlags_NoMove,
-            "NoScrollbar"				, ImGuiWindowFlags_NoScrollbar,
-            "NoScrollWithMouse"			, ImGuiWindowFlags_NoScrollWithMouse,
-            "NoCollapse"				, ImGuiWindowFlags_NoCollapse,
-            "AlwaysAutoResize"			, ImGuiWindowFlags_AlwaysAutoResize,
-            "NoBackground"				, ImGuiWindowFlags_NoBackground,
-            "NoSavedSettings"			, ImGuiWindowFlags_NoSavedSettings,
-            "NoMouseInputs"				, ImGuiWindowFlags_NoMouseInputs,
-            "MenuBar"					, ImGuiWindowFlags_MenuBar,
-            "HorizontalScrollbar"		, ImGuiWindowFlags_HorizontalScrollbar,
-            "NoFocusOnAppearing"		, ImGuiWindowFlags_NoFocusOnAppearing,
-            "NoBringToFrontOnFocus"		, ImGuiWindowFlags_NoBringToFrontOnFocus,
-            "AlwaysVerticalScrollbar"	, ImGuiWindowFlags_AlwaysVerticalScrollbar,
-            "AlwaysHorizontalScrollbar"	, ImGuiWindowFlags_AlwaysHorizontalScrollbar,
-            "AlwaysUseWindowPadding"	, ImGuiWindowFlags_AlwaysUseWindowPadding,
-            "NoNavInputs"				, ImGuiWindowFlags_NoNavInputs,
-            "NoNavFocus"				, ImGuiWindowFlags_NoNavFocus,
-            "UnsavedDocument"			, ImGuiWindowFlags_UnsavedDocument,
+            "None"                           , ImGuiWindowFlags_None,
+            "NoTitleBar"                     , ImGuiWindowFlags_NoTitleBar,
+            "NoResize"                       , ImGuiWindowFlags_NoResize,
+            "NoMove"                         , ImGuiWindowFlags_NoMove,
+            "NoScrollbar"                    , ImGuiWindowFlags_NoScrollbar,
+            "NoScrollWithMouse"              , ImGuiWindowFlags_NoScrollWithMouse,
+            "NoCollapse"                     , ImGuiWindowFlags_NoCollapse,
+            "AlwaysAutoResize"               , ImGuiWindowFlags_AlwaysAutoResize,
+            "NoBackground"                   , ImGuiWindowFlags_NoBackground,
+            "NoSavedSettings"                , ImGuiWindowFlags_NoSavedSettings,
+            "NoMouseInputs"                  , ImGuiWindowFlags_NoMouseInputs,
+            "MenuBar"                        , ImGuiWindowFlags_MenuBar,
+            "HorizontalScrollbar"            , ImGuiWindowFlags_HorizontalScrollbar,
+            "NoFocusOnAppearing"             , ImGuiWindowFlags_NoFocusOnAppearing,
+            "NoBringToFrontOnFocus"          , ImGuiWindowFlags_NoBringToFrontOnFocus,
+            "AlwaysVerticalScrollbar"        , ImGuiWindowFlags_AlwaysVerticalScrollbar,
+            "AlwaysHorizontalScrollbar"      , ImGuiWindowFlags_AlwaysHorizontalScrollbar,
+            "AlwaysUseWindowPadding"         , ImGuiWindowFlags_AlwaysUseWindowPadding,
+            "NoNavInputs"                    , ImGuiWindowFlags_NoNavInputs,
+            "NoNavFocus"                     , ImGuiWindowFlags_NoNavFocus,
+            "UnsavedDocument"                , ImGuiWindowFlags_UnsavedDocument,
 
-            "NoNav"						, ImGuiWindowFlags_NoNav,
-            "NoDecoration"				, ImGuiWindowFlags_NoDecoration,
-            "NoInputs"					, ImGuiWindowFlags_NoInputs,
+            "NoNav"                          , ImGuiWindowFlags_NoNav,
+            "NoDecoration"                   , ImGuiWindowFlags_NoDecoration,
+            "NoInputs"                       , ImGuiWindowFlags_NoInputs,
 
-            "NavFlattened"				, ImGuiWindowFlags_NavFlattened,
-            "ChildWindow"				, ImGuiWindowFlags_ChildWindow,
-            "Tooltip"					, ImGuiWindowFlags_Tooltip,
-            "Popup"						, ImGuiWindowFlags_Popup,
-            "Modal"						, ImGuiWindowFlags_Modal,
-            "ChildMenu"					, ImGuiWindowFlags_ChildMenu
+            "NavFlattened"                   , ImGuiWindowFlags_NavFlattened,
+            "ChildWindow"                    , ImGuiWindowFlags_ChildWindow,
+            "Tooltip"                        , ImGuiWindowFlags_Tooltip,
+            "Popup"                          , ImGuiWindowFlags_Popup,
+            "Modal"                          , ImGuiWindowFlags_Modal,
+            "ChildMenu"                      , ImGuiWindowFlags_ChildMenu
         );
 #pragma endregion Window Flags
 
 #pragma region Focused Flags
         lua.new_enum("ImGuiFocusedFlags",
-            "None"						, ImGuiFocusedFlags_None,
-            "ChildWindows"				, ImGuiFocusedFlags_ChildWindows,
-            "RootWindow"				, ImGuiFocusedFlags_RootWindow,
-            "AnyWindow"					, ImGuiFocusedFlags_AnyWindow,
-            "RootAndChildWindows"		, ImGuiFocusedFlags_RootAndChildWindows
+            "None"                           , ImGuiFocusedFlags_None,
+            "ChildWindows"                   , ImGuiFocusedFlags_ChildWindows,
+            "RootWindow"                     , ImGuiFocusedFlags_RootWindow,
+            "AnyWindow"                      , ImGuiFocusedFlags_AnyWindow,
+            "RootAndChildWindows"            , ImGuiFocusedFlags_RootAndChildWindows
         );
 #pragma endregion Focused Flags
 
 #pragma region Hovered Flags
         lua.new_enum("ImGuiHoveredFlags",
-            "None"						, ImGuiHoveredFlags_None,
-            "ChildWindows"				, ImGuiHoveredFlags_ChildWindows,
-            "RootWindow"				, ImGuiHoveredFlags_RootWindow,
-            "AnyWindow"					, ImGuiHoveredFlags_AnyWindow,
-            "AllowWhenBlockedByPopup"	, ImGuiHoveredFlags_AllowWhenBlockedByPopup,
-            "AllowWhenBlockedByActiveItem", ImGuiHoveredFlags_AllowWhenBlockedByActiveItem,
-            "AllowWhenOverlapped"		, ImGuiHoveredFlags_AllowWhenOverlapped,
-            "AllowWhenDisabled"			, ImGuiHoveredFlags_AllowWhenDisabled,
-            "RectOnly"					, ImGuiHoveredFlags_RectOnly,
-            "RootAndChildWindows"		, ImGuiHoveredFlags_RootAndChildWindows
+            "None"                           , ImGuiHoveredFlags_None,
+            "ChildWindows"                   , ImGuiHoveredFlags_ChildWindows,
+            "RootWindow"                     , ImGuiHoveredFlags_RootWindow,
+            "AnyWindow"                      , ImGuiHoveredFlags_AnyWindow,
+            "AllowWhenBlockedByPopup"        , ImGuiHoveredFlags_AllowWhenBlockedByPopup,
+            "AllowWhenBlockedByActiveItem"   , ImGuiHoveredFlags_AllowWhenBlockedByActiveItem,
+            "AllowWhenOverlapped"            , ImGuiHoveredFlags_AllowWhenOverlapped,
+            "AllowWhenDisabled"              , ImGuiHoveredFlags_AllowWhenDisabled,
+            "RectOnly"                       , ImGuiHoveredFlags_RectOnly,
+            "RootAndChildWindows"            , ImGuiHoveredFlags_RootAndChildWindows
         );
 #pragma endregion Hovered Flags
 
 #pragma region Cond
         lua.new_enum("ImGuiCond",
-            "None"						, ImGuiCond_None,
-            "Always"					, ImGuiCond_Always,
-            "Once"						, ImGuiCond_Once,
-            "FirstUseEver"				, ImGuiCond_FirstUseEver,
-            "Appearing"					, ImGuiCond_Appearing
+            "None"                           , ImGuiCond_None,
+            "Always"                         , ImGuiCond_Always,
+            "Once"                           , ImGuiCond_Once,
+            "FirstUseEver"                   , ImGuiCond_FirstUseEver,
+            "Appearing"                      , ImGuiCond_Appearing
         );
 #pragma endregion Cond
 
 #pragma region Col
         lua.new_enum("ImGuiCol",
-            "Text"						, ImGuiCol_Text,
-            "TextDisabled"				, ImGuiCol_TextDisabled,
-            "WindowBg"					, ImGuiCol_WindowBg,
-            "ChildBg"					, ImGuiCol_ChildBg,
-            "PopupBg"					, ImGuiCol_PopupBg,
-            "Border"					, ImGuiCol_Border,
-            "BorderShadow"				, ImGuiCol_BorderShadow,
-            "FrameBg"					, ImGuiCol_FrameBg,
-            "FrameBgHovered"			, ImGuiCol_FrameBgHovered,
-            "FrameBgActive"				, ImGuiCol_FrameBgActive,
-            "TitleBg"					, ImGuiCol_TitleBg,
-            "TitleBgActive"				, ImGuiCol_TitleBgActive,
-            "TitleBgCollapsed"			, ImGuiCol_TitleBgCollapsed,
-            "MenuBarBg"					, ImGuiCol_MenuBarBg,
-            "ScrollbarBg"				, ImGuiCol_ScrollbarBg,
-            "ScrollbarGrab"				, ImGuiCol_ScrollbarGrab,
-            "ScrollbarGrabHovered"		, ImGuiCol_ScrollbarGrabHovered,
-            "ScrollbarGrabActive"		, ImGuiCol_ScrollbarGrabActive,
-            "CheckMark"					, ImGuiCol_CheckMark,
-            "SliderGrab"				, ImGuiCol_SliderGrab,
-            "SliderGrabActive"			, ImGuiCol_SliderGrabActive,
-            "Button"					, ImGuiCol_Button,
-            "ButtonHovered"				, ImGuiCol_ButtonHovered,
-            "ButtonActive"				, ImGuiCol_ButtonActive,
-            "Header"					, ImGuiCol_Header,
-            "HeaderHovered"				, ImGuiCol_HeaderHovered,
-            "HeaderActive"				, ImGuiCol_HeaderActive,
-            "Separator"					, ImGuiCol_Separator,
-            "SeparatorHovered"			, ImGuiCol_SeparatorHovered,
-            "SeparatorActive"			, ImGuiCol_SeparatorActive,
-            "ResizeGrip"				, ImGuiCol_ResizeGrip,
-            "ResizeGripHovered"			, ImGuiCol_ResizeGripHovered,
-            "ResizeGripActive"			, ImGuiCol_ResizeGripActive,
-            "Tab"						, ImGuiCol_Tab,
-            "TabHovered"				, ImGuiCol_TabHovered,
-            "TabActive"					, ImGuiCol_TabActive,
-            "TabUnfocused"				, ImGuiCol_TabUnfocused,
-            "TabUnfocusedActive"		, ImGuiCol_TabUnfocusedActive,
-            "PlotLines"					, ImGuiCol_PlotLines,
-            "PlotLinesHovered"			, ImGuiCol_PlotLinesHovered,
-            "PlotHistogram"				, ImGuiCol_PlotHistogram,
-            "PlotHistogramHovered"		, ImGuiCol_PlotHistogramHovered,
-            "TableHeaderBg"             , ImGuiCol_TableHeaderBg,     
-            "TableBorderStrong"         , ImGuiCol_TableBorderStrong, 
-            "TableBorderLight"          , ImGuiCol_TableBorderLight,  
-            "TableRowBg"                , ImGuiCol_TableRowBg,        
-            "TableRowBgAlt"             , ImGuiCol_TableRowBgAlt,     
-            "TextSelectedBg"			, ImGuiCol_TextSelectedBg,
-            "DragDropTarget"			, ImGuiCol_DragDropTarget,
-            "NavHighlight"				, ImGuiCol_NavHighlight,
-            "NavWindowingHighlight"		, ImGuiCol_NavWindowingHighlight,
-            "NavWindowingDimBg"			, ImGuiCol_NavWindowingDimBg,
-            "ModalWindowDimBg"			, ImGuiCol_ModalWindowDimBg,
-            "COUNT"						, ImGuiCol_COUNT
+            "Text"                           , ImGuiCol_Text,
+            "TextDisabled"                   , ImGuiCol_TextDisabled,
+            "WindowBg"                       , ImGuiCol_WindowBg,
+            "ChildBg"                        , ImGuiCol_ChildBg,
+            "PopupBg"                        , ImGuiCol_PopupBg,
+            "Border"                         , ImGuiCol_Border,
+            "BorderShadow"                   , ImGuiCol_BorderShadow,
+            "FrameBg"                        , ImGuiCol_FrameBg,
+            "FrameBgHovered"                 , ImGuiCol_FrameBgHovered,
+            "FrameBgActive"                  , ImGuiCol_FrameBgActive,
+            "TitleBg"                        , ImGuiCol_TitleBg,
+            "TitleBgActive"                  , ImGuiCol_TitleBgActive,
+            "TitleBgCollapsed"               , ImGuiCol_TitleBgCollapsed,
+            "MenuBarBg"                      , ImGuiCol_MenuBarBg,
+            "ScrollbarBg"                    , ImGuiCol_ScrollbarBg,
+            "ScrollbarGrab"                  , ImGuiCol_ScrollbarGrab,
+            "ScrollbarGrabHovered"           , ImGuiCol_ScrollbarGrabHovered,
+            "ScrollbarGrabActive"            , ImGuiCol_ScrollbarGrabActive,
+            "CheckMark"                      , ImGuiCol_CheckMark,
+            "SliderGrab"                     , ImGuiCol_SliderGrab,
+            "SliderGrabActive"               , ImGuiCol_SliderGrabActive,
+            "Button"                         , ImGuiCol_Button,
+            "ButtonHovered"                  , ImGuiCol_ButtonHovered,
+            "ButtonActive"                   , ImGuiCol_ButtonActive,
+            "Header"                         , ImGuiCol_Header,
+            "HeaderHovered"                  , ImGuiCol_HeaderHovered,
+            "HeaderActive"                   , ImGuiCol_HeaderActive,
+            "Separator"                      , ImGuiCol_Separator,
+            "SeparatorHovered"               , ImGuiCol_SeparatorHovered,
+            "SeparatorActive"                , ImGuiCol_SeparatorActive,
+            "ResizeGrip"                     , ImGuiCol_ResizeGrip,
+            "ResizeGripHovered"              , ImGuiCol_ResizeGripHovered,
+            "ResizeGripActive"               , ImGuiCol_ResizeGripActive,
+            "Tab"                            , ImGuiCol_Tab,
+            "TabHovered"                     , ImGuiCol_TabHovered,
+            "TabActive"                      , ImGuiCol_TabActive,
+            "TabUnfocused"                   , ImGuiCol_TabUnfocused,
+            "TabUnfocusedActive"             , ImGuiCol_TabUnfocusedActive,
+            "PlotLines"                      , ImGuiCol_PlotLines,
+            "PlotLinesHovered"               , ImGuiCol_PlotLinesHovered,
+            "PlotHistogram"                  , ImGuiCol_PlotHistogram,
+            "PlotHistogramHovered"           , ImGuiCol_PlotHistogramHovered,
+            "TableHeaderBg"                  , ImGuiCol_TableHeaderBg,
+            "TableBorderStrong"              , ImGuiCol_TableBorderStrong,
+            "TableBorderLight"               , ImGuiCol_TableBorderLight,
+            "TableRowBg"                     , ImGuiCol_TableRowBg,
+            "TableRowBgAlt"                  , ImGuiCol_TableRowBgAlt,
+            "TextSelectedBg"                 , ImGuiCol_TextSelectedBg,
+            "DragDropTarget"                 , ImGuiCol_DragDropTarget,
+            "NavHighlight"                   , ImGuiCol_NavHighlight,
+            "NavWindowingHighlight"          , ImGuiCol_NavWindowingHighlight,
+            "NavWindowingDimBg"              , ImGuiCol_NavWindowingDimBg,
+            "ModalWindowDimBg"               , ImGuiCol_ModalWindowDimBg,
+            "COUNT"                          , ImGuiCol_COUNT
         );
 #pragma endregion Col
 
 #pragma region Style
         lua.new_enum("ImGuiStyleVar",
-            "Alpha"						, ImGuiStyleVar_Alpha,
-            "WindowPadding"				, ImGuiStyleVar_WindowPadding,
-            "WindowRounding"			, ImGuiStyleVar_WindowRounding,
-            "WindowBorderSize"			, ImGuiStyleVar_WindowBorderSize,
-            "WindowMinSize"				, ImGuiStyleVar_WindowMinSize,
-            "WindowTitleAlign"			, ImGuiStyleVar_WindowTitleAlign,
-            "ChildRounding"				, ImGuiStyleVar_ChildRounding,
-            "ChildBorderSize"			, ImGuiStyleVar_ChildBorderSize,
-            "PopupRounding"				, ImGuiStyleVar_PopupRounding,
-            "PopupBorderSize"			, ImGuiStyleVar_PopupBorderSize,
-            "FramePadding"				, ImGuiStyleVar_FramePadding,
-            "FrameRounding"				, ImGuiStyleVar_FrameRounding,
-            "FrameBorderSize"			, ImGuiStyleVar_FrameBorderSize,
-            "ItemSpacing"				, ImGuiStyleVar_ItemSpacing,
-            "ItemInnerSpacing"			, ImGuiStyleVar_ItemInnerSpacing,
-            "IndentSpacing"				, ImGuiStyleVar_IndentSpacing,
-            "ScrollbarSize"				, ImGuiStyleVar_ScrollbarSize,
-            "ScrollbarRounding"			, ImGuiStyleVar_ScrollbarRounding,
-            "GrabMinSize"				, ImGuiStyleVar_GrabMinSize,
-            "GrabRounding"				, ImGuiStyleVar_GrabRounding,
-            "TabRounding"				, ImGuiStyleVar_TabRounding,
-            "SelectableTextAlign"		, ImGuiStyleVar_SelectableTextAlign,
-            "ButtonTextAlign"			, ImGuiStyleVar_ButtonTextAlign,
-            "COUNT"						, ImGuiStyleVar_COUNT
+            "Alpha"                          , ImGuiStyleVar_Alpha,
+            "WindowPadding"                  , ImGuiStyleVar_WindowPadding,
+            "WindowRounding"                 , ImGuiStyleVar_WindowRounding,
+            "WindowBorderSize"               , ImGuiStyleVar_WindowBorderSize,
+            "WindowMinSize"                  , ImGuiStyleVar_WindowMinSize,
+            "WindowTitleAlign"               , ImGuiStyleVar_WindowTitleAlign,
+            "ChildRounding"                  , ImGuiStyleVar_ChildRounding,
+            "ChildBorderSize"                , ImGuiStyleVar_ChildBorderSize,
+            "PopupRounding"                  , ImGuiStyleVar_PopupRounding,
+            "PopupBorderSize"                , ImGuiStyleVar_PopupBorderSize,
+            "FramePadding"                   , ImGuiStyleVar_FramePadding,
+            "FrameRounding"                  , ImGuiStyleVar_FrameRounding,
+            "FrameBorderSize"                , ImGuiStyleVar_FrameBorderSize,
+            "ItemSpacing"                    , ImGuiStyleVar_ItemSpacing,
+            "ItemInnerSpacing"               , ImGuiStyleVar_ItemInnerSpacing,
+            "IndentSpacing"                  , ImGuiStyleVar_IndentSpacing,
+            "ScrollbarSize"                  , ImGuiStyleVar_ScrollbarSize,
+            "ScrollbarRounding"              , ImGuiStyleVar_ScrollbarRounding,
+            "GrabMinSize"                    , ImGuiStyleVar_GrabMinSize,
+            "GrabRounding"                   , ImGuiStyleVar_GrabRounding,
+            "TabRounding"                    , ImGuiStyleVar_TabRounding,
+            "SelectableTextAlign"            , ImGuiStyleVar_SelectableTextAlign,
+            "ButtonTextAlign"                , ImGuiStyleVar_ButtonTextAlign,
+            "COUNT"                          , ImGuiStyleVar_COUNT
         );
 #pragma endregion Style
 
 #pragma region Dir
         lua.new_enum("ImGuiDir",
-            "None"						, ImGuiDir_None,
-            "Left"						, ImGuiDir_Left,
-            "Right"						, ImGuiDir_Right,
-            "Up"						, ImGuiDir_Up,
-            "Down"						, ImGuiDir_Down,
-            "COUNT"						, ImGuiDir_COUNT
+            "None"                           , ImGuiDir_None,
+            "Left"                           , ImGuiDir_Left,
+            "Right"                          , ImGuiDir_Right,
+            "Up"                             , ImGuiDir_Up,
+            "Down"                           , ImGuiDir_Down,
+            "COUNT"                          , ImGuiDir_COUNT
         );
 #pragma endregion Dir
 
 #pragma region Combo Flags
         lua.new_enum("ImGuiComboFlags",
-            "None"					, ImGuiComboFlags_None,
-            "PopupAlignLeft"		, ImGuiComboFlags_PopupAlignLeft,
-            "HeightSmall"			, ImGuiComboFlags_HeightSmall,
-            "HeightRegular"			, ImGuiComboFlags_HeightRegular,
-            "HeightLarge"			, ImGuiComboFlags_HeightLarge,
-            "HeightLargest"			, ImGuiComboFlags_HeightLargest,
-            "NoArrowButton"			, ImGuiComboFlags_NoArrowButton,
-            "NoPreview"				, ImGuiComboFlags_NoPreview,
-            "HeightMask"			, ImGuiComboFlags_HeightMask_
+            "None"                           , ImGuiComboFlags_None,
+            "PopupAlignLeft"                 , ImGuiComboFlags_PopupAlignLeft,
+            "HeightSmall"                    , ImGuiComboFlags_HeightSmall,
+            "HeightRegular"                  , ImGuiComboFlags_HeightRegular,
+            "HeightLarge"                    , ImGuiComboFlags_HeightLarge,
+            "HeightLargest"                  , ImGuiComboFlags_HeightLargest,
+            "NoArrowButton"                  , ImGuiComboFlags_NoArrowButton,
+            "NoPreview"                      , ImGuiComboFlags_NoPreview,
+            "HeightMask"                     , ImGuiComboFlags_HeightMask_
         );
 #pragma endregion Combo Flags
 
 #pragma region InputText Flags
         lua.new_enum("ImGuiInputTextFlags",
-            "None"					, ImGuiInputTextFlags_None,
-            "CharsDecimal"			, ImGuiInputTextFlags_CharsDecimal,
-            "CharsHexadecimal"		, ImGuiInputTextFlags_CharsHexadecimal,
-            "CharsUppercase"		, ImGuiInputTextFlags_CharsUppercase,
-            "CharsNoBlank"			, ImGuiInputTextFlags_CharsNoBlank,
-            "AutoSelectAll"			, ImGuiInputTextFlags_AutoSelectAll,
-            "EnterReturnsTrue"		, ImGuiInputTextFlags_EnterReturnsTrue,
-            "CallbackCompletion"	, ImGuiInputTextFlags_CallbackCompletion,
-            "CallbackHistory"		, ImGuiInputTextFlags_CallbackHistory,
-            "CallbackAlways"		, ImGuiInputTextFlags_CallbackAlways,
-            "CallbackCharFilter"	, ImGuiInputTextFlags_CallbackCharFilter,
-            "AllowTabInput"			, ImGuiInputTextFlags_AllowTabInput,
-            "CtrlEnterForNewLine"	, ImGuiInputTextFlags_CtrlEnterForNewLine,
-            "NoHorizontalScroll"	, ImGuiInputTextFlags_NoHorizontalScroll,
-            "AlwaysInsertMode"		, ImGuiInputTextFlags_AlwaysInsertMode,
-            "ReadOnly"				, ImGuiInputTextFlags_ReadOnly,
-            "Password"				, ImGuiInputTextFlags_Password,
-            "NoUndoRedo"			, ImGuiInputTextFlags_NoUndoRedo,
-            "CharsScientific"		, ImGuiInputTextFlags_CharsScientific,
-            "CallbackResize"		, ImGuiInputTextFlags_CallbackResize,
-            "CallbackEdit"		    , ImGuiInputTextFlags_CallbackEdit,
-            "Multiline"				, ImGuiInputTextFlags_Multiline,
-            "NoMarkEdited"			, ImGuiInputTextFlags_NoMarkEdited
+            "None"                           , ImGuiInputTextFlags_None,
+            "CharsDecimal"                   , ImGuiInputTextFlags_CharsDecimal,
+            "CharsHexadecimal"               , ImGuiInputTextFlags_CharsHexadecimal,
+            "CharsUppercase"                 , ImGuiInputTextFlags_CharsUppercase,
+            "CharsNoBlank"                   , ImGuiInputTextFlags_CharsNoBlank,
+            "AutoSelectAll"                  , ImGuiInputTextFlags_AutoSelectAll,
+            "EnterReturnsTrue"               , ImGuiInputTextFlags_EnterReturnsTrue,
+            "CallbackCompletion"             , ImGuiInputTextFlags_CallbackCompletion,
+            "CallbackHistory"                , ImGuiInputTextFlags_CallbackHistory,
+            "CallbackAlways"                 , ImGuiInputTextFlags_CallbackAlways,
+            "CallbackCharFilter"             , ImGuiInputTextFlags_CallbackCharFilter,
+            "AllowTabInput"                  , ImGuiInputTextFlags_AllowTabInput,
+            "CtrlEnterForNewLine"            , ImGuiInputTextFlags_CtrlEnterForNewLine,
+            "NoHorizontalScroll"             , ImGuiInputTextFlags_NoHorizontalScroll,
+            "AlwaysInsertMode"               , ImGuiInputTextFlags_AlwaysInsertMode,
+            "ReadOnly"                       , ImGuiInputTextFlags_ReadOnly,
+            "Password"                       , ImGuiInputTextFlags_Password,
+            "NoUndoRedo"                     , ImGuiInputTextFlags_NoUndoRedo,
+            "CharsScientific"                , ImGuiInputTextFlags_CharsScientific,
+            "CallbackResize"                 , ImGuiInputTextFlags_CallbackResize,
+            "CallbackEdit"                   , ImGuiInputTextFlags_CallbackEdit,
+            "Multiline"                      , ImGuiInputTextFlags_Multiline,
+            "NoMarkEdited"                   , ImGuiInputTextFlags_NoMarkEdited
         );
 #pragma endregion InputText Flags
 
 #pragma region Slider Flags
         lua.new_enum("ImGuiSliderFlags",
-            "None"              , ImGuiSliderFlags_None,
-            "ClampOnInput"      , ImGuiSliderFlags_ClampOnInput,
-            "Logarithmic"       , ImGuiSliderFlags_Logarithmic,
-            "NoRoundToFormat"   , ImGuiSliderFlags_NoRoundToFormat,
-            "NoInput"           , ImGuiSliderFlags_NoInput
+            "None"                           , ImGuiSliderFlags_None,
+            "ClampOnInput"                   , ImGuiSliderFlags_ClampOnInput,
+            "Logarithmic"                    , ImGuiSliderFlags_Logarithmic,
+            "NoRoundToFormat"                , ImGuiSliderFlags_NoRoundToFormat,
+            "NoInput"                        , ImGuiSliderFlags_NoInput
         );
 #pragma endregion Slider Flags
 
 #pragma region ColorEdit Flags
         lua.new_enum("ImGuiColorEditFlags",
-            "None"					, ImGuiColorEditFlags_None,
-            "NoAlpha"				, ImGuiColorEditFlags_NoAlpha,
-            "NoPicker"				, ImGuiColorEditFlags_NoPicker,
-            "NoOptions"				, ImGuiColorEditFlags_NoOptions,
-            "NoSmallPreview"		, ImGuiColorEditFlags_NoSmallPreview,
-            "NoInputs"				, ImGuiColorEditFlags_NoInputs,
-            "NoTooltip"				, ImGuiColorEditFlags_NoTooltip,
-            "NoLabel"				, ImGuiColorEditFlags_NoLabel,
-            "NoSidePreview"			, ImGuiColorEditFlags_NoSidePreview,
-            "NoDragDrop"			, ImGuiColorEditFlags_NoDragDrop,
-            "NoBorder"				, ImGuiColorEditFlags_NoBorder,
+            "None"                           , ImGuiColorEditFlags_None,
+            "NoAlpha"                        , ImGuiColorEditFlags_NoAlpha,
+            "NoPicker"                       , ImGuiColorEditFlags_NoPicker,
+            "NoOptions"                      , ImGuiColorEditFlags_NoOptions,
+            "NoSmallPreview"                 , ImGuiColorEditFlags_NoSmallPreview,
+            "NoInputs"                       , ImGuiColorEditFlags_NoInputs,
+            "NoTooltip"                      , ImGuiColorEditFlags_NoTooltip,
+            "NoLabel"                        , ImGuiColorEditFlags_NoLabel,
+            "NoSidePreview"                  , ImGuiColorEditFlags_NoSidePreview,
+            "NoDragDrop"                     , ImGuiColorEditFlags_NoDragDrop,
+            "NoBorder"                       , ImGuiColorEditFlags_NoBorder,
 
-            "AlphaBar"				, ImGuiColorEditFlags_AlphaBar,
-            "AlphaPreview"			, ImGuiColorEditFlags_AlphaPreview,
-            "AlphaPreviewHalf"		, ImGuiColorEditFlags_AlphaPreviewHalf,
-            "HDR"					, ImGuiColorEditFlags_HDR,
-            "DisplayRGB"			, ImGuiColorEditFlags_DisplayRGB,
-            "DisplayHSV"			, ImGuiColorEditFlags_DisplayHSV,
-            "DisplayHex"			, ImGuiColorEditFlags_DisplayHex,
-            "Uint8"					, ImGuiColorEditFlags_Uint8,
-            "Float"					, ImGuiColorEditFlags_Float,
-            "PickerHueBar"			, ImGuiColorEditFlags_PickerHueBar,
-            "PickerHueWheel"		, ImGuiColorEditFlags_PickerHueWheel,
-            "InputRGB"				, ImGuiColorEditFlags_InputRGB,
-            "InputHSV"				, ImGuiColorEditFlags_InputHSV,
+            "AlphaBar"                       , ImGuiColorEditFlags_AlphaBar,
+            "AlphaPreview"                   , ImGuiColorEditFlags_AlphaPreview,
+            "AlphaPreviewHalf"               , ImGuiColorEditFlags_AlphaPreviewHalf,
+            "HDR"                            , ImGuiColorEditFlags_HDR,
+            "DisplayRGB"                     , ImGuiColorEditFlags_DisplayRGB,
+            "DisplayHSV"                     , ImGuiColorEditFlags_DisplayHSV,
+            "DisplayHex"                     , ImGuiColorEditFlags_DisplayHex,
+            "Uint8"                          , ImGuiColorEditFlags_Uint8,
+            "Float"                          , ImGuiColorEditFlags_Float,
+            "PickerHueBar"                   , ImGuiColorEditFlags_PickerHueBar,
+            "PickerHueWheel"                 , ImGuiColorEditFlags_PickerHueWheel,
+            "InputRGB"                       , ImGuiColorEditFlags_InputRGB,
+            "InputHSV"                       , ImGuiColorEditFlags_InputHSV,
 
-            "_OptionsDefault"		, ImGuiColorEditFlags__OptionsDefault,
+            "_OptionsDefault"                , ImGuiColorEditFlags__OptionsDefault,
 
-            "_DisplayMask"			, ImGuiColorEditFlags__DisplayMask,
-            "_DataTypeMask"			, ImGuiColorEditFlags__DataTypeMask,
-            "_PickerMask"			, ImGuiColorEditFlags__PickerMask,
-            "_InputMask"			, ImGuiColorEditFlags__InputMask
+            "_DisplayMask"                   , ImGuiColorEditFlags__DisplayMask,
+            "_DataTypeMask"                  , ImGuiColorEditFlags__DataTypeMask,
+            "_PickerMask"                    , ImGuiColorEditFlags__PickerMask,
+            "_InputMask"                     , ImGuiColorEditFlags__InputMask
         );
 #pragma endregion ColorEdit Flags
 
 #pragma region TreeNode Flags
         lua.new_enum("ImGuiTreeNodeFlags",
-            "None"					, ImGuiTreeNodeFlags_None,
-            "Selected"				, ImGuiTreeNodeFlags_Selected,
-            "Framed"				, ImGuiTreeNodeFlags_Framed,
-            "AllowItemOverlap"		, ImGuiTreeNodeFlags_AllowItemOverlap,
-            "NoTreePushOnOpen"		, ImGuiTreeNodeFlags_NoTreePushOnOpen,
-            "NoAutoOpenOnLog"		, ImGuiTreeNodeFlags_NoAutoOpenOnLog,
-            "DefaultOpen"			, ImGuiTreeNodeFlags_DefaultOpen,
-            "OpenOnDoubleClick"		, ImGuiTreeNodeFlags_OpenOnDoubleClick,
-            "OpenOnArrow"			, ImGuiTreeNodeFlags_OpenOnArrow,
-            "Leaf"					, ImGuiTreeNodeFlags_Leaf,
-            "Bullet"				, ImGuiTreeNodeFlags_Bullet,
-            "FramePadding"			, ImGuiTreeNodeFlags_FramePadding,
-            "SpanAvailWidth"		, ImGuiTreeNodeFlags_SpanAvailWidth,
-            "SpanFullWidth"			, ImGuiTreeNodeFlags_SpanFullWidth,
-            "NavLeftJumpsBackHere"	, ImGuiTreeNodeFlags_NavLeftJumpsBackHere,
-            "CollapsingHeader"		, ImGuiTreeNodeFlags_CollapsingHeader
+            "None"                           , ImGuiTreeNodeFlags_None,
+            "Selected"                       , ImGuiTreeNodeFlags_Selected,
+            "Framed"                         , ImGuiTreeNodeFlags_Framed,
+            "AllowItemOverlap"               , ImGuiTreeNodeFlags_AllowItemOverlap,
+            "NoTreePushOnOpen"               , ImGuiTreeNodeFlags_NoTreePushOnOpen,
+            "NoAutoOpenOnLog"                , ImGuiTreeNodeFlags_NoAutoOpenOnLog,
+            "DefaultOpen"                    , ImGuiTreeNodeFlags_DefaultOpen,
+            "OpenOnDoubleClick"              , ImGuiTreeNodeFlags_OpenOnDoubleClick,
+            "OpenOnArrow"                    , ImGuiTreeNodeFlags_OpenOnArrow,
+            "Leaf"                           , ImGuiTreeNodeFlags_Leaf,
+            "Bullet"                         , ImGuiTreeNodeFlags_Bullet,
+            "FramePadding"                   , ImGuiTreeNodeFlags_FramePadding,
+            "SpanAvailWidth"                 , ImGuiTreeNodeFlags_SpanAvailWidth,
+            "SpanFullWidth"                  , ImGuiTreeNodeFlags_SpanFullWidth,
+            "NavLeftJumpsBackHere"           , ImGuiTreeNodeFlags_NavLeftJumpsBackHere,
+            "CollapsingHeader"               , ImGuiTreeNodeFlags_CollapsingHeader
         );
 #pragma endregion TreeNode Flags
 
 #pragma region Selectable Flags
         lua.new_enum("ImGuiSelectableFlags",
-            "None"					, ImGuiSelectableFlags_None,
-            "DontClosePopups"		, ImGuiSelectableFlags_DontClosePopups,
-            "SpanAllColumns"		, ImGuiSelectableFlags_SpanAllColumns,
-            "AllowDoubleClick"		, ImGuiSelectableFlags_AllowDoubleClick,
-            "Disabled"				, ImGuiSelectableFlags_Disabled,
-            "AllowItemOverlap"		, ImGuiSelectableFlags_AllowItemOverlap
+            "None"                           , ImGuiSelectableFlags_None,
+            "DontClosePopups"                , ImGuiSelectableFlags_DontClosePopups,
+            "SpanAllColumns"                 , ImGuiSelectableFlags_SpanAllColumns,
+            "AllowDoubleClick"               , ImGuiSelectableFlags_AllowDoubleClick,
+            "Disabled"                       , ImGuiSelectableFlags_Disabled,
+            "AllowItemOverlap"               , ImGuiSelectableFlags_AllowItemOverlap
         );
 #pragma endregion Selectable Flags
 
 #pragma region Popup Flags
         lua.new_enum("ImGuiPopupFlags",
-            "None"					, ImGuiPopupFlags_None,
-            "MouseButtonLeft"		, ImGuiPopupFlags_MouseButtonLeft,
-            "MouseButtonRight"		, ImGuiPopupFlags_MouseButtonRight,
-            "MouseButtonMiddle"		, ImGuiPopupFlags_MouseButtonMiddle,
-            "MouseButtonMask_"		, ImGuiPopupFlags_MouseButtonMask_,
-            "MouseButtonDefault_"	, ImGuiPopupFlags_MouseButtonDefault_,
-            "NoOpenOverExistingPopup", ImGuiPopupFlags_NoOpenOverExistingPopup,
-            "NoOpenOverItems"		, ImGuiPopupFlags_NoOpenOverItems,
-            "AnyPopupId"			, ImGuiPopupFlags_AnyPopupId,
-            "AnyPopupLevel"			, ImGuiPopupFlags_AnyPopupLevel,
-            "AnyPopup"				, ImGuiPopupFlags_AnyPopup
+            "None"                           , ImGuiPopupFlags_None,
+            "MouseButtonLeft"                , ImGuiPopupFlags_MouseButtonLeft,
+            "MouseButtonRight"               , ImGuiPopupFlags_MouseButtonRight,
+            "MouseButtonMiddle"              , ImGuiPopupFlags_MouseButtonMiddle,
+            "MouseButtonMask_"               , ImGuiPopupFlags_MouseButtonMask_,
+            "MouseButtonDefault_"            , ImGuiPopupFlags_MouseButtonDefault_,
+            "NoOpenOverExistingPopup"        , ImGuiPopupFlags_NoOpenOverExistingPopup,
+            "NoOpenOverItems"                , ImGuiPopupFlags_NoOpenOverItems,
+            "AnyPopupId"                     , ImGuiPopupFlags_AnyPopupId,
+            "AnyPopupLevel"                  , ImGuiPopupFlags_AnyPopupLevel,
+            "AnyPopup"                       , ImGuiPopupFlags_AnyPopup
         );
 #pragma endregion Popup Flags
 
 #pragma region TabBar Flags
         lua.new_enum("ImGuiTabBarFlags",
-            "None"							, ImGuiTabBarFlags_None,
-            "Reorderable"					, ImGuiTabBarFlags_Reorderable,
-            "AutoSelectNewTabs"				, ImGuiTabBarFlags_AutoSelectNewTabs,
-            "TabListPopupButton"			, ImGuiTabBarFlags_TabListPopupButton,
-            "NoCloseWithMiddleMouseButton"	, ImGuiTabBarFlags_NoCloseWithMiddleMouseButton,
-            "NoTabListScrollingButtons"		, ImGuiTabBarFlags_NoTabListScrollingButtons,
-            "NoTooltip"						, ImGuiTabBarFlags_NoTooltip,
-            "FittingPolicyResizeDown"		, ImGuiTabBarFlags_FittingPolicyResizeDown,
-            "FittingPolicyScroll"			, ImGuiTabBarFlags_FittingPolicyScroll,
-            "FittingPolicyMask_"			, ImGuiTabBarFlags_FittingPolicyMask_,
-            "FittingPolicyDefault_"			, ImGuiTabBarFlags_FittingPolicyDefault_
+            "None"                           , ImGuiTabBarFlags_None,
+            "Reorderable"                    , ImGuiTabBarFlags_Reorderable,
+            "AutoSelectNewTabs"              , ImGuiTabBarFlags_AutoSelectNewTabs,
+            "TabListPopupButton"             , ImGuiTabBarFlags_TabListPopupButton,
+            "NoCloseWithMiddleMouseButton"   , ImGuiTabBarFlags_NoCloseWithMiddleMouseButton,
+            "NoTabListScrollingButtons"      , ImGuiTabBarFlags_NoTabListScrollingButtons,
+            "NoTooltip"                      , ImGuiTabBarFlags_NoTooltip,
+            "FittingPolicyResizeDown"        , ImGuiTabBarFlags_FittingPolicyResizeDown,
+            "FittingPolicyScroll"            , ImGuiTabBarFlags_FittingPolicyScroll,
+            "FittingPolicyMask_"             , ImGuiTabBarFlags_FittingPolicyMask_,
+            "FittingPolicyDefault_"          , ImGuiTabBarFlags_FittingPolicyDefault_
         );
 #pragma endregion TabBar Flags
 
 #pragma region TabItem Flags
         lua.new_enum("ImGuiTabItemFlags",
-            "None"							, ImGuiTabItemFlags_None,
-            "UnsavedDocument"				, ImGuiTabItemFlags_UnsavedDocument,
-            "SetSelected"					, ImGuiTabItemFlags_SetSelected,
-            "NoCloseWithMiddleMouseButton"	, ImGuiTabItemFlags_NoCloseWithMiddleMouseButton,
-            "NoPushId"						, ImGuiTabItemFlags_NoPushId,
-            "NoTooltip"						, ImGuiTabItemFlags_NoTooltip,
-            "NoReorder"                     , ImGuiTabItemFlags_NoReorder,
-            "Leading"                       , ImGuiTabItemFlags_Leading,
-            "Trailing"                      , ImGuiTabItemFlags_Trailing
+            "None"                           , ImGuiTabItemFlags_None,
+            "UnsavedDocument"                , ImGuiTabItemFlags_UnsavedDocument,
+            "SetSelected"                    , ImGuiTabItemFlags_SetSelected,
+            "NoCloseWithMiddleMouseButton"   , ImGuiTabItemFlags_NoCloseWithMiddleMouseButton,
+            "NoPushId"                       , ImGuiTabItemFlags_NoPushId,
+            "NoTooltip"                      , ImGuiTabItemFlags_NoTooltip,
+            "NoReorder"                      , ImGuiTabItemFlags_NoReorder,
+            "Leading"                        , ImGuiTabItemFlags_Leading,
+            "Trailing"                       , ImGuiTabItemFlags_Trailing
         );
 #pragma endregion TabItem Flags
 
 #ifdef SOL_IMGUI_ENABLE_INPUT_FUNCTIONS
 #pragma region MouseButton
         lua.new_enum("ImGuiMouseButton",
-            "ImGuiMouseButton_Left"			, ImGuiMouseButton_Left,
-            "ImGuiMouseButton_Right"		, ImGuiMouseButton_Right,
-            "ImGuiMouseButton_Middle"		, ImGuiMouseButton_Middle,
-            "ImGuiMouseButton_COUNT"		, ImGuiMouseButton_COUNT
+            "ImGuiMouseButton_Left"          , ImGuiMouseButton_Left,
+            "ImGuiMouseButton_Right"         , ImGuiMouseButton_Right,
+            "ImGuiMouseButton_Middle"        , ImGuiMouseButton_Middle,
+            "ImGuiMouseButton_COUNT"         , ImGuiMouseButton_COUNT
         );
 #pragma endregion MouseButton
 
 #pragma region Key
         lua.new_enum("ImGuiKey",
-            "Tab"							, ImGuiKey_Tab,
-            "LeftArrow"						, ImGuiKey_LeftArrow,
-            "RightArrow"					, ImGuiKey_RightArrow,
-            "UpArrow"						, ImGuiKey_UpArrow,
-            "DownArrow"						, ImGuiKey_DownArrow,
-            "PageUp"						, ImGuiKey_PageUp,
-            "PageDown"						, ImGuiKey_PageDown,
-            "Home"							, ImGuiKey_Home,
-            "End"							, ImGuiKey_End,
-            "Insert"						, ImGuiKey_Insert,
-            "Delete"						, ImGuiKey_Delete,
-            "Backspace"						, ImGuiKey_Backspace,
-            "Space"							, ImGuiKey_Space,
-            "Enter"							, ImGuiKey_Enter,
-            "Escape"						, ImGuiKey_Escape,
-            "KeyPadEnter"					, ImGuiKey_KeyPadEnter,
-            "A"								, ImGuiKey_A,
-            "C"								, ImGuiKey_C,
-            "V"								, ImGuiKey_V,
-            "X"								, ImGuiKey_X,
-            "Y"								, ImGuiKey_Y,
-            "Z"								, ImGuiKey_Z,
-            "COUNT"							, ImGuiKey_COUNT
+            "Tab"                            , ImGuiKey_Tab,
+            "LeftArrow"                      , ImGuiKey_LeftArrow,
+            "RightArrow"                     , ImGuiKey_RightArrow,
+            "UpArrow"                        , ImGuiKey_UpArrow,
+            "DownArrow"                      , ImGuiKey_DownArrow,
+            "PageUp"                         , ImGuiKey_PageUp,
+            "PageDown"                       , ImGuiKey_PageDown,
+            "Home"                           , ImGuiKey_Home,
+            "End"                            , ImGuiKey_End,
+            "Insert"                         , ImGuiKey_Insert,
+            "Delete"                         , ImGuiKey_Delete,
+            "Backspace"                      , ImGuiKey_Backspace,
+            "Space"                          , ImGuiKey_Space,
+            "Enter"                          , ImGuiKey_Enter,
+            "Escape"                         , ImGuiKey_Escape,
+            "KeyPadEnter"                    , ImGuiKey_KeyPadEnter,
+            "A"                              , ImGuiKey_A,
+            "C"                              , ImGuiKey_C,
+            "V"                              , ImGuiKey_V,
+            "X"                              , ImGuiKey_X,
+            "Y"                              , ImGuiKey_Y,
+            "Z"                              , ImGuiKey_Z,
+            "COUNT"                          , ImGuiKey_COUNT
         );
 #pragma endregion Key
 
 #pragma region MouseCursor
         lua.new_enum("ImGuiMouseCursor",
-            "None"							, ImGuiMouseCursor_None,
-            "Arrow"							, ImGuiMouseCursor_Arrow,
-            "TextInput"						, ImGuiMouseCursor_TextInput,
-            "ResizeAll"						, ImGuiMouseCursor_ResizeAll,
-            "ResizeNS"						, ImGuiMouseCursor_ResizeNS,
-            "ResizeEW"						, ImGuiMouseCursor_ResizeEW,
-            "ResizeNESW"					, ImGuiMouseCursor_ResizeNESW,
-            "ResizeNWSE"					, ImGuiMouseCursor_ResizeNWSE,
-            "Hand"							, ImGuiMouseCursor_Hand,
-            "NotAllowed"					, ImGuiMouseCursor_NotAllowed,
-            "COUNT"							, ImGuiMouseCursor_COUNT
+            "None"                          , ImGuiMouseCursor_None,
+            "Arrow"                         , ImGuiMouseCursor_Arrow,
+            "TextInput"                     , ImGuiMouseCursor_TextInput,
+            "ResizeAll"                     , ImGuiMouseCursor_ResizeAll,
+            "ResizeNS"                      , ImGuiMouseCursor_ResizeNS,
+            "ResizeEW"                      , ImGuiMouseCursor_ResizeEW,
+            "ResizeNESW"                    , ImGuiMouseCursor_ResizeNESW,
+            "ResizeNWSE"                    , ImGuiMouseCursor_ResizeNWSE,
+            "Hand"                          , ImGuiMouseCursor_Hand,
+            "NotAllowed"                    , ImGuiMouseCursor_NotAllowed,
+            "COUNT"                         , ImGuiMouseCursor_COUNT
         );
 #pragma endregion MouseCursor
 #endif // SOL_IMGUI_ENABLE_INPUT_FUNCTIONS
@@ -2027,112 +2027,112 @@ namespace sol_ImGui
         sol::table ImGui = lua.create_named_table("ImGui");
 
 #pragma region Windows
-        ImGui.set_function("Begin"							, sol::overload(
+        ImGui.set_function("Begin"              , sol::overload(
                                                                 sol::resolve<bool(const std::string&)>(Begin),
                                                                 sol::resolve<std::tuple<bool, bool>(const std::string&, bool)>(Begin),
                                                                 sol::resolve<std::tuple<bool, bool>(const std::string&, bool, int)>(Begin)
                                                             ));
-        ImGui.set_function("End"							, End);
+        ImGui.set_function("End"              , End);
 #pragma endregion Windows
 
 #pragma region Child Windows
-        ImGui.set_function("BeginChild"						, sol::overload(
+        ImGui.set_function("BeginChild"            , sol::overload(
                                                                 sol::resolve<bool(const std::string&)>(BeginChild),
                                                                 sol::resolve<bool(const std::string&, float)>(BeginChild),
                                                                 sol::resolve<bool(const std::string&, float, float)>(BeginChild),
                                                                 sol::resolve<bool(const std::string&, float, float, bool)>(BeginChild),
                                                                 sol::resolve<bool(const std::string&, float, float, bool, int)>(BeginChild)
                                                             ));
-        ImGui.set_function("EndChild"						, EndChild);
+        ImGui.set_function("EndChild"            , EndChild);
 #pragma endregion Child Windows
 
 #pragma region Window Utilities
-        ImGui.set_function("IsWindowAppearing"				, IsWindowAppearing);
-        ImGui.set_function("IsWindowCollapsed"				, IsWindowCollapsed);
-        ImGui.set_function("IsWindowFocused"				, sol::overload(
+        ImGui.set_function("IsWindowAppearing"      , IsWindowAppearing);
+        ImGui.set_function("IsWindowCollapsed"      , IsWindowCollapsed);
+        ImGui.set_function("IsWindowFocused"        , sol::overload(
                                                                 sol::resolve<bool()>(IsWindowFocused),
                                                                 sol::resolve<bool(int)>(IsWindowFocused)
                                                             ));
-        ImGui.set_function("IsWindowHovered"				, sol::overload(
+        ImGui.set_function("IsWindowHovered"        , sol::overload(
                                                                 sol::resolve<bool()>(IsWindowHovered),
                                                                 sol::resolve<bool(int)>(IsWindowHovered)
                                                             ));
-        ImGui.set_function("GetWindowPos"					, GetWindowPos);
-        ImGui.set_function("GetWindowSize"					, GetWindowSize);
-        ImGui.set_function("GetWindowWidth"					, GetWindowWidth);
-        ImGui.set_function("GetWindowHeight"				, GetWindowHeight);
+        ImGui.set_function("GetWindowPos"           , GetWindowPos);
+        ImGui.set_function("GetWindowSize"          , GetWindowSize);
+        ImGui.set_function("GetWindowWidth"         , GetWindowWidth);
+        ImGui.set_function("GetWindowHeight"        , GetWindowHeight);
 
         // Prefer  SetNext...
-        ImGui.set_function("SetNextWindowPos"				, sol::overload(
+        ImGui.set_function("SetNextWindowPos"        , sol::overload(
                                                                 sol::resolve<void(float, float)>(SetNextWindowPos),
                                                                 sol::resolve<void(float, float, int)>(SetNextWindowPos),
                                                                 sol::resolve<void(float, float, int, float, float)>(SetNextWindowPos)
                                                             ));
-        ImGui.set_function("SetNextWindowSize"				, sol::overload(
+        ImGui.set_function("SetNextWindowSize"        , sol::overload(
                                                                 sol::resolve<void(float, float)>(SetNextWindowSize),
                                                                 sol::resolve<void(float, float, int)>(SetNextWindowSize)
                                                             ));
-        ImGui.set_function("SetNextWindowSizeConstraints"	, SetNextWindowSizeConstraints);
-        ImGui.set_function("SetNextWindowContentSize"		, SetNextWindowContentSize);
-        ImGui.set_function("SetNextWindowCollapsed"			, sol::overload(
+        ImGui.set_function("SetNextWindowSizeConstraints"  , SetNextWindowSizeConstraints);
+        ImGui.set_function("SetNextWindowContentSize"    , SetNextWindowContentSize);
+        ImGui.set_function("SetNextWindowCollapsed"      , sol::overload(
                                                                 sol::resolve<void(bool)>(SetNextWindowCollapsed),
                                                                 sol::resolve<void(bool, int)>(SetNextWindowCollapsed)
                                                             ));
-        ImGui.set_function("SetNextWindowFocus"				, SetNextWindowFocus);
-        ImGui.set_function("SetNextWindowBgAlpha"			, SetNextWindowBgAlpha);
-        ImGui.set_function("SetWindowPos"					, sol::overload(
+        ImGui.set_function("SetNextWindowFocus"        , SetNextWindowFocus);
+        ImGui.set_function("SetNextWindowBgAlpha"      , SetNextWindowBgAlpha);
+        ImGui.set_function("SetWindowPos"          , sol::overload(
                                                                 sol::resolve<void(float, float)>(SetWindowPos),
                                                                 sol::resolve<void(float, float, int)>(SetWindowPos),
                                                                 sol::resolve<void(const std::string&, float, float)>(SetWindowPos),
                                                                 sol::resolve<void(const std::string&, float, float, int)>(SetWindowPos)
                                                             ));
-        ImGui.set_function("SetWindowSize"					, sol::overload(
+        ImGui.set_function("SetWindowSize"          , sol::overload(
                                                                 sol::resolve<void(float, float)>(SetWindowSize),
                                                                 sol::resolve<void(float, float, int)>(SetWindowSize),
                                                                 sol::resolve<void(const std::string&, float, float)>(SetWindowSize),
                                                                 sol::resolve<void(const std::string&, float, float, int)>(SetWindowSize)
                                                             ));
-        ImGui.set_function("SetWindowCollapsed"				, sol::overload(
+        ImGui.set_function("SetWindowCollapsed"        , sol::overload(
                                                                 sol::resolve<void(bool)>(SetWindowCollapsed),
                                                                 sol::resolve<void(bool, int)>(SetWindowCollapsed),
                                                                 sol::resolve<void(const std::string&, bool)>(SetWindowCollapsed),
                                                                 sol::resolve<void(const std::string&, bool, int)>(SetWindowCollapsed)
                                                             ));
-        ImGui.set_function("SetWindowFocus"					, sol::overload(
+        ImGui.set_function("SetWindowFocus"          , sol::overload(
                                                                 sol::resolve<void()>(SetWindowFocus),
                                                                 sol::resolve<void(const std::string&)>(SetWindowFocus)
                                                             ));
-        ImGui.set_function("SetWindowFontScale"				, SetWindowFontScale);
+        ImGui.set_function("SetWindowFontScale"        , SetWindowFontScale);
 #pragma endregion Window Utilities
 
 #pragma region Content Region
-        ImGui.set_function("GetContentRegionMax"			, GetContentRegionMax);
-        ImGui.set_function("GetContentRegionAvail"			, GetContentRegionAvail);
-        ImGui.set_function("GetWindowContentRegionMin"		, GetWindowContentRegionMin);
-        ImGui.set_function("GetWindowContentRegionMax"		, GetWindowContentRegionMax);
-        ImGui.set_function("GetWindowContentRegionWidth"	, GetWindowContentRegionWidth);
+        ImGui.set_function("GetContentRegionMax"          , GetContentRegionMax);
+        ImGui.set_function("GetContentRegionAvail"        , GetContentRegionAvail);
+        ImGui.set_function("GetWindowContentRegionMin"    , GetWindowContentRegionMin);
+        ImGui.set_function("GetWindowContentRegionMax"    , GetWindowContentRegionMax);
+        ImGui.set_function("GetWindowContentRegionWidth"  , GetWindowContentRegionWidth);
 #pragma endregion Content Region
 
 #pragma region Windows Scrolling
-        ImGui.set_function("GetScrollX"						, GetScrollX);
-        ImGui.set_function("GetScrollY"						, GetScrollY);
-        ImGui.set_function("GetScrollMaxX"					, GetScrollMaxX);
-        ImGui.set_function("GetScrollMaxY"					, GetScrollMaxY);
-        ImGui.set_function("SetScrollX"						, SetScrollX);
-        ImGui.set_function("SetScrollY"						, SetScrollY);
-        ImGui.set_function("SetScrollHereX"					, sol::overload(
+        ImGui.set_function("GetScrollX"              , GetScrollX);
+        ImGui.set_function("GetScrollY"              , GetScrollY);
+        ImGui.set_function("GetScrollMaxX"           , GetScrollMaxX);
+        ImGui.set_function("GetScrollMaxY"           , GetScrollMaxY);
+        ImGui.set_function("SetScrollX"              , SetScrollX);
+        ImGui.set_function("SetScrollY"              , SetScrollY);
+        ImGui.set_function("SetScrollHereX"          , sol::overload(
                                                                 sol::resolve<void()>(SetScrollHereX),
                                                                 sol::resolve<void(float)>(SetScrollHereX)
                                                             ));
-        ImGui.set_function("SetScrollHereY"					, sol::overload(
+        ImGui.set_function("SetScrollHereY"          , sol::overload(
                                                                 sol::resolve<void()>(SetScrollHereY),
                                                                 sol::resolve<void(float)>(SetScrollHereY)
                                                             ));
-        ImGui.set_function("SetScrollFromPosX"				, sol::overload(
+        ImGui.set_function("SetScrollFromPosX"        , sol::overload(
                                                                 sol::resolve<void(float)>(SetScrollFromPosX),
                                                                 sol::resolve<void(float, float)>(SetScrollFromPosX)
                                                             ));
-        ImGui.set_function("SetScrollFromPosY"				, sol::overload(
+        ImGui.set_function("SetScrollFromPosY"        , sol::overload(
                                                                 sol::resolve<void(float)>(SetScrollFromPosY),
                                                                 sol::resolve<void(float, float)>(SetScrollFromPosY)
                                                             ));
@@ -2140,14 +2140,14 @@ namespace sol_ImGui
 
 #pragma region Parameters stacks (shared)
 #ifdef SOL_IMGUI_ENABLE_FONT_MANIPULATORS
-        ImGui.set_function("PushFont"						, PushFont);
-        ImGui.set_function("PopFont"						, PopFont);
+        ImGui.set_function("PushFont"            , PushFont);
+        ImGui.set_function("PopFont"             , PopFont);
 #endif // SOL_IMGUI_ENABLE_FONT_MANIPULATORS
-        ImGui.set_function("PushStyleColor"					, sol::overload(
+        ImGui.set_function("PushStyleColor"         , sol::overload(
                                                                 sol::resolve<void(int, int)>(PushStyleColor),
                                                                 sol::resolve<void(int, float, float, float, float)>(PushStyleColor)
                                                             ));
-        ImGui.set_function("PopStyleColor"					, sol::overload(
+        ImGui.set_function("PopStyleColor"          , sol::overload(
                                                                 sol::resolve<void()>(PopStyleColor),
                                                                 sol::resolve<void(int)>(PopStyleColor)
                                                             ));
@@ -2155,17 +2155,17 @@ namespace sol_ImGui
                                                                 sol::resolve<void(int, float)>(PushStyleVar),
                                                                 sol::resolve<void(int, float, float)>(PushStyleVar)
                                                             ));
-        ImGui.set_function("PopStyleVar"					, sol::overload(
+        ImGui.set_function("PopStyleVar"            , sol::overload(
                                                                 sol::resolve<void()>(PopStyleVar),
                                                                 sol::resolve<void(int)>(PopStyleVar)
                                                             ));
-        ImGui.set_function("GetStyleColorVec4"				, GetStyleColorVec4);
+        ImGui.set_function("GetStyleColorVec4"      , GetStyleColorVec4);
 #ifdef SOL_IMGUI_ENABLE_FONT_MANIPULATORS
-        ImGui.set_function("GetFont"						, GetFont);
+        ImGui.set_function("GetFont"                , GetFont);
 #endif // SOL_IMGUI_ENABLE_FONT_MANIPULATORS
-        ImGui.set_function("GetFontSize"					, GetFontSize);
-        ImGui.set_function("GetFontTexUvWhitePixel"			, GetFontTexUvWhitePixel);
-        ImGui.set_function("GetColorU32"					, sol::overload(
+        ImGui.set_function("GetFontSize"            , GetFontSize);
+        ImGui.set_function("GetFontTexUvWhitePixel" , GetFontTexUvWhitePixel);
+        ImGui.set_function("GetColorU32"            , sol::overload(
                                                                 sol::resolve<int(int, float)>(GetColorU32),
                                                                 sol::resolve<int(float, float, float, float)>(GetColorU32),
                                                                 sol::resolve<int(int)>(GetColorU32)
@@ -2173,110 +2173,110 @@ namespace sol_ImGui
 #pragma endregion Parameters stacks (shared)
 
 #pragma region Parameters stacks (current window)
-        ImGui.set_function("PushItemWidth"					, PushItemWidth);
-        ImGui.set_function("PopItemWidth"					, PopItemWidth);
-        ImGui.set_function("SetNextItemWidth"				, SetNextItemWidth);
-        ImGui.set_function("CalcItemWidth"					, CalcItemWidth);
-        ImGui.set_function("PushTextWrapPos"				, sol::overload(
+        ImGui.set_function("PushItemWidth"           , PushItemWidth);
+        ImGui.set_function("PopItemWidth"            , PopItemWidth);
+        ImGui.set_function("SetNextItemWidth"        , SetNextItemWidth);
+        ImGui.set_function("CalcItemWidth"           , CalcItemWidth);
+        ImGui.set_function("PushTextWrapPos"         , sol::overload(
                                                                     sol::resolve<void()>(PushTextWrapPos),
                                                                     sol::resolve<void(float)>(PushTextWrapPos)
                                                             ));
-        ImGui.set_function("PopTextWrapPos"					, PopTextWrapPos);
-        ImGui.set_function("PushAllowKeyboardFocus"			, PushAllowKeyboardFocus);
-        ImGui.set_function("PopAllowKeyboardFocus"			, PopAllowKeyboardFocus);
-        ImGui.set_function("PushButtonRepeat"				, PushButtonRepeat);
-        ImGui.set_function("PopButtonRepeat"				, PopButtonRepeat);
+        ImGui.set_function("PopTextWrapPos"          , PopTextWrapPos);
+        ImGui.set_function("PushAllowKeyboardFocus"  , PushAllowKeyboardFocus);
+        ImGui.set_function("PopAllowKeyboardFocus"   , PopAllowKeyboardFocus);
+        ImGui.set_function("PushButtonRepeat"        , PushButtonRepeat);
+        ImGui.set_function("PopButtonRepeat"         , PopButtonRepeat);
 #pragma endregion Parameters stacks (current window)
 
 #pragma region Cursor / Layout
-        ImGui.set_function("Separator"						, Separator);
-        ImGui.set_function("SameLine"						, sol::overload(
+        ImGui.set_function("Separator"               , Separator);
+        ImGui.set_function("SameLine"                , sol::overload(
                                                                 sol::resolve<void()>(SameLine),
                                                                 sol::resolve<void(float)>(SameLine)
                                                             ));
-        ImGui.set_function("NewLine"						, NewLine);
-        ImGui.set_function("Spacing"						, Spacing);
-        ImGui.set_function("Dummy"							, Dummy);
-        ImGui.set_function("Indent"							, sol::overload(
+        ImGui.set_function("NewLine"                 , NewLine);
+        ImGui.set_function("Spacing"                 , Spacing);
+        ImGui.set_function("Dummy"                   , Dummy);
+        ImGui.set_function("Indent"                  , sol::overload(
                                                                 sol::resolve<void()>(Indent),
                                                                 sol::resolve<void(float)>(Indent)
                                                             ));
-        ImGui.set_function("Unindent"						, sol::overload(
+        ImGui.set_function("Unindent"                , sol::overload(
                                                                 sol::resolve<void()>(Unindent),
                                                                 sol::resolve<void(float)>(Unindent)
                                                             ));
-        ImGui.set_function("BeginGroup"						, BeginGroup);
-        ImGui.set_function("EndGroup"						, EndGroup);
-        ImGui.set_function("GetCursorPos"					, GetCursorPos);
-        ImGui.set_function("GetCursorPosX"					, GetCursorPosX);
-        ImGui.set_function("GetCursorPosY"					, GetCursorPosY);
-        ImGui.set_function("SetCursorPos"					, SetCursorPos);
-        ImGui.set_function("SetCursorPosX"					, SetCursorPosX);
-        ImGui.set_function("SetCursorPosY"					, SetCursorPosY);
-        ImGui.set_function("GetCursorStartPos"				, GetCursorStartPos);
-        ImGui.set_function("GetCursorScreenPos"				, GetCursorScreenPos);
-        ImGui.set_function("SetCursorScreenPos"				, SetCursorScreenPos);
-        ImGui.set_function("AlignTextToFramePadding"		, AlignTextToFramePadding);
-        ImGui.set_function("GetTextLineHeight"				, GetTextLineHeight);
-        ImGui.set_function("GetTextLineHeightWithSpacing"	, GetTextLineHeightWithSpacing);
-        ImGui.set_function("GetFrameHeight"					, GetFrameHeight);
-        ImGui.set_function("GetFrameHeightWithSpacing"		, GetFrameHeightWithSpacing);
+        ImGui.set_function("BeginGroup"                   , BeginGroup);
+        ImGui.set_function("EndGroup"                     , EndGroup);
+        ImGui.set_function("GetCursorPos"                 , GetCursorPos);
+        ImGui.set_function("GetCursorPosX"                , GetCursorPosX);
+        ImGui.set_function("GetCursorPosY"                , GetCursorPosY);
+        ImGui.set_function("SetCursorPos"                 , SetCursorPos);
+        ImGui.set_function("SetCursorPosX"                , SetCursorPosX);
+        ImGui.set_function("SetCursorPosY"                , SetCursorPosY);
+        ImGui.set_function("GetCursorStartPos"            , GetCursorStartPos);
+        ImGui.set_function("GetCursorScreenPos"           , GetCursorScreenPos);
+        ImGui.set_function("SetCursorScreenPos"           , SetCursorScreenPos);
+        ImGui.set_function("AlignTextToFramePadding"      , AlignTextToFramePadding);
+        ImGui.set_function("GetTextLineHeight"            , GetTextLineHeight);
+        ImGui.set_function("GetTextLineHeightWithSpacing" , GetTextLineHeightWithSpacing);
+        ImGui.set_function("GetFrameHeight"               , GetFrameHeight);
+        ImGui.set_function("GetFrameHeightWithSpacing"    , GetFrameHeightWithSpacing);
 #pragma endregion Cursor / Layout
 
 #pragma region ID stack / scopes
-        ImGui.set_function("PushID"							, sol::overload(
+        ImGui.set_function("PushID"              , sol::overload(
                                                                 sol::resolve<void(const std::string&)>(PushID),
                                                                 sol::resolve<void(const std::string&, const std::string&)>(PushID),
                                                                 sol::resolve<void(int)>(PushID)
                                                             ));
-        ImGui.set_function("PopID"							, PopID);
-        ImGui.set_function("GetID"							, sol::overload(
+        ImGui.set_function("PopID"              , PopID);
+        ImGui.set_function("GetID"              , sol::overload(
                                                                 sol::resolve<int(const std::string&)>(GetID),
                                                                 sol::resolve<int(const std::string&, const std::string&)>(GetID)
                                                             ));
 #pragma endregion ID stack / scopes
 
 #pragma region Widgets: Text
-        ImGui.set_function("TextUnformatted"				, sol::overload(
+        ImGui.set_function("TextUnformatted"        , sol::overload(
                                                                 sol::resolve<void(const std::string&)>(TextUnformatted),
                                                                 sol::resolve<void(const std::string&, const std::string&)>(TextUnformatted)
                                                             ));
-        ImGui.set_function("Text"							, Text);
-        ImGui.set_function("TextColored"					, TextColored);
-        ImGui.set_function("TextDisabled"					, TextDisabled);
-        ImGui.set_function("TextWrapped"					, TextWrapped);
-        ImGui.set_function("LabelText"						, LabelText);
-        ImGui.set_function("BulletText"						, BulletText);
+        ImGui.set_function("Text"                 , Text);
+        ImGui.set_function("TextColored"          , TextColored);
+        ImGui.set_function("TextDisabled"         , TextDisabled);
+        ImGui.set_function("TextWrapped"          , TextWrapped);
+        ImGui.set_function("LabelText"            , LabelText);
+        ImGui.set_function("BulletText"           , BulletText);
 #pragma endregion Widgets: Text
 
 #pragma region Widgets: Main
-        ImGui.set_function("Button"							, sol::overload(
+        ImGui.set_function("Button"              , sol::overload(
                                                                 sol::resolve<bool(const std::string&)>(Button),
                                                                 sol::resolve<bool(const std::string&, float, float)>(Button)
                                                             ));
-        ImGui.set_function("SmallButton"					, SmallButton);
-        ImGui.set_function("InvisibleButton"				, InvisibleButton);
-        ImGui.set_function("ArrowButton"					, ArrowButton);
-        ImGui.set_function("Checkbox"						, Checkbox);
-        ImGui.set_function("RadioButton"					, sol::overload(
+        ImGui.set_function("SmallButton"            , SmallButton);
+        ImGui.set_function("InvisibleButton"        , InvisibleButton);
+        ImGui.set_function("ArrowButton"            , ArrowButton);
+        ImGui.set_function("Checkbox"               , Checkbox);
+        ImGui.set_function("RadioButton"            , sol::overload(
                                                                 sol::resolve<bool(const std::string&, bool)>(RadioButton),
                                                                 sol::resolve<std::tuple<int, bool>(const std::string&, int, int)>(RadioButton)
                                                             ));
-        ImGui.set_function("ProgressBar"					, sol::overload(
+        ImGui.set_function("ProgressBar"          , sol::overload(
                                                                 sol::resolve<void(float)>(ProgressBar),
                                                                 sol::resolve<void(float, float, float)>(ProgressBar),
                                                                 sol::resolve<void(float, float, float, const std::string&)>(ProgressBar)
                                                             ));
-        ImGui.set_function("Bullet"							, Bullet);
+        ImGui.set_function("Bullet"              , Bullet);
 #pragma endregion Widgets: Main
 
 #pragma region Widgets: Combo Box
-        ImGui.set_function("BeginCombo"						, sol::overload(
+        ImGui.set_function("BeginCombo"          , sol::overload(
                                                                 sol::resolve<bool(const std::string&, const std::string&)>(BeginCombo),
                                                                 sol::resolve<bool(const std::string&, const std::string&, int)>(BeginCombo)
                                                             ));
-        ImGui.set_function("EndCombo"						, EndCombo);
-        ImGui.set_function("Combo"							, sol::overload(
+        ImGui.set_function("EndCombo"            , EndCombo);
+        ImGui.set_function("Combo"               , sol::overload(
                                                                 sol::resolve<std::tuple<int, bool>(const std::string&, int, const sol::table&, int)>(Combo),
                                                                 sol::resolve<std::tuple<int, bool>(const std::string&, int, const sol::table&, int, int)>(Combo),
                                                                 sol::resolve<std::tuple<int, bool>(const std::string&, int, const std::string&)>(Combo),
@@ -2285,7 +2285,7 @@ namespace sol_ImGui
 #pragma endregion Widgets: Combo Box
 
 #pragma region Widgets: Drags
-        ImGui.set_function("DragFloat"						, sol::overload(
+        ImGui.set_function("DragFloat"            , sol::overload(
                                                                 sol::resolve<std::tuple<float, bool>(const std::string&, float)>(DragFloat),
                                                                 sol::resolve<std::tuple<float, bool>(const std::string&, float, float)>(DragFloat),
                                                                 sol::resolve<std::tuple<float, bool>(const std::string&, float, float, float)>(DragFloat),
@@ -2293,7 +2293,7 @@ namespace sol_ImGui
                                                                 sol::resolve<std::tuple<float, bool>(const std::string&, float, float, float, float, const std::string&)>(DragFloat),
                                                                 sol::resolve<std::tuple<float, bool>(const std::string&, float, float, float, float, const std::string&, int)>(DragFloat)
                                                             ));
-        ImGui.set_function("DragFloat2"						, sol::overload(
+        ImGui.set_function("DragFloat2"            , sol::overload(
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&)>(DragFloat2),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float)>(DragFloat2),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float)>(DragFloat2),
@@ -2301,7 +2301,7 @@ namespace sol_ImGui
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float, float, const std::string&)>(DragFloat2),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float, float, const std::string&, int)>(DragFloat2)
                                                             ));
-        ImGui.set_function("DragFloat3"						, sol::overload(
+        ImGui.set_function("DragFloat3"            , sol::overload(
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&)>(DragFloat3),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float)>(DragFloat3),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float)>(DragFloat3),
@@ -2309,7 +2309,7 @@ namespace sol_ImGui
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float, float, const std::string&)>(DragFloat3),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float, float, const std::string&, int)>(DragFloat3)
                                                             ));
-        ImGui.set_function("DragFloat4"						, sol::overload(
+        ImGui.set_function("DragFloat4"            , sol::overload(
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&)>(DragFloat4),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float)>(DragFloat4),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float)>(DragFloat4),
@@ -2317,28 +2317,28 @@ namespace sol_ImGui
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float, float, const std::string&)>(DragFloat4),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float, float, const std::string&, int)>(DragFloat4)
                                                             ));
-        ImGui.set_function("DragInt"						, sol::overload(
+        ImGui.set_function("DragInt"            , sol::overload(
                                                                 sol::resolve<std::tuple<int, bool>(const std::string&, int)>(DragInt),
                                                                 sol::resolve<std::tuple<int, bool>(const std::string&, int, float)>(DragInt),
                                                                 sol::resolve<std::tuple<int, bool>(const std::string&, int, float, int)>(DragInt),
                                                                 sol::resolve<std::tuple<int, bool>(const std::string&, int, float, int, int)>(DragInt),
                                                                 sol::resolve<std::tuple<int, bool>(const std::string&, int, float, int, int, const std::string&)>(DragInt)
                                                             ));
-        ImGui.set_function("DragInt2"						, sol::overload(
+        ImGui.set_function("DragInt2"            , sol::overload(
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&)>(DragInt2),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, float)>(DragInt2),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, float, int)>(DragInt2),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, float, int, int)>(DragInt2),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, float, int, int, const std::string&)>(DragInt2)
                                                             ));
-        ImGui.set_function("DragInt3"						, sol::overload(
+        ImGui.set_function("DragInt3"            , sol::overload(
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&)>(DragInt3),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, float)>(DragInt3),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, float, int)>(DragInt3),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, float, int, int)>(DragInt3),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, float, int, int, const std::string&)>(DragInt3)
                                                             ));
-        ImGui.set_function("DragInt4"						, sol::overload(
+        ImGui.set_function("DragInt4"            , sol::overload(
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&)>(DragInt4),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, float)>(DragInt4),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, float, int)>(DragInt4),
@@ -2348,115 +2348,115 @@ namespace sol_ImGui
 #pragma endregion Widgets: Drags
 
 #pragma region Widgets: Sliders
-        ImGui.set_function("SliderFloat"					, sol::overload(
+        ImGui.set_function("SliderFloat"          , sol::overload(
                                                                 sol::resolve<std::tuple<float, bool>(const std::string&, float, float, float)>(SliderFloat),
                                                                 sol::resolve<std::tuple<float, bool>(const std::string&, float, float, float, const std::string&)>(SliderFloat),
                                                                 sol::resolve<std::tuple<float, bool>(const std::string&, float, float, float, const std::string&, int)>(SliderFloat)
                                                             ));
-        ImGui.set_function("SliderFloat2"					, sol::overload(
+        ImGui.set_function("SliderFloat2"          , sol::overload(
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float)>(SliderFloat2),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float, const std::string&)>(SliderFloat2),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float, const std::string&, int)>(SliderFloat2)
                                                             ));
-        ImGui.set_function("SliderFloat3"					, sol::overload(
+        ImGui.set_function("SliderFloat3"          , sol::overload(
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float)>(SliderFloat3),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float, const std::string&)>(SliderFloat3),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float, const std::string&, int)>(SliderFloat3)
                                                             ));
-        ImGui.set_function("SliderFloat4"					, sol::overload(
+        ImGui.set_function("SliderFloat4"          , sol::overload(
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float)>(SliderFloat4),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float, const std::string&)>(SliderFloat4),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, float, float, const std::string&, int)>(SliderFloat4)
                                                             ));
-        ImGui.set_function("SliderAngle"					, sol::overload(
+        ImGui.set_function("SliderAngle"          , sol::overload(
                                                                 sol::resolve<std::tuple<float, bool>(const std::string&, float)>(SliderAngle),
                                                                 sol::resolve<std::tuple<float, bool>(const std::string&, float, float)>(SliderAngle),
                                                                 sol::resolve<std::tuple<float, bool>(const std::string&, float, float, float)>(SliderAngle),
                                                                 sol::resolve<std::tuple<float, bool>(const std::string&, float, float, float, const std::string&)>(SliderAngle)
                                                             ));
-        ImGui.set_function("SliderInt"						, sol::overload(
+        ImGui.set_function("SliderInt"            , sol::overload(
                                                                 sol::resolve<std::tuple<int, bool>(const std::string&, int, int, int)>(SliderInt),
                                                                 sol::resolve<std::tuple<int, bool>(const std::string&, int, int, int, const std::string&)>(SliderInt)
                                                             ));
-        ImGui.set_function("SliderInt2"						, sol::overload(
+        ImGui.set_function("SliderInt2"            , sol::overload(
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, int, int)>(SliderInt2),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, int, int, const std::string&)>(SliderInt2)
                                                             ));
-        ImGui.set_function("SliderInt3"						, sol::overload(
+        ImGui.set_function("SliderInt3"            , sol::overload(
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, int, int)>(SliderInt3),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, int, int, const std::string&)>(SliderInt3)
                                                             ));
-        ImGui.set_function("SliderInt4"						, sol::overload(
+        ImGui.set_function("SliderInt4"            , sol::overload(
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, int, int)>(SliderInt4),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, int, int, const std::string&)>(SliderInt4)
                                                             ));
-        ImGui.set_function("VSliderFloat"					, sol::overload(
+        ImGui.set_function("VSliderFloat"          , sol::overload(
                                                                 sol::resolve<std::tuple<float, bool>(const std::string&, float, float, float, float, float)>(VSliderFloat),
                                                                 sol::resolve<std::tuple<float, bool>(const std::string&, float, float, float, float, float, const std::string&)>(VSliderFloat),
                                                                 sol::resolve<std::tuple<float, bool>(const std::string&, float, float, float, float, float, const std::string&, int)>(VSliderFloat)
                                                             ));
-        ImGui.set_function("VSliderInt"						, sol::overload(
+        ImGui.set_function("VSliderInt"            , sol::overload(
                                                                 sol::resolve<std::tuple<int, bool>(const std::string&, float, float, int, int, int)>(VSliderInt),
                                                                 sol::resolve<std::tuple<int, bool>(const std::string&, float, float, int, int, int, const std::string&)>(VSliderInt)
                                                             ));
 #pragma endregion Widgets: Sliders
 
 #pragma region Widgets: Inputs using Keyboard
-        ImGui.set_function("InputText"						, sol::overload(
+        ImGui.set_function("InputText"            , sol::overload(
                                                                 sol::resolve<std::tuple<std::string, bool>(const std::string&, std::string, unsigned int)>(InputText),
                                                                 sol::resolve<std::tuple<std::string, bool>(const std::string&, std::string, unsigned int, int)>(InputText)
                                                             ));
-        ImGui.set_function("InputTextMultiline"				, sol::overload(
+        ImGui.set_function("InputTextMultiline"        , sol::overload(
                                                                 sol::resolve<std::tuple<std::string, bool>(const std::string&, std::string, unsigned int)>(InputTextMultiline),
                                                                 sol::resolve<std::tuple<std::string, bool>(const std::string&, std::string, unsigned int, float, float)>(InputTextMultiline),
                                                                 sol::resolve<std::tuple<std::string, bool>(const std::string&, std::string, unsigned int, float, float, int)>(InputTextMultiline)
                                                             ));
-        ImGui.set_function("InputTextWithHint"				, sol::overload(
+        ImGui.set_function("InputTextWithHint"        , sol::overload(
                                                                 sol::resolve<std::tuple<std::string, bool>(const std::string&, const std::string&, std::string, unsigned int)>(InputTextWithHint),
                                                                 sol::resolve<std::tuple<std::string, bool>(const std::string&, const std::string&, std::string, unsigned int, int)>(InputTextWithHint)
                                                             ));
-        ImGui.set_function("InputFloat"						, sol::overload(
+        ImGui.set_function("InputFloat"            , sol::overload(
                                                                 sol::resolve<std::tuple<float, bool>(const std::string&, float)>(InputFloat),
                                                                 sol::resolve<std::tuple<float, bool>(const std::string&, float, float)>(InputFloat),
                                                                 sol::resolve<std::tuple<float, bool>(const std::string&, float, float, float)>(InputFloat),
                                                                 sol::resolve<std::tuple<float, bool>(const std::string&, float, float, float, const std::string&)>(InputFloat),
                                                                 sol::resolve<std::tuple<float, bool>(const std::string&, float, float, float, const std::string&, int)>(InputFloat)
                                                             ));
-        ImGui.set_function("InputFloat2"					, sol::overload(
+        ImGui.set_function("InputFloat2"          , sol::overload(
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&)>(InputFloat2),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, const std::string&)>(InputFloat2),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, const std::string&, int)>(InputFloat2)
                                                             ));
-        ImGui.set_function("InputFloat3"					, sol::overload(
+        ImGui.set_function("InputFloat3"          , sol::overload(
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&)>(InputFloat3),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, const std::string&)>(InputFloat3),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, const std::string&, int)>(InputFloat3)
                                                             ));
-        ImGui.set_function("InputFloat4"					, sol::overload(
+        ImGui.set_function("InputFloat4"          , sol::overload(
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&)>(InputFloat4),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, const std::string&)>(InputFloat4),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, const std::string&, int)>(InputFloat4)
                                                             ));
-        ImGui.set_function("InputInt"						, sol::overload(
+        ImGui.set_function("InputInt"            , sol::overload(
                                                                 sol::resolve<std::tuple<int, bool>(const std::string&, int)>(InputInt),
                                                                 sol::resolve<std::tuple<int, bool>(const std::string&, int, int)>(InputInt),
                                                                 sol::resolve<std::tuple<int, bool>(const std::string&, int, int, int)>(InputInt),
                                                                 sol::resolve<std::tuple<int, bool>(const std::string&, int, int, int)>(InputInt),
                                                                 sol::resolve<std::tuple<int, bool>(const std::string&, int, int, int, int)>(InputInt)
                                                             ));
-        ImGui.set_function("InputInt2"						, sol::overload(
+        ImGui.set_function("InputInt2"            , sol::overload(
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&)>(InputInt2),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, int)>(InputInt2)
                                                             ));
-        ImGui.set_function("InputInt3"						, sol::overload(
+        ImGui.set_function("InputInt3"            , sol::overload(
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&)>(InputInt3),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, int)>(InputInt3)
                                                             ));
-        ImGui.set_function("InputInt4"						, sol::overload(
+        ImGui.set_function("InputInt4"            , sol::overload(
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&)>(InputInt4),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, int)>(InputInt4)
                                                             ));
-        ImGui.set_function("InputDouble"					, sol::overload(
+        ImGui.set_function("InputDouble"          , sol::overload(
                                                                 sol::resolve<std::tuple<double, bool>(const std::string&, double)>(InputDouble),
                                                                 sol::resolve<std::tuple<double, bool>(const std::string&, double, double)>(InputDouble),
                                                                 sol::resolve<std::tuple<double, bool>(const std::string&, double, double, double)>(InputDouble),
@@ -2466,50 +2466,50 @@ namespace sol_ImGui
 #pragma endregion Widgets: Inputs using Keyboard
 
 #pragma region Widgets: Color Editor / Picker
-        ImGui.set_function("ColorEdit3"						, sol::overload(
+        ImGui.set_function("ColorEdit3"            , sol::overload(
                                                                 sol::resolve<std::tuple <sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&)>(ColorEdit3),
                                                                 sol::resolve<std::tuple <sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, int)>(ColorEdit3)
                                                             ));
-        ImGui.set_function("ColorEdit4"						, sol::overload(
+        ImGui.set_function("ColorEdit4"            , sol::overload(
                                                                 sol::resolve<std::tuple <sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&)>(ColorEdit4),
                                                                 sol::resolve<std::tuple <sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, int)>(ColorEdit4)
                                                             ));
-        ImGui.set_function("ColorPicker3"					, sol::overload(
+        ImGui.set_function("ColorPicker3"          , sol::overload(
                                                                 sol::resolve<std::tuple <sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&)>(ColorPicker3),
                                                                 sol::resolve<std::tuple <sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, int)>(ColorPicker3)
                                                             ));
-        ImGui.set_function("ColorPicker4"					, sol::overload(
+        ImGui.set_function("ColorPicker4"          , sol::overload(
                                                                 sol::resolve<std::tuple <sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&)>(ColorPicker4),
                                                                 sol::resolve<std::tuple <sol::as_table_t<std::vector<float>>, bool>(const std::string&, const sol::table&, int)>(ColorPicker4)
                                                             ));
 #pragma endregion Widgets: Color Editor / Picker
 
 #pragma region Widgets: Trees
-        ImGui.set_function("TreeNode"						, sol::overload(
+        ImGui.set_function("TreeNode"            , sol::overload(
                                                                 sol::resolve<bool(const std::string&)>(TreeNode),
                                                                 sol::resolve<bool(const std::string&, const std::string&)>(TreeNode)
                                                             ));
-        ImGui.set_function("TreeNodeEx"						, sol::overload(
+        ImGui.set_function("TreeNodeEx"            , sol::overload(
                                                                 sol::resolve<bool(const std::string&)>(TreeNodeEx),
                                                                 sol::resolve<bool(const std::string&, int)>(TreeNodeEx),
                                                                 sol::resolve<bool(const std::string&, int, const std::string&)>(TreeNodeEx)
                                                             ));
-        ImGui.set_function("TreePush"						, TreePush);
-        ImGui.set_function("GetTreeNodeToLabelSpacing"		, GetTreeNodeToLabelSpacing);
-        ImGui.set_function("CollapsingHeader"				, sol::overload(
+        ImGui.set_function("TreePush"            , TreePush);
+        ImGui.set_function("GetTreeNodeToLabelSpacing"    , GetTreeNodeToLabelSpacing);
+        ImGui.set_function("CollapsingHeader"        , sol::overload(
                                                                 sol::resolve<bool(const std::string&)>(CollapsingHeader),
                                                                 sol::resolve<bool(const std::string&, int)>(CollapsingHeader),
                                                                 sol::resolve<std::tuple<bool, bool>(const std::string&, bool)>(CollapsingHeader),
                                                                 sol::resolve<std::tuple<bool, bool>(const std::string&, bool, int)>(CollapsingHeader)
                                                             ));
-        ImGui.set_function("SetNextItemOpen"				, sol::overload(
+        ImGui.set_function("SetNextItemOpen"        , sol::overload(
                                                                 sol::resolve<void(bool)>(SetNextItemOpen),
                                                                 sol::resolve<void(bool, int)>(SetNextItemOpen)
                                                             ));
 #pragma endregion Widgets: Trees
 
 #pragma region Widgets: Selectables
-        ImGui.set_function("Selectable"						, sol::overload(
+        ImGui.set_function("Selectable"            , sol::overload(
                                                                 sol::resolve<bool(const std::string&)>(Selectable),
                                                                 sol::resolve<bool(const std::string&, bool)>(Selectable),
                                                                 sol::resolve<bool(const std::string&, bool, int)>(Selectable),
@@ -2518,20 +2518,20 @@ namespace sol_ImGui
 #pragma endregion Widgets: Selectables
 
 #pragma region Widgets: List Boxes
-        ImGui.set_function("ListBox"						, sol::overload(
+        ImGui.set_function("ListBox"            , sol::overload(
                                                                 sol::resolve<std::tuple<int, bool>(const std::string&, int, const sol::table&, int)>(ListBox),
                                                                 sol::resolve<std::tuple<int, bool>(const std::string&, int, const sol::table&, int, int)>(ListBox)
                                                             ));
-        ImGui.set_function("ListBoxHeader"					, sol::overload(
+        ImGui.set_function("ListBoxHeader"          , sol::overload(
                                                                 sol::resolve<bool(const std::string&, float, float)>(ListBoxHeader),
                                                                 sol::resolve<bool(const std::string&, int)>(ListBoxHeader),
                                                                 sol::resolve<bool(const std::string&, int, int)>(ListBoxHeader)
                                                             ));
-        ImGui.set_function("ListBoxFooter"					, ListBoxFooter);
+        ImGui.set_function("ListBoxFooter"          , ListBoxFooter);
 #pragma endregion Widgets: List Boxes
 
 #pragma region Widgets: Value() Helpers
-        ImGui.set_function("Value"							, sol::overload(
+        ImGui.set_function("Value"              , sol::overload(
                                                                 sol::resolve<void(const std::string&, bool)>(Value),
                                                                 sol::resolve<void(const std::string&, int)>(Value),
                                                                 sol::resolve<void(const std::string&, unsigned int)>(Value),
@@ -2541,16 +2541,16 @@ namespace sol_ImGui
 #pragma endregion Widgets: Value() Helpers
 
 #pragma region Widgets: Menu
-        ImGui.set_function("BeginMenuBar"					, BeginMenuBar);
-        ImGui.set_function("EndMenuBar"						, EndMenuBar);
-        ImGui.set_function("BeginMainMenuBar"				, BeginMainMenuBar);
-        ImGui.set_function("EndMainMenuBar"					, EndMainMenuBar);
-        ImGui.set_function("BeginMenu"						, sol::overload(
+        ImGui.set_function("BeginMenuBar"            , BeginMenuBar);
+        ImGui.set_function("EndMenuBar"              , EndMenuBar);
+        ImGui.set_function("BeginMainMenuBar"        , BeginMainMenuBar);
+        ImGui.set_function("EndMainMenuBar"          , EndMainMenuBar);
+        ImGui.set_function("BeginMenu"               , sol::overload(
                                                                 sol::resolve<bool(const std::string&)>(BeginMenu),
                                                                 sol::resolve<bool(const std::string&, bool)>(BeginMenu)
                                                             ));
-        ImGui.set_function("EndMenu"						, EndMenu);
-        ImGui.set_function("MenuItem"						, sol::overload(
+        ImGui.set_function("EndMenu"             , EndMenu);
+        ImGui.set_function("MenuItem"            , sol::overload(
                                                                 sol::resolve<bool(const std::string&)>(MenuItem),
                                                                 sol::resolve<bool(const std::string&, const std::string&)>(MenuItem),
                                                                 sol::resolve<std::tuple<bool, bool>(const std::string&, const std::string&, bool)>(MenuItem),
@@ -2559,159 +2559,159 @@ namespace sol_ImGui
 #pragma endregion Widgets: Menu
 
 #pragma region Tooltips
-        ImGui.set_function("BeginTooltip"					, BeginTooltip);
-        ImGui.set_function("EndTooltip"						, EndTooltip);
-        ImGui.set_function("SetTooltip"						, SetTooltip);
+        ImGui.set_function("BeginTooltip"          , BeginTooltip);
+        ImGui.set_function("EndTooltip"            , EndTooltip);
+        ImGui.set_function("SetTooltip"            , SetTooltip);
 #pragma endregion Tooltips
 
 #pragma region Popups, Modals
-        ImGui.set_function("BeginPopup"						, sol::overload(
+        ImGui.set_function("BeginPopup"            , sol::overload(
                                                                 sol::resolve<bool(const std::string&)>(BeginPopup),
                                                                 sol::resolve<bool(const std::string&, int)>(BeginPopup)
                                                             ));
-        ImGui.set_function("BeginPopupModal"				, sol::overload(
+        ImGui.set_function("BeginPopupModal"        , sol::overload(
                                                                 sol::resolve<bool(const std::string&)>(BeginPopupModal),
                                                                 sol::resolve<bool(const std::string&, bool)>(BeginPopupModal),
                                                                 sol::resolve<bool(const std::string&, bool, int)>(BeginPopupModal)
                                                             ));
-        ImGui.set_function("EndPopup"						, EndPopup);
-        ImGui.set_function("OpenPopup"						, sol::overload(
+        ImGui.set_function("EndPopup"             , EndPopup);
+        ImGui.set_function("OpenPopup"            , sol::overload(
                                                                 sol::resolve<void(const std::string&)>(OpenPopup),
                                                                 sol::resolve<void(const std::string&, int)>(OpenPopup)
                                                             ));
-        ImGui.set_function("CloseCurrentPopup"				, CloseCurrentPopup);
-        ImGui.set_function("BeginPopupContextItem"			, sol::overload(
+        ImGui.set_function("CloseCurrentPopup"          , CloseCurrentPopup);
+        ImGui.set_function("BeginPopupContextItem"      , sol::overload(
                                                                 sol::resolve<bool()>(BeginPopupContextItem),
                                                                 sol::resolve<bool(const std::string&)>(BeginPopupContextItem),
                                                                 sol::resolve<bool(const std::string&, int)>(BeginPopupContextItem)
                                                             ));
-        ImGui.set_function("BeginPopupContextWindow"		, sol::overload(
+        ImGui.set_function("BeginPopupContextWindow"    , sol::overload(
                                                                 sol::resolve<bool()>(BeginPopupContextWindow),
                                                                 sol::resolve<bool(const std::string&)>(BeginPopupContextWindow),
                                                                 sol::resolve<bool(const std::string&, int)>(BeginPopupContextWindow)
                                                             ));
-        ImGui.set_function("BeginPopupContextVoid"			, sol::overload(
+        ImGui.set_function("BeginPopupContextVoid"      , sol::overload(
                                                                 sol::resolve<bool()>(BeginPopupContextVoid),
                                                                 sol::resolve<bool(const std::string&)>(BeginPopupContextVoid),
                                                                 sol::resolve<bool(const std::string&, int)>(BeginPopupContextVoid)
                                                             ));
-        ImGui.set_function("IsPopupOpen"					, sol::overload(
+        ImGui.set_function("IsPopupOpen"          , sol::overload(
                                                                 sol::resolve<bool(const std::string&)>(IsPopupOpen),
                                                                 sol::resolve<bool(const std::string&, int)>(IsPopupOpen)
                                                             ));
 #pragma endregion Popups, Modals
 
 #pragma region Columns
-        ImGui.set_function("Columns"						, sol::overload(
+        ImGui.set_function("Columns"            , sol::overload(
                                                                 sol::resolve<void()>(Columns),
                                                                 sol::resolve<void(int)>(Columns),
                                                                 sol::resolve<void(int, const std::string&)>(Columns),
                                                                 sol::resolve<void(int, const std::string&, bool)>(Columns)
                                                             ));
-        ImGui.set_function("NextColumn"						, NextColumn);
-        ImGui.set_function("GetColumnIndex"					, GetColumnIndex);
-        ImGui.set_function("GetColumnWidth"					, sol::overload(
+        ImGui.set_function("NextColumn"              , NextColumn);
+        ImGui.set_function("GetColumnIndex"          , GetColumnIndex);
+        ImGui.set_function("GetColumnWidth"          , sol::overload(
                                                                 sol::resolve<float()>(GetColumnWidth),
                                                                 sol::resolve<float(int)>(GetColumnWidth)
                                                             ));
-        ImGui.set_function("SetColumnWidth"					, SetColumnWidth);
-        ImGui.set_function("GetColumnOffset"				, sol::overload(
+        ImGui.set_function("SetColumnWidth"          , SetColumnWidth);
+        ImGui.set_function("GetColumnOffset"         , sol::overload(
                                                                 sol::resolve<float()>(GetColumnOffset),
                                                                 sol::resolve<float(int)>(GetColumnOffset)
                                                             ));
-        ImGui.set_function("SetColumnOffset"				, SetColumnOffset);
-        ImGui.set_function("GetColumnsCount"				, GetColumnsCount);
+        ImGui.set_function("SetColumnOffset"        , SetColumnOffset);
+        ImGui.set_function("GetColumnsCount"        , GetColumnsCount);
 #pragma endregion Columns
 
 #pragma region Tab Bars, Tabs
-        ImGui.set_function("BeginTabBar"					, sol::overload(
+        ImGui.set_function("BeginTabBar"          , sol::overload(
                                                                 sol::resolve<bool(const std::string&)>(BeginTabBar),
                                                                 sol::resolve<bool(const std::string&, int)>(BeginTabBar)
                                                             ));
-        ImGui.set_function("EndTabBar"						, EndTabBar);
-        ImGui.set_function("BeginTabItem"					, sol::overload(
+        ImGui.set_function("EndTabBar"             , EndTabBar);
+        ImGui.set_function("BeginTabItem"          , sol::overload(
                                                                 sol::resolve<bool(const std::string&)>(BeginTabItem),
                                                                 sol::resolve<std::tuple<bool, bool>(const std::string&, bool)>(BeginTabItem),
                                                                 sol::resolve<std::tuple<bool, bool>(const std::string&, bool, int)>(BeginTabItem)
                                                             ));
-        ImGui.set_function("EndTabItem"						, EndTabItem);
-        ImGui.set_function("SetTabItemClosed"				, SetTabItemClosed);
+        ImGui.set_function("EndTabItem"              , EndTabItem);
+        ImGui.set_function("SetTabItemClosed"        , SetTabItemClosed);
 #pragma endregion Tab Bars, Tabs
 
 #pragma region Logging / Capture
-        ImGui.set_function("LogToTTY"						, sol::overload(
+        ImGui.set_function("LogToTTY"            , sol::overload(
                                                                 sol::resolve<void()>(LogToTTY),
                                                                 sol::resolve<void(int)>(LogToTTY)
                                                             ));
-        ImGui.set_function("LogToFile"						, sol::overload(
+        ImGui.set_function("LogToFile"            , sol::overload(
                                                                 sol::resolve<void(int)>(LogToFile),
                                                                 sol::resolve<void(int, const std::string&)>(LogToFile)
                                                             ));
-        ImGui.set_function("LogToClipboard"					, sol::overload(
+        ImGui.set_function("LogToClipboard"          , sol::overload(
                                                                 sol::resolve<void()>(LogToClipboard),
                                                                 sol::resolve<void(int)>(LogToClipboard)
                                                             ));
-        ImGui.set_function("LogFinish"						, LogFinish);
-        ImGui.set_function("LogButtons"						, LogButtons);
-        ImGui.set_function("LogText"						, LogText);
+        ImGui.set_function("LogFinish"              , LogFinish);
+        ImGui.set_function("LogButtons"             , LogButtons);
+        ImGui.set_function("LogText"                , LogText);
 #pragma endregion Logging / Capture
 
 #pragma region Clipping
-        ImGui.set_function("PushClipRect"					, PushClipRect);
-        ImGui.set_function("PopClipRect"					, PopClipRect);
+        ImGui.set_function("PushClipRect"           , PushClipRect);
+        ImGui.set_function("PopClipRect"            , PopClipRect);
 #pragma endregion Clipping
 
 #pragma region Focus, Activation
-        ImGui.set_function("SetItemDefaultFocus"			, SetItemDefaultFocus);
-        ImGui.set_function("SetKeyboardFocusHere"			, sol::overload(
+        ImGui.set_function("SetItemDefaultFocus"       , SetItemDefaultFocus);
+        ImGui.set_function("SetKeyboardFocusHere"      , sol::overload(
                                                                 sol::resolve<void()>(SetKeyboardFocusHere),
                                                                 sol::resolve<void(int)>(SetKeyboardFocusHere)
                                                             ));
 #pragma endregion Focus, Activation
 
 #pragma region Item/Widgets Utilities
-        ImGui.set_function("IsItemHovered"					, sol::overload(
+        ImGui.set_function("IsItemHovered"          , sol::overload(
                                                                 sol::resolve<bool()>(IsItemHovered),
                                                                 sol::resolve<bool(int)>(IsItemHovered)
                                                             ));
-        ImGui.set_function("IsItemActive"					, IsItemActive);
-        ImGui.set_function("IsItemFocused"					, IsItemFocused);
-        ImGui.set_function("IsItemClicked"					, sol::overload(
+        ImGui.set_function("IsItemActive"           , IsItemActive);
+        ImGui.set_function("IsItemFocused"          , IsItemFocused);
+        ImGui.set_function("IsItemClicked"          , sol::overload(
                                                                 sol::resolve<bool()>(IsItemClicked),
                                                                 sol::resolve<bool(int)>(IsItemClicked)
                                                             ));
-        ImGui.set_function("IsItemVisible"					, IsItemVisible);
-        ImGui.set_function("IsItemEdited"					, IsItemEdited);
-        ImGui.set_function("IsItemActivated"				, IsItemActivated);
-        ImGui.set_function("IsItemDeactivated"				, IsItemDeactivated);
-        ImGui.set_function("IsItemDeactivatedAfterEdit"		, IsItemDeactivatedAfterEdit);
-        ImGui.set_function("IsItemToggledOpen"				, IsItemToggledOpen);
-        ImGui.set_function("IsAnyItemHovered"				, IsAnyItemHovered);
-        ImGui.set_function("IsAnyItemActive"				, IsAnyItemActive);
-        ImGui.set_function("IsAnyItemFocused"				, IsAnyItemFocused);
-        ImGui.set_function("GetItemRectMin"					, GetItemRectMin);
-        ImGui.set_function("GetItemRectMax"					, GetItemRectMax);
-        ImGui.set_function("GetItemRectSize"				, GetItemRectSize);
-        ImGui.set_function("SetItemAllowOverlap"			, SetItemAllowOverlap);
+        ImGui.set_function("IsItemVisible"              , IsItemVisible);
+        ImGui.set_function("IsItemEdited"               , IsItemEdited);
+        ImGui.set_function("IsItemActivated"            , IsItemActivated);
+        ImGui.set_function("IsItemDeactivated"          , IsItemDeactivated);
+        ImGui.set_function("IsItemDeactivatedAfterEdit" , IsItemDeactivatedAfterEdit);
+        ImGui.set_function("IsItemToggledOpen"          , IsItemToggledOpen);
+        ImGui.set_function("IsAnyItemHovered"           , IsAnyItemHovered);
+        ImGui.set_function("IsAnyItemActive"            , IsAnyItemActive);
+        ImGui.set_function("IsAnyItemFocused"           , IsAnyItemFocused);
+        ImGui.set_function("GetItemRectMin"             , GetItemRectMin);
+        ImGui.set_function("GetItemRectMax"             , GetItemRectMax);
+        ImGui.set_function("GetItemRectSize"            , GetItemRectSize);
+        ImGui.set_function("SetItemAllowOverlap"        , SetItemAllowOverlap);
 #pragma endregion Item/Widgets Utilities
 
 #pragma region Miscellaneous Utilities
-        ImGui.set_function("IsRectVisible"					, sol::overload(
+        ImGui.set_function("IsRectVisible"          , sol::overload(
                                                                 sol::resolve<bool(float, float)>(IsRectVisible),
                                                                 sol::resolve<bool(float, float, float, float)>(IsRectVisible)
                                                             ));
-        ImGui.set_function("GetTime"						, GetTime);
-        ImGui.set_function("GetFrameCount"					, GetFrameCount);
-        ImGui.set_function("GetStyleColorName"				, GetStyleColorName);
-        ImGui.set_function("BeginChildFrame"				, sol::overload(
+        ImGui.set_function("GetTime"                , GetTime);
+        ImGui.set_function("GetFrameCount"          , GetFrameCount);
+        ImGui.set_function("GetStyleColorName"      , GetStyleColorName);
+        ImGui.set_function("BeginChildFrame"        , sol::overload(
                                                                 sol::resolve<bool(unsigned int, float, float)>(BeginChildFrame),
                                                                 sol::resolve<bool(unsigned int, float, float, int)>(BeginChildFrame)
                                                             ));
-        ImGui.set_function("EndChildFrame"					, EndChildFrame);
+        ImGui.set_function("EndChildFrame"          , EndChildFrame);
 #pragma endregion Miscellaneous Utilities
 
 #pragma region Text Utilities
-        ImGui.set_function("CalcTextSize"					, sol::overload(
+        ImGui.set_function("CalcTextSize"          , sol::overload(
                                                                 sol::resolve<std::tuple<float, float>(const std::string&)>(CalcTextSize),
                                                                 sol::resolve<std::tuple<float, float>(const std::string&, bool)>(CalcTextSize),
                                                                 sol::resolve<std::tuple<float, float>(const std::string&, bool, float)>(CalcTextSize)
@@ -2719,58 +2719,58 @@ namespace sol_ImGui
 #pragma endregion Text Utilities
 
 #pragma region Color Utilities
-        ImGui.set_function("ColorConvertU32ToFloat4"		, ColorConvertU32ToFloat4);
-        ImGui.set_function("ColorConvertFloat4ToU32"		, ColorConvertFloat4ToU32);
-        ImGui.set_function("ColorConvertRGBtoHSV"			, ColorConvertRGBtoHSV);
-        ImGui.set_function("ColorConvertHSVtoRGB"			, ColorConvertHSVtoRGB);
+        ImGui.set_function("ColorConvertU32ToFloat4"     , ColorConvertU32ToFloat4);
+        ImGui.set_function("ColorConvertFloat4ToU32"     , ColorConvertFloat4ToU32);
+        ImGui.set_function("ColorConvertRGBtoHSV"        , ColorConvertRGBtoHSV);
+        ImGui.set_function("ColorConvertHSVtoRGB"        , ColorConvertHSVtoRGB);
 #pragma endregion Color Utilities
 
 #ifdef SOL_IMGUI_ENABLE_INPUT_FUNCTIONS
 #pragma region Inputs Utilities: Keyboard
-        ImGui.set_function("GetKeyIndex"					, GetKeyIndex);
-        ImGui.set_function("IsKeyDown"						, IsKeyDown);
-        ImGui.set_function("IsKeyPressed"					, sol::overload(
+        ImGui.set_function("GetKeyIndex"              , GetKeyIndex);
+        ImGui.set_function("IsKeyDown"                , IsKeyDown);
+        ImGui.set_function("IsKeyPressed"             , sol::overload(
                                                                 sol::resolve<bool(int)>(IsKeyPressed),
                                                                 sol::resolve<bool(int, bool)>(IsKeyPressed)
                                                             ));
-        ImGui.set_function("IsKeyReleased"					, IsKeyReleased);
-        ImGui.set_function("CaptureKeyboardFromApp"			, sol::overload(
+        ImGui.set_function("IsKeyReleased"            , IsKeyReleased);
+        ImGui.set_function("CaptureKeyboardFromApp"   , sol::overload(
                                                                 sol::resolve<void()>(CaptureKeyboardFromApp),
                                                                 sol::resolve<void(bool)>(CaptureKeyboardFromApp)
                                                             ));
 #pragma endregion Inputs Utilities: Keyboard
 
 #pragma region Inputs Utilities: Mouse
-        ImGui.set_function("IsMouseDown"					, IsMouseDown);
-        ImGui.set_function("IsMouseClicked"					, sol::overload(
+        ImGui.set_function("IsMouseDown"             , IsMouseDown);
+        ImGui.set_function("IsMouseClicked"          , sol::overload(
                                                                 sol::resolve<bool(int)>(IsMouseClicked),
                                                                 sol::resolve<bool(int, bool)>(IsMouseClicked)
                                                             ));
-        ImGui.set_function("IsMouseReleased"				, IsMouseReleased);
-        ImGui.set_function("IsMouseDoubleClicked"			, IsMouseDoubleClicked);
-        ImGui.set_function("IsMouseHoveringRect"			, sol::overload(
+        ImGui.set_function("IsMouseReleased"           , IsMouseReleased);
+        ImGui.set_function("IsMouseDoubleClicked"      , IsMouseDoubleClicked);
+        ImGui.set_function("IsMouseHoveringRect"       , sol::overload(
                                                                 sol::resolve<bool(float, float, float, float)>(IsMouseHoveringRect),
                                                                 sol::resolve<bool(float, float, float, float, bool)>(IsMouseHoveringRect)
                                                             ));
-        ImGui.set_function("IsAnyMouseDown"					, IsAnyMouseDown);
-        ImGui.set_function("GetMousePos"					, GetMousePos);
+        ImGui.set_function("IsAnyMouseDown"           , IsAnyMouseDown);
+        ImGui.set_function("GetMousePos"              , GetMousePos);
         ImGui.set_function("GetMousePosOnOpeningCurrentPopup", GetMousePosOnOpeningCurrentPopup);
-        ImGui.set_function("IsMouseDragging"				, sol::overload(
+        ImGui.set_function("IsMouseDragging"          , sol::overload(
                                                                 sol::resolve<bool(int)>(IsMouseDragging),
                                                                 sol::resolve<bool(int, float)>(IsMouseDragging)
                                                             ));
-        ImGui.set_function("GetMouseDragDelta"				, sol::overload(
+        ImGui.set_function("GetMouseDragDelta"        , sol::overload(
                                                                 sol::resolve<std::tuple<float, float>()>(GetMouseDragDelta),
                                                                 sol::resolve<std::tuple<float, float>(int)>(GetMouseDragDelta),
                                                                 sol::resolve<std::tuple<float, float>(int, float)>(GetMouseDragDelta)
                                                             ));
-        ImGui.set_function("ResetMouseDragDelta"			, sol::overload(
+        ImGui.set_function("ResetMouseDragDelta"      , sol::overload(
                                                                 sol::resolve<void()>(ResetMouseDragDelta),
                                                                 sol::resolve<void(int)>(ResetMouseDragDelta)
                                                             ));
-        ImGui.set_function("GetMouseCursor"					, GetMouseCursor);
-        ImGui.set_function("SetMouseCursor"					, SetMouseCursor);
-        ImGui.set_function("CaptureMouseFromApp"			, sol::overload(
+        ImGui.set_function("GetMouseCursor"           , GetMouseCursor);
+        ImGui.set_function("SetMouseCursor"           , SetMouseCursor);
+        ImGui.set_function("CaptureMouseFromApp"      , sol::overload(
                                                                 sol::resolve<void()>(CaptureMouseFromApp),
                                                                 sol::resolve<void(bool)>(CaptureMouseFromApp)
                                                             ));
@@ -2778,8 +2778,8 @@ namespace sol_ImGui
 #endif // SOL_IMGUI_ENABLE_INPUT_FUNCTIONS
 
 #pragma region Clipboard Utilities
-        ImGui.set_function("GetClipboardText"				, GetClipboardText);
-        ImGui.set_function("SetClipboardText"				, SetClipboardText);
+        ImGui.set_function("GetClipboardText"        , GetClipboardText);
+        ImGui.set_function("SetClipboardText"        , SetClipboardText);
 #pragma endregion Clipboard Utilities
     }
 }

--- a/src/sol_imgui/sol_imgui.h
+++ b/src/sol_imgui/sol_imgui.h
@@ -520,12 +520,13 @@ namespace sol_ImGui
 
         return std::make_tuple(float4, used);
     }
-    inline void DragFloatRange2()                                                                                                          { /* TODO: DragFloatRange2(...) ==> UNSUPPORTED */ }
-    inline std::tuple<int, bool> DragInt(const std::string& label, int v)                                                                  { bool used = ImGui::DragInt(label.c_str(), &v); return std::make_tuple(v, used); }
-    inline std::tuple<int, bool> DragInt(const std::string& label, int v, float v_speed)                                                   { bool used = ImGui::DragInt(label.c_str(), &v, v_speed); return std::make_tuple(v, used); }
-    inline std::tuple<int, bool> DragInt(const std::string& label, int v, float v_speed, int v_min)                                        { bool used = ImGui::DragInt(label.c_str(), &v, v_speed, v_min); return std::make_tuple(v, used); }
-    inline std::tuple<int, bool> DragInt(const std::string& label, int v, float v_speed, int v_min, int v_max)                             { bool used = ImGui::DragInt(label.c_str(), &v, v_speed, v_min, v_max); return std::make_tuple(v, used); }
-    inline std::tuple<int, bool> DragInt(const std::string& label, int v, float v_speed, int v_min, int v_max, const std::string& format)  { bool used = ImGui::DragInt(label.c_str(), &v, v_speed, v_min, v_max, format.c_str()); return std::make_tuple(v, used); }
+    inline void DragFloatRange2()                                                                                                                     { /* TODO: DragFloatRange2(...) ==> UNSUPPORTED */ }
+    inline std::tuple<int, bool> DragInt(const std::string& label, int v)                                                                             { bool used = ImGui::DragInt(label.c_str(), &v); return std::make_tuple(v, used); }
+    inline std::tuple<int, bool> DragInt(const std::string& label, int v, float v_speed)                                                              { bool used = ImGui::DragInt(label.c_str(), &v, v_speed); return std::make_tuple(v, used); }
+    inline std::tuple<int, bool> DragInt(const std::string& label, int v, float v_speed, int v_min)                                                   { bool used = ImGui::DragInt(label.c_str(), &v, v_speed, v_min); return std::make_tuple(v, used); }
+    inline std::tuple<int, bool> DragInt(const std::string& label, int v, float v_speed, int v_min, int v_max)                                        { bool used = ImGui::DragInt(label.c_str(), &v, v_speed, v_min, v_max); return std::make_tuple(v, used); }
+    inline std::tuple<int, bool> DragInt(const std::string& label, int v, float v_speed, int v_min, int v_max, const std::string& format)             { bool used = ImGui::DragInt(label.c_str(), &v, v_speed, v_min, v_max, format.c_str()); return std::make_tuple(v, used); }
+    inline std::tuple<int, bool> DragInt(const std::string& label, int v, float v_speed, int v_min, int v_max, const std::string& format, int flags)  { bool used = ImGui::DragInt(label.c_str(), &v, v_speed, v_min, v_max, format.c_str(), static_cast<ImGuiSliderFlags>(flags)); return std::make_tuple(v, used); }
     inline std::tuple<sol::as_table_t<std::vector<int>>, bool> DragInt2(const std::string& label, const sol::table& v)
     {
         const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
@@ -584,6 +585,19 @@ namespace sol_ImGui
                           v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         int value[2] = { int(v1), int(v2) };
         bool used = ImGui::DragInt2(label.c_str(), value, v_speed, v_min, v_max, format.c_str());
+
+        sol::as_table_t int2 = sol::as_table(std::vector<int>{
+            value[0], value[1]
+        });
+
+        return std::make_tuple(int2, used);
+    }
+    inline std::tuple<sol::as_table_t<std::vector<int>>, bool> DragInt2(const std::string& label, const sol::table& v, float v_speed, int v_min, int v_max, const std::string& format, int flags)
+    {
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        int value[2] = { int(v1), int(v2) };
+        bool used = ImGui::DragInt2(label.c_str(), value, v_speed, v_min, v_max, format.c_str(), static_cast<ImGuiSliderFlags>(flags));
 
         sol::as_table_t int2 = sol::as_table(std::vector<int>{
             value[0], value[1]
@@ -661,6 +675,20 @@ namespace sol_ImGui
 
         return std::make_tuple(int3, used);
     }
+    inline std::tuple<sol::as_table_t<std::vector<int>>, bool> DragInt3(const std::string& label, const sol::table& v, float v_speed, int v_min, int v_max, const std::string& format, int flags)
+    {
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        int value[3] = { int(v1), int(v2), int(v3) };
+        bool used = ImGui::DragInt3(label.c_str(), value, v_speed, v_min, v_max, format.c_str(), static_cast<ImGuiSliderFlags>(flags));
+
+        sol::as_table_t int3 = sol::as_table(std::vector<int>{
+            value[0], value[1], value[2]
+        });
+
+        return std::make_tuple(int3, used);
+    }
     inline std::tuple<sol::as_table_t<std::vector<int>>, bool> DragInt4(const std::string& label, const sol::table& v)
     {
         const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
@@ -729,6 +757,21 @@ namespace sol_ImGui
                           v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         int value[4] = { int(v1), int(v2), int(v3), int(v4) };
         bool used = ImGui::DragInt4(label.c_str(), value, v_speed, v_min, v_max, format.c_str());
+
+        sol::as_table_t int4 = sol::as_table(std::vector<int>{
+            value[0], value[1], value[2], value[3]
+        });
+
+        return std::make_tuple(int4, used);
+    }
+    inline std::tuple<sol::as_table_t<std::vector<int>>, bool> DragInt4(const std::string& label, const sol::table& v, float v_speed, int v_min, int v_max, const std::string& format, int flags)
+    {
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        int value[4] = { int(v1), int(v2), int(v3), int(v4) };
+        bool used = ImGui::DragInt4(label.c_str(), value, v_speed, v_min, v_max, format.c_str(), static_cast<ImGuiSliderFlags>(flags));
 
         sol::as_table_t int4 = sol::as_table(std::vector<int>{
             value[0], value[1], value[2], value[3]
@@ -870,12 +913,14 @@ namespace sol_ImGui
 
         return std::make_tuple(float4, used);
     }
-    inline std::tuple<float, bool> SliderAngle(const std::string& label, float v_rad)                                                                         { bool used = ImGui::SliderAngle(label.c_str(), &v_rad); return std::make_tuple(v_rad, used); }
-    inline std::tuple<float, bool> SliderAngle(const std::string& label, float v_rad, float v_degrees_min)                                                    { bool used = ImGui::SliderAngle(label.c_str(), &v_rad, v_degrees_min); return std::make_tuple(v_rad, used); }
-    inline std::tuple<float, bool> SliderAngle(const std::string& label, float v_rad, float v_degrees_min, float v_degrees_max)                               { bool used = ImGui::SliderAngle(label.c_str(), &v_rad, v_degrees_min, v_degrees_max); return std::make_tuple(v_rad, used); }
-    inline std::tuple<float, bool> SliderAngle(const std::string& label, float v_rad, float v_degrees_min, float v_degrees_max, const std::string& format)    { bool used = ImGui::SliderAngle(label.c_str(), &v_rad, v_degrees_min, v_degrees_max, format.c_str()); return std::make_tuple(v_rad, used); }
-    inline std::tuple<int, bool> SliderInt(const std::string& label, int v, int v_min, int v_max)                                                             { bool used = ImGui::SliderInt(label.c_str(), &v, v_min, v_max); return std::make_tuple(v, used); }
-    inline std::tuple<int, bool> SliderInt(const std::string& label, int v, int v_min, int v_max, const std::string& format)                                  { bool used = ImGui::SliderInt(label.c_str(), &v, v_min, v_max, format.c_str()); return std::make_tuple(v, used); }
+    inline std::tuple<float, bool> SliderAngle(const std::string& label, float v_rad)                                                                                    { bool used = ImGui::SliderAngle(label.c_str(), &v_rad); return std::make_tuple(v_rad, used); }
+    inline std::tuple<float, bool> SliderAngle(const std::string& label, float v_rad, float v_degrees_min)                                                               { bool used = ImGui::SliderAngle(label.c_str(), &v_rad, v_degrees_min); return std::make_tuple(v_rad, used); }
+    inline std::tuple<float, bool> SliderAngle(const std::string& label, float v_rad, float v_degrees_min, float v_degrees_max)                                          { bool used = ImGui::SliderAngle(label.c_str(), &v_rad, v_degrees_min, v_degrees_max); return std::make_tuple(v_rad, used); }
+    inline std::tuple<float, bool> SliderAngle(const std::string& label, float v_rad, float v_degrees_min, float v_degrees_max, const std::string& format)               { bool used = ImGui::SliderAngle(label.c_str(), &v_rad, v_degrees_min, v_degrees_max, format.c_str()); return std::make_tuple(v_rad, used); }
+    inline std::tuple<float, bool> SliderAngle(const std::string& label, float v_rad, float v_degrees_min, float v_degrees_max, const std::string& format, int flags)    { bool used = ImGui::SliderAngle(label.c_str(), &v_rad, v_degrees_min, v_degrees_max, format.c_str(), static_cast<ImGuiSliderFlags>(flags)); return std::make_tuple(v_rad, used); }
+    inline std::tuple<int, bool> SliderInt(const std::string& label, int v, int v_min, int v_max)                                                                        { bool used = ImGui::SliderInt(label.c_str(), &v, v_min, v_max); return std::make_tuple(v, used); }
+    inline std::tuple<int, bool> SliderInt(const std::string& label, int v, int v_min, int v_max, const std::string& format)                                             { bool used = ImGui::SliderInt(label.c_str(), &v, v_min, v_max, format.c_str()); return std::make_tuple(v, used); }
+    inline std::tuple<int, bool> SliderInt(const std::string& label, int v, int v_min, int v_max, const std::string& format, int flags)                                  { bool used = ImGui::SliderInt(label.c_str(), &v, v_min, v_max, format.c_str(), static_cast<ImGuiSliderFlags>(flags)); return std::make_tuple(v, used); }
     inline std::tuple<sol::as_table_t<std::vector<int>>, bool> SliderInt2(const std::string& label, const sol::table& v, int v_min, int v_max)
     {
         const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
@@ -895,6 +940,19 @@ namespace sol_ImGui
                           v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         int value[2] = { int(v1), int(v2) };
         bool used = ImGui::SliderInt2(label.c_str(), value, v_min, v_max, format.c_str());
+
+        sol::as_table_t int2 = sol::as_table(std::vector<int>{
+            value[0], value[1]
+        });
+
+        return std::make_tuple(int2, used);
+    }
+    inline std::tuple<sol::as_table_t<std::vector<int>>, bool> SliderInt2(const std::string& label, const sol::table& v, int v_min, int v_max, const std::string& format, int flags)
+    {
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        int value[2] = { int(v1), int(v2) };
+        bool used = ImGui::SliderInt2(label.c_str(), value, v_min, v_max, format.c_str(), static_cast<ImGuiSliderFlags>(flags));
 
         sol::as_table_t int2 = sol::as_table(std::vector<int>{
             value[0], value[1]
@@ -923,6 +981,20 @@ namespace sol_ImGui
                           v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
         int value[3] = { int(v1), int(v2), int(v3) };
         bool used = ImGui::SliderInt3(label.c_str(), value, v_min, v_max, format.c_str());
+
+        sol::as_table_t int3 = sol::as_table(std::vector<int>{
+            value[0], value[1], value[2]
+        });
+
+        return std::make_tuple(int3, used);
+    }
+    inline std::tuple<sol::as_table_t<std::vector<int>>, bool> SliderInt3(const std::string& label, const sol::table& v, int v_min, int v_max, const std::string& format, int flags)
+    {
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        int value[3] = { int(v1), int(v2), int(v3) };
+        bool used = ImGui::SliderInt3(label.c_str(), value, v_min, v_max, format.c_str(), static_cast<ImGuiSliderFlags>(flags));
 
         sol::as_table_t int3 = sol::as_table(std::vector<int>{
             value[0], value[1], value[2]
@@ -960,6 +1032,21 @@ namespace sol_ImGui
 
         return std::make_tuple(int4, used);
     }
+    inline std::tuple<sol::as_table_t<std::vector<int>>, bool> SliderInt4(const std::string& label, const sol::table& v, int v_min, int v_max, const std::string& format, int flags)
+    {
+        const lua_Number  v1{ v[1].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v2{ v[2].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v3{ v[3].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) },
+                          v4{ v[4].get<std::optional<lua_Number>>().value_or(static_cast<lua_Number>(0)) };
+        int value[4] = { int(v1), int(v2), int(v3), int(v4) };
+        bool used = ImGui::SliderInt4(label.c_str(), value, v_min, v_max, format.c_str(), static_cast<ImGuiSliderFlags>(flags));
+
+        sol::as_table_t int4 = sol::as_table(std::vector<int>{
+            value[0], value[1], value[2], value[3]
+        });
+
+        return std::make_tuple(int4, used);
+    }
     inline void SliderScalar()                                                                                                                                                    { /* TODO: SliderScalar(...) ==> UNSUPPORTED */ }
     inline void SliderScalarN()                                                                                                                                                   { /* TODO: SliderScalarN(...) ==> UNSUPPORTED */ }
     inline std::tuple<float, bool> VSliderFloat(const std::string& label, float sizeX, float sizeY, float v, float v_min, float v_max)                                            { bool used = ImGui::VSliderFloat(label.c_str(), { sizeX, sizeY }, &v, v_min, v_max); return std::make_tuple(v, used); }
@@ -967,6 +1054,7 @@ namespace sol_ImGui
     inline std::tuple<float, bool> VSliderFloat(const std::string& label, float sizeX, float sizeY, float v, float v_min, float v_max, const std::string& format, int flags)      { bool used = ImGui::VSliderFloat(label.c_str(), { sizeX, sizeY }, &v, v_min, v_max, format.c_str(), static_cast<ImGuiSliderFlags>(flags)); return std::make_tuple(v, used); }
     inline std::tuple<int, bool> VSliderInt(const std::string& label, float sizeX, float sizeY, int v, int v_min, int v_max)                                                      { bool used = ImGui::VSliderInt(label.c_str(), { sizeX, sizeY }, &v, v_min, v_max); return std::make_tuple(v, used); }
     inline std::tuple<int, bool> VSliderInt(const std::string& label, float sizeX, float sizeY, int v, int v_min, int v_max, const std::string& format)                           { bool used = ImGui::VSliderInt(label.c_str(), { sizeX, sizeY }, &v, v_min, v_max, format.c_str()); return std::make_tuple(v, used); }
+    inline std::tuple<int, bool> VSliderInt(const std::string& label, float sizeX, float sizeY, int v, int v_min, int v_max, const std::string& format, int flags)                { bool used = ImGui::VSliderInt(label.c_str(), { sizeX, sizeY }, &v, v_min, v_max, format.c_str(), static_cast<ImGuiSliderFlags>(flags)); return std::make_tuple(v, used); }
     inline void VSliderScalar()                                                                                                                                                   { /* TODO: VSliderScalar(...) ==> UNSUPPORTED */ }
 
     // Widgets: Input with Keyboard
@@ -2322,28 +2410,32 @@ namespace sol_ImGui
                                                                 sol::resolve<std::tuple<int, bool>(const std::string&, int, float)>(DragInt),
                                                                 sol::resolve<std::tuple<int, bool>(const std::string&, int, float, int)>(DragInt),
                                                                 sol::resolve<std::tuple<int, bool>(const std::string&, int, float, int, int)>(DragInt),
-                                                                sol::resolve<std::tuple<int, bool>(const std::string&, int, float, int, int, const std::string&)>(DragInt)
+                                                                sol::resolve<std::tuple<int, bool>(const std::string&, int, float, int, int, const std::string&)>(DragInt),
+                                                                sol::resolve<std::tuple<int, bool>(const std::string&, int, float, int, int, const std::string&, int)>(DragInt)
                                                             ));
         ImGui.set_function("DragInt2"            , sol::overload(
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&)>(DragInt2),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, float)>(DragInt2),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, float, int)>(DragInt2),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, float, int, int)>(DragInt2),
-                                                                sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, float, int, int, const std::string&)>(DragInt2)
+                                                                sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, float, int, int, const std::string&)>(DragInt2),
+                                                                sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, float, int, int, const std::string&, int)>(DragInt2)
                                                             ));
         ImGui.set_function("DragInt3"            , sol::overload(
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&)>(DragInt3),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, float)>(DragInt3),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, float, int)>(DragInt3),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, float, int, int)>(DragInt3),
-                                                                sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, float, int, int, const std::string&)>(DragInt3)
+                                                                sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, float, int, int, const std::string&)>(DragInt3),
+                                                                sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, float, int, int, const std::string&, int)>(DragInt3)
                                                             ));
         ImGui.set_function("DragInt4"            , sol::overload(
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&)>(DragInt4),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, float)>(DragInt4),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, float, int)>(DragInt4),
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, float, int, int)>(DragInt4),
-                                                                sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, float, int, int, const std::string&)>(DragInt4)
+                                                                sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, float, int, int, const std::string&)>(DragInt4),
+                                                                sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, float, int, int, const std::string&, int)>(DragInt4)
                                                             ));
 #pragma endregion Widgets: Drags
 
@@ -2372,23 +2464,28 @@ namespace sol_ImGui
                                                                 sol::resolve<std::tuple<float, bool>(const std::string&, float)>(SliderAngle),
                                                                 sol::resolve<std::tuple<float, bool>(const std::string&, float, float)>(SliderAngle),
                                                                 sol::resolve<std::tuple<float, bool>(const std::string&, float, float, float)>(SliderAngle),
-                                                                sol::resolve<std::tuple<float, bool>(const std::string&, float, float, float, const std::string&)>(SliderAngle)
+                                                                sol::resolve<std::tuple<float, bool>(const std::string&, float, float, float, const std::string&)>(SliderAngle),
+                                                                sol::resolve<std::tuple<float, bool>(const std::string&, float, float, float, const std::string&, int)>(SliderAngle)
                                                             ));
         ImGui.set_function("SliderInt"            , sol::overload(
                                                                 sol::resolve<std::tuple<int, bool>(const std::string&, int, int, int)>(SliderInt),
-                                                                sol::resolve<std::tuple<int, bool>(const std::string&, int, int, int, const std::string&)>(SliderInt)
+                                                                sol::resolve<std::tuple<int, bool>(const std::string&, int, int, int, const std::string&)>(SliderInt),
+                                                                sol::resolve<std::tuple<int, bool>(const std::string&, int, int, int, const std::string&, int)>(SliderInt)
                                                             ));
         ImGui.set_function("SliderInt2"            , sol::overload(
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, int, int)>(SliderInt2),
-                                                                sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, int, int, const std::string&)>(SliderInt2)
+                                                                sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, int, int, const std::string&)>(SliderInt2),
+                                                                sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, int, int, const std::string&, int)>(SliderInt2)
                                                             ));
         ImGui.set_function("SliderInt3"            , sol::overload(
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, int, int)>(SliderInt3),
-                                                                sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, int, int, const std::string&)>(SliderInt3)
+                                                                sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, int, int, const std::string&)>(SliderInt3),
+                                                                sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, int, int, const std::string&, int)>(SliderInt3)
                                                             ));
         ImGui.set_function("SliderInt4"            , sol::overload(
                                                                 sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, int, int)>(SliderInt4),
-                                                                sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, int, int, const std::string&)>(SliderInt4)
+                                                                sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, int, int, const std::string&)>(SliderInt4),
+                                                                sol::resolve<std::tuple<sol::as_table_t<std::vector<int>>, bool>(const std::string&, const sol::table&, int, int, const std::string&, int)>(SliderInt4)
                                                             ));
         ImGui.set_function("VSliderFloat"          , sol::overload(
                                                                 sol::resolve<std::tuple<float, bool>(const std::string&, float, float, float, float, float)>(VSliderFloat),
@@ -2397,7 +2494,8 @@ namespace sol_ImGui
                                                             ));
         ImGui.set_function("VSliderInt"            , sol::overload(
                                                                 sol::resolve<std::tuple<int, bool>(const std::string&, float, float, int, int, int)>(VSliderInt),
-                                                                sol::resolve<std::tuple<int, bool>(const std::string&, float, float, int, int, int, const std::string&)>(VSliderInt)
+                                                                sol::resolve<std::tuple<int, bool>(const std::string&, float, float, int, int, int, const std::string&)>(VSliderInt),
+                                                                sol::resolve<std::tuple<int, bool>(const std::string&, float, float, int, int, int, const std::string&, int)>(VSliderInt)
                                                             ));
 #pragma endregion Widgets: Sliders
 

--- a/src/sol_imgui/sol_imgui.h
+++ b/src/sol_imgui/sol_imgui.h
@@ -4,32 +4,18 @@ namespace sol_ImGui
 {
     // Windows
     inline bool Begin(const std::string& name)                              { return ImGui::Begin(name.c_str()); }
+    inline bool Begin(const std::string& name, int flags)                   { return ImGui::Begin(name.c_str(), NULL, static_cast<ImGuiWindowFlags_>(flags)); }
     inline std::tuple<bool, bool> Begin(const std::string& name, bool open)
     {
         if (!open) return std::make_tuple(false, false);
-
-        bool shouldDraw = ImGui::Begin(name.c_str(), &open);
-
-        if(!open)
-        {
-            ImGui::End();
-            return std::make_tuple(false, false);
-        }
-
-        return std::make_tuple(open, shouldDraw);
+        const bool shouldDraw = ImGui::Begin(name.c_str(), &open);
+        return std::make_tuple(open, open && shouldDraw);
     }
     inline std::tuple<bool, bool> Begin(const std::string& name, bool open, int flags)
     {
         if (!open) return std::make_tuple(false, false);
-        bool shouldDraw = ImGui::Begin(name.c_str(), &open, static_cast<ImGuiWindowFlags_>(flags));
-
-        if(!open)
-        {
-            ImGui::End();
-            return std::make_tuple(false, false);
-        }
-
-        return std::make_tuple(open, shouldDraw);
+        const bool shouldDraw = ImGui::Begin(name.c_str(), &open, static_cast<ImGuiWindowFlags_>(flags));
+        return std::make_tuple(open, open && shouldDraw);
     }
     inline void End()                                               { ImGui::End(); }
 
@@ -1535,6 +1521,7 @@ namespace sol_ImGui
     inline bool BeginPopup(const std::string& str_id)                                   { return ImGui::BeginPopup(str_id.c_str()); }
     inline bool BeginPopup(const std::string& str_id, int flags)                        { return ImGui::BeginPopup(str_id.c_str(), static_cast<ImGuiWindowFlags>(flags)); }
     inline bool BeginPopupModal(const std::string& name)                                { return ImGui::BeginPopupModal(name.c_str()); }
+    inline bool BeginPopupModal(const std::string& name, int flags)                     { return ImGui::BeginPopupModal(name.c_str(), NULL, static_cast<ImGuiWindowFlags>(flags)); }
     inline bool BeginPopupModal(const std::string& name, bool open)                     { return ImGui::BeginPopupModal(name.c_str(), &open); }
     inline bool BeginPopupModal(const std::string& name, bool open, int flags)          { return ImGui::BeginPopupModal(name.c_str(), &open, static_cast<ImGuiWindowFlags>(flags)); }
     inline void EndPopup()                                                              { ImGui::EndPopup(); }
@@ -1573,6 +1560,7 @@ namespace sol_ImGui
     inline bool BeginTabBar(const std::string& str_id, int flags)                                   { return ImGui::BeginTabBar(str_id.c_str(), static_cast<ImGuiTabBarFlags>(flags)); }
     inline void EndTabBar()                                                                         { ImGui::EndTabBar(); }
     inline bool BeginTabItem(const std::string& label)                                              { return ImGui::BeginTabItem(label.c_str()); }
+    inline bool BeginTabItem(const std::string& label, int flags)                                   { return ImGui::BeginTabItem(label.c_str(), NULL, static_cast<ImGuiTabItemFlags>(flags)); }
     inline std::tuple<bool, bool> BeginTabItem(const std::string& label, bool open)                 { bool selected = ImGui::BeginTabItem(label.c_str(), &open); return std::make_tuple(open, selected); }
     inline std::tuple<bool, bool> BeginTabItem(const std::string& label, bool open, int flags)      { bool selected = ImGui::BeginTabItem(label.c_str(), &open, static_cast<ImGuiTabItemFlags>(flags)); return std::make_tuple(open, selected); }
     inline void EndTabItem()                                                                        { ImGui::EndTabItem(); }
@@ -2117,6 +2105,7 @@ namespace sol_ImGui
 #pragma region Windows
         ImGui.set_function("Begin"              , sol::overload(
                                                                 sol::resolve<bool(const std::string&)>(Begin),
+                                                                sol::resolve<bool(const std::string&, int)>(Begin),
                                                                 sol::resolve<std::tuple<bool, bool>(const std::string&, bool)>(Begin),
                                                                 sol::resolve<std::tuple<bool, bool>(const std::string&, bool, int)>(Begin)
                                                             ));
@@ -2669,6 +2658,7 @@ namespace sol_ImGui
                                                             ));
         ImGui.set_function("BeginPopupModal"        , sol::overload(
                                                                 sol::resolve<bool(const std::string&)>(BeginPopupModal),
+                                                                sol::resolve<bool(const std::string&, int)>(BeginPopupModal),
                                                                 sol::resolve<bool(const std::string&, bool)>(BeginPopupModal),
                                                                 sol::resolve<bool(const std::string&, bool, int)>(BeginPopupModal)
                                                             ));
@@ -2729,6 +2719,7 @@ namespace sol_ImGui
         ImGui.set_function("EndTabBar"             , EndTabBar);
         ImGui.set_function("BeginTabItem"          , sol::overload(
                                                                 sol::resolve<bool(const std::string&)>(BeginTabItem),
+                                                                sol::resolve<bool(const std::string&, int)>(BeginTabItem),
                                                                 sol::resolve<std::tuple<bool, bool>(const std::string&, bool)>(BeginTabItem),
                                                                 sol::resolve<std::tuple<bool, bool>(const std::string&, bool, int)>(BeginTabItem)
                                                             ));


### PR DESCRIPTION
- Enabled ImGui keyboard navigation (Following @WSSDude420 's instruction 😄 )
- Removed the deprecated argument of Drag and Slider widgets, replace it with the newer ImGuiSliderFlag in sol_imgui.h
- Fixed space and tab mix up and alignment in sol_imgui.h
- Made the argument `open` optional in  ImGui.Begin(), ImGui.BeginModal(), ImGui.BeginTabItem(), so the close button can be hidden when setting flags.
- Added bindings for the new table widgets in ImGui 1.8.0