### PR TITLE
Add bit lib (accessible with bit32), actually use LuaJIT with sol3

### DIFF
--- a/src/scripting/LuaSandbox.cpp
+++ b/src/scripting/LuaSandbox.cpp
@@ -77,6 +77,7 @@ static constexpr const char* s_cGlobalTablesWhitelist[] =
     "string",
     "table",
     "math",
+    "bit32"
 };
 
 static constexpr const char* s_cGlobalExtraLibsWhitelist[] =

--- a/src/scripting/Scripting.cpp
+++ b/src/scripting/Scripting.cpp
@@ -46,7 +46,7 @@ void Scripting::Initialize()
     auto& luaVm = lua.Get();
 
     luaVm.open_libraries(sol::lib::base, sol::lib::string, sol::lib::io, sol::lib::math, sol::lib::package,
-                         sol::lib::os, sol::lib::table);
+                         sol::lib::os, sol::lib::table, sol::lib::bit32);
     luaVm.require("sqlite3", luaopen_lsqlite3);
 
     sol_ImGui::InitBindings(luaVm);

--- a/xmake.lua
+++ b/xmake.lua
@@ -12,7 +12,6 @@ add_rules("plugin.vsxmake.autoupdate")
 
 if is_mode("debug") or is_mode("releasedbg") then
     add_defines("CET_DEBUG")
-
 elseif is_mode("release") then
     add_defines("NDEBUG")
     set_optimize("fastest")
@@ -56,7 +55,7 @@ target("RED4ext.SDK")
     add_includedirs("vendor/RED4ext.SDK/include/", { public = true })
 
 target("cyber_engine_tweaks")
-    add_defines("WIN32_LEAN_AND_MEAN", "NOMINMAX", "SOL_ALL_SAFETIES_ON", "WINVER=0x0601") -- WINVER=0x0601 == Windows 7, we need this specified now for some reason
+    add_defines("WIN32_LEAN_AND_MEAN", "NOMINMAX", "SOL_ALL_SAFETIES_ON", "WINVER=0x0601", "SOL_LUAJIT=1") -- WINVER=0x0601 == Windows 7, we need this specified now for some reason
     set_pcxxheader("src/stdafx.h")
     set_kind("shared")
     set_filename("cyber_engine_tweaks.asi")


### PR DESCRIPTION
Adds left out define needed for sol to actually utilize LuaJIT (right now, it just uses Lua 5.1 thanks to it)

Also adds and whitelists bit library, as bit-wise ops are missing in older Lua (accessible with bit32 from within Lua).