### PR TITLE
Fix global calls and GameOptions.Toggle()

### DIFF
--- a/src/scripting/GameOptions.cpp
+++ b/src/scripting/GameOptions.cpp
@@ -122,7 +122,7 @@ bool GameOption::SetColor(int value)
 
 bool GameOption::Toggle()
 {
-    if (GetType() == kBoolean)
+    if (GetType() != kBoolean)
         return false;
 
     Boolean = !Boolean;

--- a/src/scripting/Scripting.h
+++ b/src/scripting/Scripting.h
@@ -42,7 +42,7 @@ protected:
     sol::object GetSingletonHandle(const std::string& acName, sol::this_environment aThisEnv);
     sol::protected_function InternalIndex(const std::string& acName, sol::this_environment aThisEnv);
     
-    sol::object Execute(const std::string& aFuncName, sol::variadic_args aArgs, std::string& aReturnMessage, sol::this_state aState) const;
+    sol::variadic_results Execute(const std::string& aFuncName, sol::variadic_args aArgs, std::string& aReturnMessage, sol::this_state aState) const;
 
 private:
     TiltedPhoques::Lockable<sol::state, std::recursive_mutex> m_lua;


### PR DESCRIPTION
1. Fix falsy "Unknown error" when calling a global that returns `nil`.
Examples of global calls that can return `nil`:
```lua
Game['GetMountedVehicle;GameObject'](Game.GetPlayer())
Game.GetUISystem()
Game.GetPlayer()
```

2. Return out params from global function the same way as for instance methods.
Examples of global functions with out params:
```lua
Game['ScriptedPuppet::GenerateLootModifiers;ScriptedPuppetarray<gameStatModifierData>'](Game.GetPlayer())
Game['AIActionHelper::GetActiveTopHostilePuppetThreat;ScriptedPuppetTrackedLocation'](Game.GetTargetingSystem():GetLookAtObject(Game.GetPlayer(), false, false))
```

3. Fix typo in `GameOption::Toggle`.
