### PR TITLE
Reorder roll, pitch, and yaw to be consistent with the internal order

### DIFF
--- a/src/reverse/BasicTypes.cpp
+++ b/src/reverse/BasicTypes.cpp
@@ -17,7 +17,7 @@ std::string Vector4::ToString() const noexcept
 
 std::string EulerAngles::ToString() const noexcept
 {
-    return fmt::format("ToEulerAngles{{ pitch = {0}, yaw = {1}, roll = {2} }}", pitch, yaw, roll);
+    return fmt::format("ToEulerAngles{{ roll = {0}, pitch = {1}, yaw = {2} }}", roll, pitch, yaw);
 }
 
 std::string Quaternion::ToString() const noexcept

--- a/src/reverse/BasicTypes.h
+++ b/src/reverse/BasicTypes.h
@@ -29,13 +29,13 @@ struct Vector4
 
 struct EulerAngles
 {
-    EulerAngles(float aPitch = 0.f, float aYaw = 0.f, float aRoll = 0.f)
-        : pitch(aPitch), yaw(aYaw), roll(aRoll)
+    EulerAngles(float aRoll = 0.f, float aPitch = 0.f, float aYaw = 0.f)
+        : roll(aRoll), pitch(aPitch), yaw(aYaw)
     {}
     
+    float roll;
     float pitch;
     float yaw;
-    float roll;
     
     std::string ToString() const noexcept;
 };

--- a/src/scripting/Scripting.cpp
+++ b/src/scripting/Scripting.cpp
@@ -180,16 +180,16 @@ void Scripting::Initialize()
     luaVm.new_usertype<EulerAngles>("EulerAngles",
         sol::constructors<EulerAngles(float, float, float), EulerAngles(float, float), EulerAngles(float), EulerAngles()>(),
         sol::meta_function::to_string, &EulerAngles::ToString,
+        "roll", &EulerAngles::roll,
         "pitch", &EulerAngles::pitch,
-        "yaw", &EulerAngles::yaw,
-        "roll", &EulerAngles::roll);
+        "yaw", &EulerAngles::yaw);
 
     luaVm["ToEulerAngles"] = [](sol::table table) -> EulerAngles
     {
         return EulerAngles
         {
-            table["pitch"].get_or(0.f),
             table["roll"].get_or(0.f),
+            table["pitch"].get_or(0.f),
             table["yaw"].get_or(0.f)
         };
     };


### PR DESCRIPTION
EulerAngles::ToString had the roll and yaw values swapped because of incorrect parameter order in [Scripting.cpp](https://github.com/yamashi/CyberEngineTweaks/blob/master/src/scripting/Scripting.cpp#L183). I fixed this by rearranging the parameter order everywhere to be consistent with [EulerAngles.hpp](https://github.com/yamashi/RED4ext.SDK/blob/6438a96c0fe1e6e00a2815c97bbf51b1b0bdc9ee/include/RED4ext/Types/generated/EulerAngles.hpp#L16) (roll, pitch, yaw).