### PR TITLE
Fixes for out params, mod database, and lua operators for basic types

### DIFF
--- a/src/VKBindings.cpp
+++ b/src/VKBindings.cpp
@@ -99,7 +99,7 @@ std::vector<VKBindInfo> VKBindings::InitializeMods(std::vector<VKBindInfo> aVKBi
     }
 
     // insert CET overlay bind info
-    assert(m_pOverlay); // overlay must be set before first use!
+    assert(m_cpOverlay); // overlay must be set before first use!
     const auto overlayKeyBind { m_cpOverlay->GetBind() };
     const auto overlayKeyCodeIt { m_idToBind.find(overlayKeyBind.ID) };
     const auto overlayKeyCode { (overlayKeyCodeIt == m_idToBind.cend()) ? (0) : (overlayKeyCodeIt->second) };

--- a/src/reverse/BasicTypes.cpp
+++ b/src/reverse/BasicTypes.cpp
@@ -10,9 +10,19 @@ std::string Vector3::ToString() const noexcept
     return fmt::format("ToVector3{{ x = {0}, y = {1}, z = {2} }}", x, y, z);
 }
 
+bool Vector3::operator==(const Vector3& acRhs) const noexcept
+{
+    return x == acRhs.x && y == acRhs.y && z == acRhs.z;
+}
+
 std::string Vector4::ToString() const noexcept
 {
     return fmt::format("ToVector4{{ x = {0}, y = {1}, z = {2}, w = {3} }}", x, y, z, w);
+}
+
+bool Vector4::operator==(const Vector4& acRhs) const noexcept
+{
+    return x == acRhs.x && y == acRhs.y && z == acRhs.z && w == acRhs.w;
 }
 
 std::string EulerAngles::ToString() const noexcept
@@ -20,9 +30,19 @@ std::string EulerAngles::ToString() const noexcept
     return fmt::format("ToEulerAngles{{ roll = {0}, pitch = {1}, yaw = {2} }}", roll, pitch, yaw);
 }
 
+bool EulerAngles::operator==(const EulerAngles& acRhs) const noexcept
+{
+    return roll == acRhs.roll && pitch == acRhs.pitch && yaw == acRhs.yaw;
+}
+
 std::string Quaternion::ToString() const noexcept
 {
     return fmt::format("ToQuaternion{{ i = {0}, j = {1}, k = {2}, r = {3} }}", i, j, k, r);
+}
+
+bool Quaternion::operator==(const Quaternion& acRhs) const noexcept
+{
+    return i == acRhs.i && j == acRhs.j && k == acRhs.k && r == acRhs.r;
 }
 
 std::string CName::AsString() const noexcept
@@ -40,14 +60,34 @@ std::string CName::ToString() const noexcept
     return fmt::format("ToCName{{ hash_lo = 0x{0:08X}, hash_hi = 0x{1:08X} --[[ {2} --]] }}", hash_lo, hash_hi, resolved);
 }
 
+bool CName::operator==(const CName& acRhs) const noexcept
+{
+    return hash == acRhs.hash;
+}
+
 std::string TweakDBID::ToString() const noexcept
 {
     return fmt::format("ToTweakDBID{{ hash = 0x{0:08X}, length = {1:d} }}", name_hash, name_length);
 }
 
+bool TweakDBID::operator==(const TweakDBID& acRhs) const noexcept
+{
+    return name_hash == acRhs.name_hash && name_length == acRhs.name_length;
+}
+
+TweakDBID TweakDBID::operator+(const std::string_view acName) const noexcept
+{
+    return TweakDBID(*this, acName);
+}
+
 std::string ItemID::ToString() const noexcept
 {
     return fmt::format("ToItemID{{ id = {0}, rng_seed = {1}, unknown = {2}, maybe_type = {3} }}", id.ToString(), rng_seed, unknown, maybe_type);
+}
+
+bool ItemID::operator==(const ItemID& acRhs) const noexcept
+{
+    return id == acRhs.id && rng_seed == acRhs.rng_seed;
 }
 
 static const unsigned int crc32_table[] =

--- a/src/reverse/BasicTypes.h
+++ b/src/reverse/BasicTypes.h
@@ -11,6 +11,8 @@ struct Vector3
     float z;
 
     std::string ToString() const noexcept;
+
+	bool operator==(const Vector3& acRhs) const noexcept;
 };
 
 struct Vector4
@@ -25,6 +27,8 @@ struct Vector4
     float w;
 
     std::string ToString() const noexcept;
+
+	bool operator==(const Vector4& acRhs) const noexcept;
 };
 
 struct EulerAngles
@@ -38,6 +42,8 @@ struct EulerAngles
     float yaw;
     
     std::string ToString() const noexcept;
+
+	bool operator==(const EulerAngles& acRhs) const noexcept;
 };
 
 struct Quaternion
@@ -52,6 +58,8 @@ struct Quaternion
     float r;
 
     std::string ToString() const noexcept;
+
+	bool operator==(const Quaternion& acRhs) const noexcept;
 };
 
 uint32_t crc32(const char* buf, size_t len, uint32_t seed);
@@ -74,6 +82,8 @@ struct CName
 
     std::string AsString() const noexcept;
     std::string ToString() const noexcept;
+
+	bool operator==(const CName& acRhs) const noexcept;
 };
 
 #pragma pack(push, 1)
@@ -109,6 +119,9 @@ struct TweakDBID
     }
 
     std::string ToString() const noexcept;
+
+	bool operator==(const TweakDBID& acRhs) const noexcept;
+	TweakDBID operator+(const std::string_view acName) const noexcept;
     
     union
     {
@@ -132,6 +145,8 @@ struct ItemID
         : id(aId), rng_seed(aRngSeed), unknown(aUnknown), maybe_type(aMaybeType), pad(0) {}
 
     std::string ToString() const noexcept;
+
+	bool operator==(const ItemID& acRhs) const noexcept;
     
     TweakDBID id;
     uint32_t rng_seed{ 2 };

--- a/src/reverse/Converter.h
+++ b/src/reverse/Converter.h
@@ -182,7 +182,7 @@ struct ClassConverter : LuaRED<ClassReference, "ClassReference">
             else
             {
                 result.value = nullptr;
-			}
+            }
         }
         else
         {

--- a/src/reverse/Converter.h
+++ b/src/reverse/Converter.h
@@ -172,6 +172,18 @@ struct ClassConverter : LuaRED<ClassReference, "ClassReference">
         {
             result.value = aObject.as<ClassReference*>()->GetHandle();
         }
+        else if (aObject == sol::nil)
+        {
+            RED4ext::CClass* pClass = static_cast<RED4ext::CClass*>(apRtti);
+            if (pClass && !pClass->flags.isAbstract)
+            {
+                result.value = pClass->AllocInstance();
+            }
+            else
+            {
+                result.value = nullptr;
+			}
+        }
         else
         {
             result.value = nullptr;

--- a/src/reverse/Enum.cpp
+++ b/src/reverse/Enum.cpp
@@ -153,8 +153,15 @@ std::string Enum::ToString() const
     return "Invalid enum";
 }
 
+bool Enum::operator==(const Enum& acRhs) const noexcept
+{
+    if (!m_cpType || !acRhs.m_cpType)
+        return false;
+
+    return m_cpType->hash == acRhs.m_cpType->hash && m_value == acRhs.m_value;
+}
+
 const RED4ext::CEnum* Enum::GetType() const
 {
     return m_cpType;
 }
-

--- a/src/reverse/Enum.h
+++ b/src/reverse/Enum.h
@@ -23,6 +23,8 @@ struct Enum
 
     std::string ToString() const;
 
+	bool operator==(const Enum& acRhs) const noexcept;
+
     const RED4ext::CEnum* GetType() const;
 
 protected:

--- a/src/reverse/Type.cpp
+++ b/src/reverse/Type.cpp
@@ -232,15 +232,18 @@ sol::variadic_results Type::Execute(RED4ext::CBaseFunction* apFunc, const std::s
         return {};
     }
 
+    auto iArg = 0u;
+
     for (auto i = 0u; i < apFunc->params.size; ++i)
     {
         if (apFunc->params[i]->flags.isOut) // Deal with out params
         {
             args[i] = Scripting::ToRED(sol::nil, apFunc->params[i]->type, &s_scratchMemory);
         }
-        else if (i < aArgs.size())
+        else if (iArg < aArgs.size())
         {
-            args[i] = Scripting::ToRED(aArgs[i].get<sol::object>(), apFunc->params[i]->type, &s_scratchMemory);
+            args[i] = Scripting::ToRED(aArgs[iArg].get<sol::object>(), apFunc->params[i]->type, &s_scratchMemory);
+            ++iArg;
         }
         else if (apFunc->params[i]->flags.isOptional) // Deal with optional params
         {

--- a/src/scripting/LuaSandbox.cpp
+++ b/src/scripting/LuaSandbox.cpp
@@ -165,7 +165,11 @@ void LuaSandbox::Initialize()
 
 void LuaSandbox::ResetState()
 {
+    for (auto& cSandbox : m_sandboxes)
+        CloseDBForSandbox(cSandbox);
+
     m_modules.clear();
+
     if (m_sandboxes.size() > 1) // first one is always present, meant for console
         m_sandboxes.erase(m_sandboxes.cbegin()+1, m_sandboxes.cend());
 }
@@ -486,4 +490,13 @@ void LuaSandbox::InitializeLoggerForSandbox(Sandbox& aSandbox, const std::string
 
     // assign logger to special var so we can access it from our functions
     sbEnv["__logger"] = logger;
+}
+
+void LuaSandbox::CloseDBForSandbox(Sandbox& aSandbox) const
+{
+    aSandbox.ExecuteString(R"(
+        if type(db) == 'userdata' and tostring(db):find('^sqlite database') then
+            db:close()
+        end
+    )");
 }

--- a/src/scripting/LuaSandbox.h
+++ b/src/scripting/LuaSandbox.h
@@ -27,6 +27,8 @@ private:
     void InitializeIOForSandbox(Sandbox& aSandbox, const std::string& acName);
     void InitializeLoggerForSandbox(Sandbox& aSandbox, const std::string& acName) const;
 
+	void CloseDBForSandbox(Sandbox& aSandbox) const;
+
     Scripting* m_pScripting;
     const VKBindings& m_vkBindings;
     sol::environment m_env{ };

--- a/src/scripting/Scripting.cpp
+++ b/src/scripting/Scripting.cpp
@@ -67,16 +67,6 @@ void Scripting::Initialize()
         return GetMod(acName);
     };
 
-    luaVm["ToVector3"] = [](sol::table table) -> Vector3
-    {
-        return Vector3
-        {
-            table["x"].get_or(0.f),
-            table["y"].get_or(0.f),
-            table["z"].get_or(0.f)
-        };
-    };
-
     luaVm.new_usertype<Scripting>("__Game",
         sol::meta_function::construct, sol::no_constructor,
         sol::meta_function::index, &Scripting::Index,
@@ -87,8 +77,7 @@ void Scripting::Initialize()
         sol::meta_function::index, &Type::Index,
         sol::meta_function::new_index, &Type::NewIndex);
 
-    luaVm.new_usertype<StrongReference>(
-        "StrongReference",
+    luaVm.new_usertype<StrongReference>("StrongReference",
         sol::meta_function::construct, sol::no_constructor,
         sol::base_classes, sol::bases<Type>(),
         sol::meta_function::index, &StrongReference::Index,
@@ -106,8 +95,7 @@ void Scripting::Initialize()
         sol::meta_function::index, &SingletonReference::Index,
         sol::meta_function::new_index, &SingletonReference::NewIndex);
 
-    luaVm.new_usertype<ClassReference>(
-        "ClassReference",
+    luaVm.new_usertype<ClassReference>("ClassReference",
         sol::meta_function::construct, sol::no_constructor,
         sol::base_classes, sol::bases<Type>(),
         sol::meta_function::index, &ClassReference::Index,
@@ -134,10 +122,16 @@ void Scripting::Initialize()
         "Dump", &GameOptions::Dump,
         "List", &GameOptions::List);
 
-    luaVm.new_usertype<Vector3>(
-        "Vector3",
+    luaVm.new_usertype<Enum>("Enum",
+        sol::constructors<Enum(const std::string&, const std::string&), Enum(const std::string&, uint32_t)>(),
+        sol::meta_function::to_string, &Enum::ToString,
+        sol::meta_function::equal_to, &Enum::operator==,
+        "value", sol::property(&Enum::GetValueName, &Enum::SetValueByName));
+
+    luaVm.new_usertype<Vector3>("Vector3",
         sol::constructors<Vector3(float, float, float), Vector3(float, float), Vector3(float), Vector3()>(),
         sol::meta_function::to_string, &Vector3::ToString,
+        sol::meta_function::equal_to, &Vector3::operator==,
         "x", &Vector3::x,
         "y", &Vector3::y,
         "z", &Vector3::z);
@@ -155,16 +149,11 @@ void Scripting::Initialize()
     luaVm.new_usertype<Vector4>("Vector4",
         sol::constructors<Vector4(float, float, float, float), Vector4(float, float, float), Vector4(float, float), Vector4(float), Vector4()>(),
         sol::meta_function::to_string, &Vector4::ToString,
+        sol::meta_function::equal_to, &Vector4::operator==,
         "x", &Vector4::x,
         "y", &Vector4::y,
         "z", &Vector4::z,
         "w", &Vector4::w);
-
-    luaVm.new_usertype<Enum>(
-        "Enum",
-        sol::constructors<Enum(const std::string&, const std::string&), Enum(const std::string&, uint32_t)>(),
-        sol::meta_function::to_string, &Enum::ToString,
-        "value", sol::property(&Enum::GetValueName, &Enum::SetValueByName));
 
     luaVm["ToVector4"] = [](sol::table table) -> Vector4
     {
@@ -180,6 +169,7 @@ void Scripting::Initialize()
     luaVm.new_usertype<EulerAngles>("EulerAngles",
         sol::constructors<EulerAngles(float, float, float), EulerAngles(float, float), EulerAngles(float), EulerAngles()>(),
         sol::meta_function::to_string, &EulerAngles::ToString,
+        sol::meta_function::equal_to, &EulerAngles::operator==,
         "roll", &EulerAngles::roll,
         "pitch", &EulerAngles::pitch,
         "yaw", &EulerAngles::yaw);
@@ -194,10 +184,10 @@ void Scripting::Initialize()
         };
     };
 
-    luaVm.new_usertype<Quaternion>(
-        "Quaternion",
+    luaVm.new_usertype<Quaternion>("Quaternion",
         sol::constructors<Quaternion(float, float, float, float), Quaternion(float, float, float), Quaternion(float, float), Quaternion(float), Quaternion()>(),
         sol::meta_function::to_string, &Quaternion::ToString,
+        sol::meta_function::equal_to, &Quaternion::operator==,
         "i", &Quaternion::i,
         "j", &Quaternion::j,
         "k", &Quaternion::k,
@@ -214,10 +204,10 @@ void Scripting::Initialize()
         };
     };
 
-    luaVm.new_usertype<CName>(
-        "CName",
+    luaVm.new_usertype<CName>("CName",
         sol::constructors<CName(const std::string&), CName(uint32_t), CName(uint32_t, uint32_t), CName()>(),
         sol::meta_function::to_string, &CName::ToString,
+        sol::meta_function::equal_to, &CName::operator==,
         "hash_lo", &CName::hash_lo,
         "hash_hi", &CName::hash_hi,
         "value", sol::property(&CName::AsString));
@@ -231,10 +221,12 @@ void Scripting::Initialize()
         };
     };
 
-    luaVm.new_usertype<TweakDBID>(
-        "TweakDBID",
+    luaVm.new_usertype<TweakDBID>("TweakDBID",
         sol::constructors<TweakDBID(const std::string&), TweakDBID(const TweakDBID&, const std::string&), TweakDBID(uint32_t, uint8_t), TweakDBID()>(),
         sol::meta_function::to_string, &TweakDBID::ToString,
+        sol::meta_function::equal_to, &TweakDBID::operator==,
+        sol::meta_function::addition, &TweakDBID::operator+,
+        sol::meta_function::concatenation, &TweakDBID::operator+,
         "hash", &TweakDBID::name_hash,
         "length", &TweakDBID::name_length);
 
@@ -247,10 +239,10 @@ void Scripting::Initialize()
         };
     };
 
-    luaVm.new_usertype<ItemID>(
-        "ItemID",
+    luaVm.new_usertype<ItemID>("ItemID",
         sol::constructors<ItemID(const TweakDBID&, uint32_t, uint16_t, uint8_t), ItemID(const TweakDBID&, uint32_t, uint16_t), ItemID(const TweakDBID&, uint32_t), ItemID(const TweakDBID&), ItemID()>(),
         sol::meta_function::to_string, &ItemID::ToString,
+        sol::meta_function::equal_to, &ItemID::operator==,
         "id", &ItemID::id,
         "tdbid", &ItemID::id,
         "rng_seed", &ItemID::rng_seed,

--- a/src/scripting/Scripting.cpp
+++ b/src/scripting/Scripting.cpp
@@ -964,15 +964,18 @@ sol::object Scripting::Execute(const std::string& aFuncName, sol::variadic_args 
         return sol::nil;
     }
 
+    auto iArg = 0u;
+
     for (auto i = argOffset; i < pFunc->params.size; ++i)
     {
         if (pFunc->params[i]->flags.isOut) // Deal with out params
         {
             args[i] = ToRED(sol::nil, pFunc->params[i]->type, &s_scratchMemory);
         }
-        else if (i - argOffset < aArgs.size())
+        else if (iArg < aArgs.size())
         {
-            args[i] = ToRED(aArgs[i - argOffset].get<sol::object>(), pFunc->params[i]->type, &s_scratchMemory);
+            args[i] = ToRED(aArgs[iArg].get<sol::object>(), pFunc->params[i]->type, &s_scratchMemory);
+            ++iArg;
         }
         else if (pFunc->params[i]->flags.isOptional) // Deal with optional params
         {


### PR DESCRIPTION
1. Fixed out params handling when out params are not in the end of the param list.  
```
import function GetCurveValue(out x : Float, out y : Float, curveName : CName, isDebug : Bool);
import function GetObjectClosestToCrosshair(instigator : whandle:gameObject, out angleDistance : EulerAngles, query : gameTargetSearchQuery) : handle:gameObject;
```

2. Fixed CClassConverter for nils. This call `args[i] = Scripting::ToRED(sol::nil, apFunc->params[i]->type, &s_scratchMemory);` for creating a placeholder for the out param was resulting in a `nullptr` when param is not a handle.
```
import function LookAt(instigator : whandle:gameObject, out params : gameaimAssistAimRequest);
```

3. Comparison operators for basic types and concatenation for TweakDBID:  
```lua
print(Vector3.new(1, 2, 3) == ToVector3{ x = 1, y = 2, z = 3 }) -- true
print(Enum.new("gameGameVersion", "Current") == Enum.new("gameGameVersion", "CP77_Patch_1_2")) -- true
print(TweakDBID.new("Items.Preset_Igla_Default") + ".displayName" == TweakDBID.new("Items.Preset_Igla_Default.displayName")) -- true
```

4. Close mod DB on shutdown. If DB is not closed, after reloading the mods, the DB file may be locked for a while, so any attempts to change the DB in onInit will fail.

5.  Removed Vector3 duplicate (the usertype was defined twice in Scripting.cpp) and moved Enum definition.

6.  Fixed incorrect assert in VKBindings.cpp.

