### PR TITLE
Fix LuaRED ToRED conversion for 64-bit integral types

### DIFF
--- a/src/reverse/LuaRED.h
+++ b/src/reverse/LuaRED.h
@@ -32,7 +32,19 @@ struct LuaRED
         }
         else if (!CheckObjectType || aObject.is<T>())
         {
-            result.value = apAllocator->New<T>(aObject.as<T>());
+            if constexpr (std::is_integral_v<T> && (sizeof(T) == sizeof(uint64_t)))
+            {
+                sol::state_view v(aObject.lua_state());
+                std::string str = v["tostring"](aObject);
+                if constexpr (std::is_signed_v<T>)
+                    result.value = apAllocator->New<T>(std::stoll(str));
+                else
+                    result.value = apAllocator->New<T>(std::stoull(str));
+            }
+            else
+            {
+                result.value = apAllocator->New<T>(aObject.as<T>());
+            }
         }
 
         return result;
@@ -46,7 +58,19 @@ struct LuaRED
         }
         else if (!CheckObjectType || aObject.is<T>())
         {
-            *reinterpret_cast<T*>(apType->value) = aObject.as<T>();
+            if constexpr (std::is_integral_v<T> && (sizeof(T) == sizeof(uint64_t)))
+            {
+                sol::state_view v(aObject.lua_state());
+                std::string str = v["tostring"](aObject);
+                if constexpr (std::is_signed_v<T>)
+                    *reinterpret_cast<T*>(apType->value) = std::stoll(str);
+                else
+                    *reinterpret_cast<T*>(apType->value) = std::stoull(str);
+            }
+            else
+            {
+                *reinterpret_cast<T*>(apType->value) = aObject.as<T>();
+            }
         }
     }
 


### PR DESCRIPTION
It's not possible to use `aObject.as<T>()` on 64-bit value directly because it's a cdata in LuaJIT and not a number. 

The solutions is to use Lua's `tostring()` to get the string representation of the number packed in cdata and then convert it using `std::stoll` / `std::stoull`.

Test:
```lua
local entityId = NewObject('entEntityID')
entityId.hash = 16570246047455160070ULL
```