### PR TITLE
Fixes and cleanup for VKBindings

### DIFF
--- a/src/VKBindings.h
+++ b/src/VKBindings.h
@@ -126,11 +126,12 @@ private:
 
     LRESULT HandleRAWInput(HRAWINPUT ahRAWInput);
 
-    std::map<uint64_t, VKBind> m_binds{ };
-    TiltedPhoques::Map<std::string, uint64_t> m_idToBind{ };
+    std::bitset<1 << 16> m_keyStates{ };
 
-    std::mutex m_queuedCallbacksLock{ };
-    std::queue<std::function<void()>> m_queuedCallbacks{};
+    std::map<uint64_t, VKBind> m_binds{ }; // this map needs to be ordered!
+    TiltedPhoques::Map<std::string, uint64_t> m_idToBind{ };
+    
+    TiltedPhoques::TaskQueue m_queuedCallbacks{ };
     
     VKCodeBindDecoded m_recording{ };
     size_t m_recordingLength{ 0 };


### PR DESCRIPTION
- Changed std::queue and std::mutex combo to TiltedPhoques::TaskQueue for bind callbacks
- Fixed scroll wheel binding
- Fixed single inputs unable to be called at the same time