### PR TITLE
Deep copy environments

### DIFF
--- a/src/Utils.h
+++ b/src/Utils.h
@@ -7,3 +7,22 @@ void trim(std::string& s);
 spdlog::sink_ptr CreateCustomSinkST(std::function<void(const std::string&)> aSinkItHandler, std::function<void()> aFlushHandler = nullptr);
 spdlog::sink_ptr CreateCustomSinkMT(std::function<void(const std::string&)> aSinkItHandler, std::function<void()> aFlushHandler = nullptr);
 std::shared_ptr<spdlog::logger> CreateLogger(const std::filesystem::path& aPath, const std::string& aID, spdlog::sink_ptr aExtraSink = nullptr, const std::string& aPattern = "[%Y-%m-%d %H:%M:%S UTC%z] [%l] %v");
+
+// deep copies sol object (doesnt take into account potential duplicates)
+sol::object DeepCopySolObject(sol::object aObj, const sol::state_view& aStateView);
+
+// extend hash so we can hash sol objects too
+namespace std
+{
+    template<>
+    struct hash<sol::object>
+    {
+        std::size_t operator()(const sol::object& k) const
+        {
+            return reinterpret_cast<size_t>(k.pointer());
+        }
+    };
+} // namespace std
+
+// deep copies sol object (takes into account potential duplicates, may be redundant)
+sol::object DeepCopySolObject(sol::object aObj, const sol::state_view& aStateView,std::unordered_map<sol::object, sol::object>& aSeen);

--- a/src/scripting/FunctionOverride.cpp
+++ b/src/scripting/FunctionOverride.cpp
@@ -48,7 +48,8 @@ bool FunctionOverride::HookRunPureScriptFunction(RED4ext::CClassFunction* apFunc
         const auto& calls = itor->second.Calls;
         for (const auto& call : calls)
         {
-            const auto result = call->ScriptFunction(as_args(args), call->Environment);
+            call->Environment.set_on(call->ScriptFunction);
+            const auto result = call->ScriptFunction(as_args(args));
             if (!call->Forward)
             {
                 if (result.valid() && ret.value && ret.type)
@@ -211,7 +212,8 @@ void FunctionOverride::HandleOverridenFunction(RED4ext::IScriptable* apContext, 
         const auto& calls = context.Calls;
         for (const auto& call : calls)
         {
-            const auto result = call->ScriptFunction(as_args(args), call->Environment);
+            call->Environment.set_on(call->ScriptFunction);
+            const auto result = call->ScriptFunction(as_args(args));
             if (!call->Forward)
             {
                 if (apFunction->returnType)

--- a/src/scripting/LuaSandbox.cpp
+++ b/src/scripting/LuaSandbox.cpp
@@ -77,6 +77,7 @@ static constexpr const char* s_cGlobalTablesWhitelist[] =
     "string",
     "table",
     "math",
+    "bit32"
 };
 
 static constexpr const char* s_cGlobalExtraLibsWhitelist[] =

--- a/src/scripting/Sandbox.cpp
+++ b/src/scripting/Sandbox.cpp
@@ -3,14 +3,17 @@
 #include "Sandbox.h"
 #include "Scripting.h"
 
+#include <Utils.h>
+
 Sandbox::Sandbox(Scripting* apScripting, sol::environment aBaseEnvironment, const std::filesystem::path& acRootPath)
     : m_pScripting(apScripting)
     , m_env(apScripting->GetState().Get(), sol::create)
     , m_path(acRootPath)
 {
     // copy base environment, do not set it as fallback, as it may cause globals to bleed into other things!
+    sol::state_view sv = apScripting->GetState().Get();
     for (const auto& cKV : aBaseEnvironment)
-        m_env[cKV.first].set(cKV.second.as<sol::object>());
+        m_env[DeepCopySolObject(cKV.first, sv)] = DeepCopySolObject(cKV.second, sv);
 }
 
 sol::protected_function_result Sandbox::ExecuteFile(const std::string& acPath) const

--- a/src/scripting/ScriptContext.cpp
+++ b/src/scripting/ScriptContext.cpp
@@ -13,7 +13,8 @@ static sol::protected_function_result TryLuaFunction(std::shared_ptr<spdlog::log
     {
         try
         {
-            result = aFunc(aArgs..., aEnv);
+            aEnv.set_on(aFunc);
+            result = aFunc(aArgs...);
         }
         catch(std::exception& e)
         {

--- a/src/scripting/Scripting.cpp
+++ b/src/scripting/Scripting.cpp
@@ -46,7 +46,7 @@ void Scripting::Initialize()
     auto& luaVm = lua.Get();
 
     luaVm.open_libraries(sol::lib::base, sol::lib::string, sol::lib::io, sol::lib::math, sol::lib::package,
-                         sol::lib::os, sol::lib::table);
+                         sol::lib::os, sol::lib::table, sol::lib::bit32);
     luaVm.require("sqlite3", luaopen_lsqlite3);
 
     sol_ImGui::InitBindings(luaVm);

--- a/xmake.lua
+++ b/xmake.lua
@@ -12,7 +12,6 @@ add_rules("plugin.vsxmake.autoupdate")
 
 if is_mode("debug") or is_mode("releasedbg") then
     add_defines("CET_DEBUG")
-
 elseif is_mode("release") then
     add_defines("NDEBUG")
     set_optimize("fastest")
@@ -56,7 +55,7 @@ target("RED4ext.SDK")
     add_includedirs("vendor/RED4ext.SDK/include/", { public = true })
 
 target("cyber_engine_tweaks")
-    add_defines("WIN32_LEAN_AND_MEAN", "NOMINMAX", "SOL_ALL_SAFETIES_ON", "WINVER=0x0601") -- WINVER=0x0601 == Windows 7, we need this specified now for some reason
+    add_defines("WIN32_LEAN_AND_MEAN", "NOMINMAX", "SOL_ALL_SAFETIES_ON", "WINVER=0x0601", "SOL_LUAJIT=1") -- WINVER=0x0601 == Windows 7, we need this specified now for some reason
     set_pcxxheader("src/stdafx.h")
     set_kind("shared")
     set_filename("cyber_engine_tweaks.asi")


### PR DESCRIPTION
This PR prevents users from overwriting tables of another mod by accident.

Before this, something like this could be done, affecting other mods in the process:
```lua
ImGui.Begin = function(name) spdlog.info("PWND!") end
```

Didnt test the snippet, may be wrong, but you get the picture...