### PR TITLE
Converter::ToRED - LuaRED implicit conversion should only be for numbers

### DIFF
--- a/src/reverse/LuaRED.h
+++ b/src/reverse/LuaRED.h
@@ -2,7 +2,7 @@
 
 #include "common/Meta.h"
 
-template<class T, FixedString REDName>
+template<class T, FixedString REDName, bool CheckObjectType = !std::is_arithmetic_v<T>>
 struct LuaRED
 {
     static constexpr char const* Name = REDName;
@@ -16,10 +16,13 @@ struct LuaRED
     {
         RED4ext::CStackType result;
         result.type = m_pRtti;
-        if(aObject != sol::nil)
-            result.value = apAllocator->New<T>(aObject.as<T>());
-        else
-            result.value = apAllocator->New<T>();
+        if (!CheckObjectType || aObject.is<T>())
+        {
+            if (aObject != sol::nil)
+                result.value = apAllocator->New<T>(aObject.as<T>());
+            else
+                result.value = apAllocator->New<T>();
+        }
 
         return result;
     }


### PR DESCRIPTION
This fixes the annoying "expecting userdata got XX"
it also lets Scripting::ToRED return nullptr in stackType.value so you could add logs in your code for the expected type.
It shouldn't cause any issues with any mod

I do it in TweakDB::SetFlat
```cpp
RED4ext::CStackType stackType = Scripting::ToRED(aValue, stackTypeCurrent.type, &s_scratchMemory);
if (stackType.value == nullptr)
{
    RED4ext::CName typeName;
    stackTypeCurrent.type->GetName(typeName);
    spdlog::get("scripting")->info("[TweakDB::SetFlat] Failed to convert value. Expecting: {}", typeName.ToString());
    return false;
}
```