### PR TITLE
Fix LuaRED converter for nils

### DIFF
--- a/src/reverse/LuaRED.h
+++ b/src/reverse/LuaRED.h
@@ -16,12 +16,13 @@ struct LuaRED
     {
         RED4ext::CStackType result;
         result.type = m_pRtti;
-        if (!CheckObjectType || aObject.is<T>())
+        if (aObject == sol::nil)
         {
-            if (aObject != sol::nil)
-                result.value = apAllocator->New<T>(aObject.as<T>());
-            else
-                result.value = apAllocator->New<T>();
+            result.value = apAllocator->New<T>();
+        }
+        else if (!CheckObjectType || aObject.is<T>())
+        {
+            result.value = apAllocator->New<T>(aObject.as<T>());
         }
 
         return result;
@@ -29,12 +30,13 @@ struct LuaRED
 
     void ToRED(sol::object aObject, RED4ext::CStackType* apType)
     {
-        if (!CheckObjectType || aObject.is<T>())
+        if (aObject == sol::nil)
         {
-            if (aObject != sol::nil)
-                *reinterpret_cast<T*>(apType->value) = aObject.as<T>();
-            else
-                *reinterpret_cast<T*>(apType->value) = T{};
+            *reinterpret_cast<T*>(apType->value) = T{};
+        }
+        else if (!CheckObjectType || aObject.is<T>())
+        {
+            *reinterpret_cast<T*>(apType->value) = aObject.as<T>();
         }
     }
 


### PR DESCRIPTION
An issue with out args of non-scalar types was found.

```
import function GetQuestMappinPosition(mappinHash : Uint32, out position : Vector3) : Bool;
```
![](https://cdn.discordapp.com/attachments/794613856948322344/819917951456641034/unknown.png)

This call `args[i] = Scripting::ToRED(sol::nil, apFunc->params[i]->type, &s_scratchMemory);` for creating a placeholder for the out arg was resulting in an empty value because of the condition `if (!CheckObjectType || aObject.is<T>())` since `sol::nil` has no type and can't be checked with `.is()`.

Command for testing (works in Main Menu):
```
print(Game.GetMappinSystem():GetQuestMappinPosition(0))
```
