### PR TITLE
Better isolation of sandboxed environments

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -96,3 +96,16 @@ std::shared_ptr<spdlog::logger> CreateLogger(const std::filesystem::path& aPath,
     register_logger(logger);
     return logger;
 }
+
+// deep copies sol object (doesnt take into account potential duplicates)
+sol::object DeepCopySolObject(sol::object aObj, const sol::state_view& aStateView)
+{
+    if (aObj.get_type() != sol::type::table)
+        return aObj;
+    sol::table src{aObj.as<sol::table>()};
+    sol::table copy{aStateView, sol::create};
+    for (auto kv : src)
+        copy[DeepCopySolObject(kv.first, aStateView)] = DeepCopySolObject(kv.second, aStateView);
+    copy[sol::metatable_key] = src[sol::metatable_key];
+    return copy;
+}

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -117,9 +117,14 @@ void MakeSolObjectImmutable(sol::object aObj, const sol::state_view& aStateView)
         return;
 
     sol::table target = aObj;
-    sol::table metatable = target.get_or(sol::metatable_key, sol::nil);
+    sol::table metatable;
+    sol::object metaref = target[sol::metatable_key];
 
-    if (metatable == sol::nil)
+    if (metaref.is<sol::table>())
+    {
+        metatable = metaref;
+    }
+    else
     {
         metatable = {aStateView, sol::create};
         target[sol::metatable_key] = metatable;
@@ -129,5 +134,5 @@ void MakeSolObjectImmutable(sol::object aObj, const sol::state_view& aStateView)
     metatable[sol::meta_function::metatable] = []() { return sol::nil; };
 
     // prevent adding new properties
-    metatable[sol::meta_function::new_index] = [](sol::table aTable, const std::string& acName, sol::object aParam) {};
+    metatable[sol::meta_function::new_index] = []() {};
 }

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -10,3 +10,6 @@ std::shared_ptr<spdlog::logger> CreateLogger(const std::filesystem::path& aPath,
 
 // deep copies sol object (doesnt take into account potential duplicates)
 sol::object DeepCopySolObject(sol::object aObj, const sol::state_view& aStateView);
+
+// makes sol object immutable when accessed from lua
+void MakeSolObjectImmutable(sol::object aObj, const sol::state_view& aStateView);

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -7,3 +7,6 @@ void trim(std::string& s);
 spdlog::sink_ptr CreateCustomSinkST(std::function<void(const std::string&)> aSinkItHandler, std::function<void()> aFlushHandler = nullptr);
 spdlog::sink_ptr CreateCustomSinkMT(std::function<void(const std::string&)> aSinkItHandler, std::function<void()> aFlushHandler = nullptr);
 std::shared_ptr<spdlog::logger> CreateLogger(const std::filesystem::path& aPath, const std::string& aID, spdlog::sink_ptr aExtraSink = nullptr, const std::string& aPattern = "[%Y-%m-%d %H:%M:%S UTC%z] [%l] %v");
+
+// deep copies sol object (doesnt take into account potential duplicates)
+sol::object DeepCopySolObject(sol::object aObj, const sol::state_view& aStateView);

--- a/src/reverse/Converter.cpp
+++ b/src/reverse/Converter.cpp
@@ -14,6 +14,7 @@ auto s_metaVisitor = [](auto... args) {
     LuaRED<uint32_t, "Uint32">(),
     LuaRED<uint64_t, "Uint64">(),
     LuaRED<float, "Float">(),
+    LuaRED<double, "Double">(),
     LuaRED<bool, "Bool">(),
     LuaRED<Quaternion, "Quaternion">(),
     LuaRED<Vector3, "Vector3">(),

--- a/src/scripting/LuaSandbox.cpp
+++ b/src/scripting/LuaSandbox.cpp
@@ -4,7 +4,6 @@
 
 #include "Scripting.h"
 
-
 #include <Utils.h>
 
 static constexpr const char* s_cGlobalObjectsWhitelist[] =
@@ -208,7 +207,7 @@ void LuaSandbox::InitializeExtraLibsForSandbox(Sandbox& aSandbox) const
     // copy extra whitelisted libs from global table
     const auto cGlobals = luaView.globals();
     for (const auto* cKey : s_cGlobalExtraLibsWhitelist)
-        sbEnv[cKey].set(cGlobals[cKey].get<sol::table>());
+        sbEnv[cKey] = DeepCopySolObject(cGlobals[cKey].get<sol::object>(), luaView);
 }
 
 void LuaSandbox::InitializeDBForSandbox(Sandbox& aSandbox) const
@@ -226,7 +225,7 @@ void LuaSandbox::InitializeDBForSandbox(Sandbox& aSandbox) const
     {
         const auto cKeyStr = cKV.first.as<std::string>();
         if (cKeyStr.compare(0, 4, "open"))
-            sqlite3Copy[cKV.first] = cKV.second;
+            sqlite3Copy[cKV.first] = DeepCopySolObject(cKV.second, luaView);
     }
     sbEnv["sqlite3"] = sqlite3Copy;
 
@@ -374,8 +373,8 @@ void LuaSandbox::InitializeIOForSandbox(Sandbox& aSandbox, const std::string& ac
     {
         const auto cIO = cGlobals["io"].get<sol::table>();
         sol::table ioSB(luaView, sol::create);
-        ioSB["type"] = cIO["type"];
-        ioSB["close"] = cIO["close"];
+        ioSB["type"] = DeepCopySolObject(cIO["type"], luaView);
+        ioSB["close"] = DeepCopySolObject(cIO["close"], luaView);
         ioSB["lines"] = [cIO, cSBRootPath](const std::string& acPath)
         {
             const auto cAbsPath = absolute(cSBRootPath / acPath).make_preferred();
@@ -404,10 +403,6 @@ void LuaSandbox::InitializeIOForSandbox(Sandbox& aSandbox, const std::string& ac
     {
         const auto cOS = cGlobals["os"].get<sol::table>();
         sol::table osSB(luaView, sol::create);
-        osSB["clock"] = cOS["clock"];
-        osSB["date"] = cOS["date"];
-        osSB["difftime"] = cOS["difftime"];
-        osSB["time"] = cOS["time"];
         osSB["rename"] = [cOS, cSBRootPath](const std::string& acOldPath, const std::string& acNewPath) -> std::tuple<sol::object, std::string>
         {
             const auto cAbsOldPath = absolute(cSBRootPath / acOldPath).make_preferred();

--- a/src/scripting/LuaSandbox.cpp
+++ b/src/scripting/LuaSandbox.cpp
@@ -37,7 +37,6 @@ static constexpr const char* s_cGlobalObjectsWhitelist[] =
     "DumpVtables",
     "GetVersion",
     "DumpAllTypeNames",
-    "ClassReference",
     "GetDisplayResolution",
     "Dump",
     "ToVector3",
@@ -49,7 +48,6 @@ static constexpr const char* s_cGlobalObjectsWhitelist[] =
     "GameOptions",
     "GameDump",
     "GetSingleton",
-    "Descriptor",
     "ItemID",
     "ToItemID",
     "TweakDBID",
@@ -59,12 +57,8 @@ static constexpr const char* s_cGlobalObjectsWhitelist[] =
     "Quaternion",
     "EulerAngles",
     "ToVector4",
-    "Unknown",
     "ToQuaternion",
-    "SingletonReference",
-    "StrongReference",
     "ToTweakDBID",
-    "WeakReference",
     "GetMod",
     "TweakDB",
     "Override",
@@ -77,6 +71,26 @@ static constexpr const char* s_cGlobalTablesWhitelist[] =
     "table",
     "math",
     "bit32"
+};
+
+static constexpr const char* s_cGlobalImmutablesList[] =
+{
+    "ClassReference",
+    "CName",
+    "Descriptor",
+    "Enum",
+    "EulerAngles",
+    "Game",
+    "GameOptions",
+    "ItemID",
+    "Quaternion",
+    "SingletonReference",
+    "StrongReference",
+    "TweakDBID",
+    "Unknown",
+    "Vector3",
+    "Vector4",
+    "WeakReference"
 };
 
 static constexpr const char* s_cGlobalExtraLibsWhitelist[] =
@@ -140,6 +154,10 @@ void LuaSandbox::Initialize()
         osCopy["time"] = os["time"];
         m_env["os"] = osCopy;
     }
+
+    // make shared things immutable
+    for (const auto* cKey : s_cGlobalImmutablesList)
+        MakeSolObjectImmutable(cGlobals[cKey], luaView);
 
     CreateSandbox();
 }

--- a/src/scripting/LuaSandbox.cpp
+++ b/src/scripting/LuaSandbox.cpp
@@ -402,7 +402,7 @@ void LuaSandbox::InitializeIOForSandbox(Sandbox& aSandbox, const std::string& ac
     // add in rename and remove repacements for os lib
     {
         const auto cOS = cGlobals["os"].get<sol::table>();
-        sol::table osSB(luaView, sol::create);
+        sol::table osSB = sbEnv["os"].get<sol::table>();
         osSB["rename"] = [cOS, cSBRootPath](const std::string& acOldPath, const std::string& acNewPath) -> std::tuple<sol::object, std::string>
         {
             const auto cAbsOldPath = absolute(cSBRootPath / acOldPath).make_preferred();
@@ -432,7 +432,6 @@ void LuaSandbox::InitializeIOForSandbox(Sandbox& aSandbox, const std::string& ac
                 return std::make_tuple(cResult.get<sol::object>(), "");
             return std::make_tuple(cResult.get<sol::object>(0), cResult.get<std::string>(1));
         };
-        sbEnv["os"] = osSB;
     }
 
     // add support functions for bindings

--- a/src/scripting/Sandbox.cpp
+++ b/src/scripting/Sandbox.cpp
@@ -3,14 +3,17 @@
 #include "Sandbox.h"
 #include "Scripting.h"
 
+#include <Utils.h>
+
 Sandbox::Sandbox(Scripting* apScripting, sol::environment aBaseEnvironment, const std::filesystem::path& acRootPath)
     : m_pScripting(apScripting)
     , m_env(apScripting->GetState().Get(), sol::create)
     , m_path(acRootPath)
 {
     // copy base environment, do not set it as fallback, as it may cause globals to bleed into other things!
+    sol::state_view sv = apScripting->GetState().Get();
     for (const auto& cKV : aBaseEnvironment)
-        m_env[cKV.first].set(cKV.second.as<sol::object>());
+        m_env[cKV.first] = DeepCopySolObject(cKV.second, sv);
 }
 
 sol::protected_function_result Sandbox::ExecuteFile(const std::string& acPath) const


### PR DESCRIPTION
This PR prevents users from overwriting tables of another mod by accident.

Deep copying is avoided inside LuaSandbox::Initialize on purpose, as that function just creates base templated environment for each Sandbox instance. Sandbox instance makes deep copy during construction.

Deep copy does not take into account duplicates, which should not really happen in our use case I believe. Did not found anything which would break cause of wrong copy.
We do not deep copy keys, so keys which are tables will not get properly copied (we do this only inside DeepCopySolObject function), but again, should not matter for our use case. Can be added relatively easily if required, have previous code saved which had this function in.

Before this, something like this could be done, affecting other mods in the process:
```lua
ImGui.Begin = function(name) spdlog.info("PWND!") end
```

Didnt test the snippet, may be wrong, but you get the picture...

Cleaned-up version of #522 

---------------------

Also adds Double inside meta visitor of Converter ( @psiberx )