### PR TITLE
TweakDB binding

### DIFF
--- a/src/reverse/StrongReference.h
+++ b/src/reverse/StrongReference.h
@@ -13,6 +13,7 @@ protected:
     
 private:
     friend struct Scripting;
+    friend struct TweakDB;
     
     RED4ext::Handle<RED4ext::IScriptable> m_strongHandle;
 };

--- a/src/reverse/TweakDB.cpp
+++ b/src/reverse/TweakDB.cpp
@@ -242,13 +242,20 @@ bool TweakDB::SetFlat(TweakDBID aDBID, sol::object aValue)
     ResetAllocator ___allocatorReset;
 
     RED4ext::CStackType stackType = Scripting::ToRED(aValue, stackTypeCurrent.type, &s_scratchMemory);
+    if (stackType.value == nullptr)
+    {
+        RED4ext::CName typeName;
+        stackTypeCurrent.type->GetName(typeName);
+        spdlog::get("scripting")->info("[TweakDB::SetFlat] Failed to convert value. Expecting: {}", typeName.ToString());
+        return false;
+    }
     if (stackType.type->IsEqual(stackType.value, stackTypeCurrent.value))
         return true;
 
     auto* pNewPoolItem = pFlatValuePool->GetOrCreate(stackType);
     if (pNewPoolItem == nullptr)
     {
-        spdlog::get("scripting")->info("Failed to create FlatValue. possibly not enough space.");
+        spdlog::get("scripting")->info("[TweakDB::SetFlat] Failed to create FlatValue");
         return false;
     }
     pCurentPoolItem->DecUseCount();

--- a/src/reverse/TweakDB.cpp
+++ b/src/reverse/TweakDB.cpp
@@ -123,6 +123,20 @@ TweakDB::TweakDB(sol::state_view aLua)
 {
 }
 
+void TweakDB::DebugStats()
+{
+    static auto* pTDB = RED4ext::TweakDB::Get();
+    std::shared_lock<RED4ext::SharedMutex> _1(pTDB->mutex00);
+    std::shared_lock<RED4ext::SharedMutex> _2(pTDB->mutex01);
+
+    spdlog::get("scripting")->info("flats: {}", pTDB->flats.size);
+    spdlog::get("scripting")->info("records: {}", pTDB->recordsByID.size);
+    spdlog::get("scripting")->info("queries: {}", pTDB->queryIDs.size);
+    spdlog::get("scripting")->info("flatDataBuffer current size: {} bytes", pTDB->flatDataBufferSize);
+    auto bufferFreeBytes = (pTDB->flatDataBuffer + pTDB->flatDataBufferSize) - pTDB->flatDataBufferEnd;
+    spdlog::get("scripting")->info("flatDataBuffer has {} free bytes (maybe {} more unique values)", bufferFreeBytes, bufferFreeBytes / 24);
+}
+
 sol::object TweakDB::GetRecord(TweakDBID aDBID)
 {
     static auto* pTDB = RED4ext::TweakDB::Get();

--- a/src/reverse/TweakDB.cpp
+++ b/src/reverse/TweakDB.cpp
@@ -89,7 +89,7 @@ void InitializeFlatValuePools()
     }
 
     std::shared_lock<RED4ext::SharedMutex> _(pTDB->mutex00);
-    if (pTDB->flatDataBufferSize == 0) return; // TweakDB is not initialized yet
+    if (pTDB->flatDataBufferCapacity == 0) return; // TweakDB is not initialized yet
 
     for (RED4ext::TweakDBID& flatID : pTDB->flats)
     {
@@ -133,9 +133,7 @@ void TweakDB::DebugStats()
     spdlog::get("scripting")->info("flats: {}", pTDB->flats.size);
     spdlog::get("scripting")->info("records: {}", pTDB->recordsByID.size);
     spdlog::get("scripting")->info("queries: {}", pTDB->queryIDs.size);
-    spdlog::get("scripting")->info("flatDataBuffer current size: {} bytes", pTDB->flatDataBufferSize);
-    auto bufferFreeBytes = (pTDB->flatDataBuffer + pTDB->flatDataBufferSize) - pTDB->flatDataBufferEnd;
-    spdlog::get("scripting")->info("flatDataBuffer has {} free bytes (maybe {} more unique values)", bufferFreeBytes, bufferFreeBytes / 24);
+    spdlog::get("scripting")->info("flatDataBuffer capacity: {} bytes", pTDB->flatDataBufferCapacity);
 }
 
 sol::object TweakDB::GetRecord(TweakDBID aDBID)
@@ -249,7 +247,7 @@ bool TweakDB::SetFlat(TweakDBID aDBID, sol::object aValue)
     auto* pNewPoolItem = pFlatValuePool->GetOrCreate(stackType);
     if (pNewPoolItem == nullptr)
     {
-        spdlog::get("scripting")->info("Failed to create FlatValue. possibly not enough space."); // TODO: RED4ext.SDK should grow buffer
+        spdlog::get("scripting")->info("Failed to create FlatValue. possibly not enough space.");
         return false;
     }
     pCurentPoolItem->DecUseCount();

--- a/src/reverse/TweakDB.cpp
+++ b/src/reverse/TweakDB.cpp
@@ -2,6 +2,7 @@
 
 #include <RED4ext/Types/TweakDB.hpp>
 
+#include <reverse/WeakReference.h>
 #include <reverse/StrongReference.h>
 #include <scripting/Scripting.h>
 
@@ -259,6 +260,32 @@ bool TweakDB::SetFlat(TweakDBID aDBID, sol::object aValue)
     pDBID->tdbOffsetBE[2] = reinterpret_cast<uint8_t*>(&pNewPoolItem->tdbOffset)[0];
 
     return true;
+}
+
+bool TweakDB::UpdateRecordByID(TweakDBID aDBID)
+{
+    static auto* pTDB = RED4ext::TweakDB::Get();
+
+    return pTDB->UpdateRecord(RED4ext::TweakDBID(aDBID.value));
+}
+
+bool TweakDB::UpdateRecord(sol::object aValue)
+{
+    static auto* pTDB = RED4ext::TweakDB::Get();
+
+    if (aValue.is<StrongReference>())
+    {
+        return pTDB->UpdateRecord(reinterpret_cast<RED4ext::gamedataTweakDBRecord*>(aValue.as<StrongReference*>()->GetHandle()));
+    }
+    else if (aValue.is<WeakReference>())
+    {
+        return pTDB->UpdateRecord(reinterpret_cast<RED4ext::gamedataTweakDBRecord*>(aValue.as<WeakReference*>()->GetHandle()));
+    }
+    else
+    {
+        spdlog::get("scripting")->info("[TweakDB::UpdateRecord] Expecting handle or whandle");
+        return false;
+    }
 }
 
 FlatValuePool::Item::Item(int32_t aTDBOffset)

--- a/src/reverse/TweakDB.cpp
+++ b/src/reverse/TweakDB.cpp
@@ -209,7 +209,7 @@ bool TweakDB::SetFlat(TweakDBID aDBID, sol::object aValue)
 }
 
 FlatValuePool::Item::Item(int32_t aTDBOffset)
-    : useCount(1),
+    : useCount(0),
     tdbOffset(aTDBOffset)
 {
 }
@@ -295,7 +295,9 @@ FlatValuePool::Item* FlatValuePool::GetOrCreate(const RED4ext::CStackType& acSta
 
     if (tdbOffset == -1)
     {
-        auto* pFlatValue = pTDB->CreateFlatValue(acStackType.type);
+        // TODO: Try to reuse items with useCount == 0 if it doesn't tank performance
+
+        auto* pFlatValue = pTDB->CreateFlatValue(acStackType);
         if (pFlatValue == nullptr)
         {
             // Failed to create FlatValue
@@ -332,7 +334,7 @@ FlatValuePool::HashType FlatValuePool::HashValue(const RED4ext::CStackType& acSt
         case FlatValuePool::Type::ArrayFloat:
         case FlatValuePool::Type::ArrayInt32:
         {
-            if (acStackType.type->GetType() == RED4ext::ERTTIType::Array)
+            if (acStackType.type->GetType() != RED4ext::ERTTIType::Array)
             {
                 RED4ext::CName typeName;
                 acStackType.type->GetName(typeName);

--- a/src/reverse/TweakDB.cpp
+++ b/src/reverse/TweakDB.cpp
@@ -1,0 +1,99 @@
+#include <stdafx.h>
+
+#include <RED4ext/Types/TweakDB.hpp>
+
+#include <scripting/Scripting.h>
+
+#include "TweakDB.h"
+
+TweakDB::TweakDB(sol::state_view aLua)
+    : m_lua(std::move(aLua))
+{
+}
+
+sol::object TweakDB::GetRecord(TweakDBID aDBID)
+{
+    static auto* pTDB = RED4ext::TweakDB::Get();
+
+    RED4ext::TweakDBID dbid;
+    dbid.value = aDBID.value;
+
+    auto* record = pTDB->GetRecord(dbid);
+    if (record == nullptr)
+        return sol::nil;
+
+    RED4ext::CStackType stackType;
+    stackType.type = (*record)->GetType();
+    stackType.value = record;
+    return Scripting::ToLua(m_lua, stackType);
+}
+
+sol::object TweakDB::Query(TweakDBID aDBID)
+{
+    static auto* pRTTI = RED4ext::CRTTISystem::Get();
+    static auto* pArrayTweakDBIDType = pRTTI->GetType("array:TweakDBID");
+    static auto* pTDB = RED4ext::TweakDB::Get();
+
+    RED4ext::TweakDBID dbid;
+    dbid.value = aDBID.value;
+
+    auto* queryResult = pTDB->Query(dbid);
+    if (queryResult == nullptr)
+        return sol::nil;
+
+    RED4ext::CStackType stackType;
+    stackType.type = pArrayTweakDBIDType;
+    stackType.value = queryResult;
+    return Scripting::ToLua(m_lua, stackType);
+}
+
+sol::object TweakDB::GetFlat(TweakDBID aDBID)
+{
+    static auto* pTDB = RED4ext::TweakDB::Get();
+
+    RED4ext::TweakDBID dbid;
+    dbid.value = aDBID.value;
+
+    auto* flatValue = pTDB->GetFlatValue(dbid);
+    if (flatValue == nullptr)
+        return sol::nil;
+
+    RED4ext::CStackType stackType;
+    flatValue->GetValue(&stackType);
+    return Scripting::ToLua(m_lua, stackType);
+}
+
+bool TweakDB::SetFlat(TweakDBID aDBID, sol::object aValue)
+{
+    static auto* pTDB = RED4ext::TweakDB::Get();
+
+    RED4ext::TweakDBID dbid;
+    dbid.value = aDBID.value;
+
+    auto* flatValue = pTDB->GetFlatValue(dbid);
+    if (flatValue == nullptr)
+        return false;
+
+    RED4ext::CStackType stackTypeCurrent;
+    flatValue->GetValue(&stackTypeCurrent);
+    bool isDefaultValue = false;
+    pTDB->defaultValueByType.for_each([&stackTypeCurrent, &isDefaultValue](const RED4ext::CName&, RED4ext::TweakDB::FlatValue* defaultFlatValue)
+        {
+            if (stackTypeCurrent.value == defaultFlatValue)
+                isDefaultValue = true;
+        });
+    if (isDefaultValue) return false; // catastrophic. don't modify.
+
+    static thread_local TiltedPhoques::ScratchAllocator s_scratchMemory(1024);
+    struct ResetAllocator
+    {
+        ~ResetAllocator()
+        {
+            s_scratchMemory.Reset();
+        }
+    };
+    ResetAllocator ___allocatorReset;
+
+    RED4ext::CStackType stackType = Scripting::ToRED(aValue, stackTypeCurrent.type, &s_scratchMemory);
+    return flatValue->SetValue(stackType);
+}

--- a/src/reverse/TweakDB.cpp
+++ b/src/reverse/TweakDB.cpp
@@ -255,6 +255,7 @@ FlatValuePool::Item::Item(int32_t aTDBOffset)
 
 void FlatValuePool::Item::DecUseCount()
 {
+    if (useCount == 0) return;
     --useCount;
 }
 

--- a/src/reverse/TweakDB.cpp
+++ b/src/reverse/TweakDB.cpp
@@ -248,7 +248,7 @@ bool TweakDB::SetFlat(TweakDBID aDBID, sol::object aValue)
     auto* pNewPoolItem = pFlatValuePool->GetOrCreate(stackType);
     if (pNewPoolItem == nullptr)
     {
-        // Failed to create FlatValue
+        spdlog::get("scripting")->info("Failed to create FlatValue. possibly not enough space."); // TODO: RED4ext.SDK should grow buffer
         return false;
     }
     pCurentPoolItem->DecUseCount();

--- a/src/reverse/TweakDB.h
+++ b/src/reverse/TweakDB.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <reverse/BasicTypes.h>
+
+struct TweakDB
+{
+  TweakDB(sol::state_view aLua);
+
+  sol::object GetRecord(TweakDBID aDBID);
+  sol::object Query(TweakDBID aDBID);
+  sol::object GetFlat(TweakDBID aDBID);
+  bool SetFlat(TweakDBID aDBID, sol::object aValue);
+
+private:
+  sol::state_view m_lua;
+};

--- a/src/reverse/TweakDB.h
+++ b/src/reverse/TweakDB.h
@@ -6,6 +6,7 @@ struct TweakDB
 {
   TweakDB(sol::state_view aLua);
 
+  void DebugStats();
   sol::object GetRecord(TweakDBID aDBID);
   sol::object Query(TweakDBID aDBID);
   sol::object GetFlat(TweakDBID aDBID);

--- a/src/reverse/TweakDB.h
+++ b/src/reverse/TweakDB.h
@@ -11,6 +11,8 @@ struct TweakDB
   sol::object Query(TweakDBID aDBID);
   sol::object GetFlat(TweakDBID aDBID);
   bool SetFlat(TweakDBID aDBID, sol::object aValue);
+  bool UpdateRecordByID(TweakDBID aDBID);
+  bool UpdateRecord(sol::object aValue);
 
 private:
   sol::state_view m_lua;

--- a/src/reverse/WeakReference.h
+++ b/src/reverse/WeakReference.h
@@ -13,6 +13,7 @@ protected:
     
 private:
     friend struct Scripting;
+    friend struct TweakDB;
     
     RED4ext::WeakHandle<RED4ext::IScriptable> m_weakHandle;
 };

--- a/src/scripting/Scripting.cpp
+++ b/src/scripting/Scripting.cpp
@@ -358,6 +358,7 @@ void Scripting::Initialize()
 
     m_lua.new_usertype<TweakDB>("__TweakDB",
         sol::meta_function::construct, sol::no_constructor,
+        "DebugStats", &TweakDB::DebugStats,
         "GetRecord", &TweakDB::GetRecord,
         "Query", &TweakDB::Query,
         "GetFlat", &TweakDB::GetFlat,

--- a/src/scripting/Scripting.cpp
+++ b/src/scripting/Scripting.cpp
@@ -362,7 +362,8 @@ void Scripting::Initialize()
         "GetRecord", &TweakDB::GetRecord,
         "Query", &TweakDB::Query,
         "GetFlat", &TweakDB::GetFlat,
-        "SetFlat", &TweakDB::SetFlat);
+        "SetFlat", &TweakDB::SetFlat,
+        "Update", sol::overload(&TweakDB::UpdateRecordByID, &TweakDB::UpdateRecord));
 
     m_lua["TweakDB"] = TweakDB(m_lua);
 

--- a/src/scripting/Scripting.cpp
+++ b/src/scripting/Scripting.cpp
@@ -16,6 +16,7 @@
 #include <reverse/Converter.h>
 #include <reverse/WeakReference.h>
 #include <reverse/Enum.h>
+#include <reverse/TweakDB.h>
 
 #include "Utils.h"
 
@@ -354,6 +355,15 @@ void Scripting::Initialize()
 
         spdlog::get("scripting")->info(oss.str());
     };
+
+    m_lua.new_usertype<TweakDB>("__TweakDB",
+        sol::meta_function::construct, sol::no_constructor,
+        "GetRecord", &TweakDB::GetRecord,
+        "Query", &TweakDB::Query,
+        "GetFlat", &TweakDB::GetFlat,
+        "SetFlat", &TweakDB::SetFlat);
+
+    m_lua["TweakDB"] = TweakDB(m_lua);
 
 #ifndef NDEBUG
     m_lua["DumpVtables"] = [this]()

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -22,7 +22,7 @@
 #include <RED4ext/Scripting/Stack.hpp>
 #include <RED4ext/Scripting/CProperty.hpp>
 #include <RED4ext/Scripting/Functions.hpp>
-#include <RED4ext/IMemoryAllocator.hpp>
+#include <RED4ext/MemoryAllocators.hpp>
 
 #include <filesystem>
 #include <iostream>


### PR DESCRIPTION
This requires latest RED4ext.SDK.

• TweakDB:GetFlat(...):
Parameter: flat DBID
Return: value or nil

• TweakDB:SetFlat(...):
Parameter: flat DBID
Return: true on success
Note: FlatValues are pooled. Our value pool is initialized on the first call to TweakDB::SetFlat

• TweakDB:GetRecord(...):
Parameter: record DBID
Return: StrongReference or nil

• TweakDB:Query(...):
Parameter: query DBID
Return: array or nil on failure

• TweakDB:Update(...):
Parameter: record DBID or a record handle
Return: true on success
Note: I was thinking about adding "TweakDB::UpdateAllRecords" but i think mods would abuse it, it will tank performance.

Query
![Query](https://user-images.githubusercontent.com/26506177/106796776-7c1d7480-6664-11eb-81e1-cc966305b6a7.PNG)
Record
![records](https://user-images.githubusercontent.com/26506177/106796778-7d4ea180-6664-11eb-9a5b-bab822ee317d.PNG)
Getting/Setting a flat value then "updating" the record to point to the new value
![SetFlat_record](https://user-images.githubusercontent.com/26506177/106796779-7de73800-6664-11eb-8b05-3868f1dc0d5a.PNG)
