### PR TITLE
Override ImGui asserts by custom definition for more granular control

### DIFF
--- a/src/imgui_impl/imgui_user_config.cpp
+++ b/src/imgui_impl/imgui_user_config.cpp
@@ -1,0 +1,16 @@
+#include <stdafx.h>
+
+// NOTE: imgui_user_config.h is included by imgui.h which is included with precompiled header, so no need to include it here once more
+
+#ifdef NDEBUG
+// inline _wassert decl for NDEBUG as it is not emitted inside assert.h header in this case
+extern "C" _ACRTIMP void __cdecl _wassert(wchar_t const* _Message, wchar_t const* _File, unsigned _Line);
+#endif
+
+// runtime assertions which can be enabled/disabled inside CET options
+void ImGuiAssert(wchar_t const* acpMessage, wchar_t const* acpFile, unsigned aLine)
+{
+    // TODO - it looks like assertions dont get logged for some weird reason, even though there is flush_on set for errors (even higher for debug)
+    spdlog::error(L"ImGui assertion failed in file \"{ 0 }\" at line { 1 }! Expression ({ 2 }) evaluates to false!", acpFile, aLine, acpMessage);
+    _wassert(acpMessage, acpFile, aLine);
+}

--- a/src/imgui_impl/imgui_user_config.cpp
+++ b/src/imgui_impl/imgui_user_config.cpp
@@ -2,6 +2,9 @@
 
 // NOTE: imgui_user_config.h is included by imgui.h which is included with precompiled header, so no need to include it here once more
 
+// global definition "Enable ImGui Assertions"
+bool g_ImGuiAssertionsEnabled{ true };
+
 #ifdef NDEBUG
 // inline _wassert decl for NDEBUG as it is not emitted inside assert.h header in this case
 extern "C" _ACRTIMP void __cdecl _wassert(wchar_t const* _Message, wchar_t const* _File, unsigned _Line);

--- a/src/imgui_impl/imgui_user_config.h
+++ b/src/imgui_impl/imgui_user_config.h
@@ -1,0 +1,12 @@
+#pragma once
+
+// global declaration "Enable ImGui Assertions"
+extern bool g_ImGuiAssertionsEnabled;
+
+// runtime assertions which can be enabled/disabled inside CET options
+void ImGuiAssert(wchar_t const* acpMessage, wchar_t const* acpFile, unsigned aLine);
+
+// custom assertion function macro for ImGui
+#define IM_ASSERT(expression) (void)(                                                    \
+    (g_ImGuiAssertionsEnabled && ((!!(expression)) ||                                    \
+    (ImGuiAssert(_CRT_WIDE(#expression), _CRT_WIDE(__FILE__), (unsigned)(__LINE__)), 0))))

--- a/xmake.lua
+++ b/xmake.lua
@@ -6,6 +6,9 @@ set_arch("x64")
 add_requires("spdlog", "nlohmann_json", "hopscotch-map", "minhook", "mem", "imgui 1.82", "sol2", "tiltedcore 0.2.1", "sqlite3", "luajit")
 add_requireconfs("sol2", { configs = { includes_lua = false } })
 
+local imguiUserConfig = path.absolute("src/imgui_impl/imgui_user_config.h")
+add_requireconfs("imgui", { configs = { user_config = imguiUserConfig } })
+
 add_rules("mode.debug","mode.releasedbg", "mode.release")
 add_rules("plugin.vsxmake.autoupdate")
 
@@ -16,7 +19,6 @@ elseif is_mode("releasedbg") then
     add_defines("CET_DEBUG")
     set_optimize("fastest")
 elseif is_mode("release") then
-	add_requireconfs("imgui", { configs = { cxflags = "/DNDEBUG" } })
     add_defines("NDEBUG")
     set_optimize("fastest")
 end
@@ -59,7 +61,7 @@ target("RED4ext.SDK")
     add_includedirs("vendor/RED4ext.SDK/include/", { public = true })
 
 target("cyber_engine_tweaks")
-    add_defines("WIN32_LEAN_AND_MEAN", "NOMINMAX", "SOL_ALL_SAFETIES_ON", "WINVER=0x0601", "SOL_LUAJIT=1") -- WINVER=0x0601 == Windows 7, we need this specified now for some reason
+    add_defines("WIN32_LEAN_AND_MEAN", "NOMINMAX", "WINVER=0x0601", "SOL_ALL_SAFETIES_ON", "SOL_LUAJIT=1", "SPDLOG_WCHAR_TO_UTF8_SUPPORT", "IMGUI_USER_CONFIG=\""..imguiUserConfig.."\"") -- WINVER=0x0601 == Windows 7, we need this specified now for some reason
     set_pcxxheader("src/stdafx.h")
     set_kind("shared")
     set_filename("cyber_engine_tweaks.asi")


### PR DESCRIPTION
This PR will reenable assertions in release. Control for these new assertions can be found in #529 .