### PR TITLE
Bumped ImGui version and updated mode-specific settings in xmake.lua

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -10,10 +10,10 @@ add_rules("mode.debug","mode.releasedbg", "mode.release")
 add_rules("plugin.vsxmake.autoupdate")
 
 if is_mode("debug") then
-    add_defines("_DEBUG", "CET_DEBUG")
+    add_defines("CET_DEBUG")
     set_optimize("none")
 elseif is_mode("releasedbg") then
-    add_defines("_DEBUG", "CET_DEBUG")
+    add_defines("CET_DEBUG")
     set_optimize("fastest")
 elseif is_mode("release") then
 	add_requireconfs("imgui", { configs = { cxflags = "/DNDEBUG" } })

--- a/xmake.lua
+++ b/xmake.lua
@@ -3,16 +3,20 @@ set_xmakever("2.5.1")
 set_languages("cxx20")
 set_arch("x64")
 
-add_requires("spdlog", "nlohmann_json", "hopscotch-map", "minhook", "mem", "imgui 1.81", "sol2", "tiltedcore 0.2.0", "sqlite3", "luajit")
-add_requireconfs("imgui", { configs = { cxflags = "/DNDEBUG" } })
+add_requires("spdlog", "nlohmann_json", "hopscotch-map", "minhook", "mem", "imgui 1.82", "sol2", "tiltedcore 0.2.0", "sqlite3", "luajit")
 add_requireconfs("sol2", { configs = { includes_lua = false } })
 
 add_rules("mode.debug","mode.releasedbg", "mode.release")
 add_rules("plugin.vsxmake.autoupdate")
 
-if is_mode("debug") or is_mode("releasedbg") then
-    add_defines("CET_DEBUG")
+if is_mode("debug") then
+    add_defines("_DEBUG", "CET_DEBUG")
+    set_optimize("none")
+elseif is_mode("releasedbg") then
+    add_defines("_DEBUG", "CET_DEBUG")
+    set_optimize("fastest")
 elseif is_mode("release") then
+	add_requireconfs("imgui", { configs = { cxflags = "/DNDEBUG" } })
     add_defines("NDEBUG")
     set_optimize("fastest")
 end

--- a/xmake.lua
+++ b/xmake.lua
@@ -3,7 +3,7 @@ set_xmakever("2.5.1")
 set_languages("cxx20")
 set_arch("x64")
 
-add_requires("spdlog", "nlohmann_json", "hopscotch-map", "minhook", "mem", "imgui 1.82", "sol2", "tiltedcore 0.2.0", "sqlite3", "luajit")
+add_requires("spdlog", "nlohmann_json", "hopscotch-map", "minhook", "mem", "imgui 1.82", "sol2", "tiltedcore 0.2.1", "sqlite3", "luajit")
 add_requireconfs("sol2", { configs = { includes_lua = false } })
 
 add_rules("mode.debug","mode.releasedbg", "mode.release")


### PR DESCRIPTION
I have split mode-specific options for better granularity.

Also have set optimize level for all of them (was only set for release previously).

ImGui version was bumped to 1.82, there should be no problems.
Also, from now on, ImGui assertions will be disabled only for release mode. They are useful for debug/releasedbg I would say.

TiltedCore was updated to 0.2.1.