### PR TITLE
Error logging for Observe / Override, implicit TweakDBID conversion, minor environment fixes

### DIFF
--- a/src/reverse/Converter.cpp
+++ b/src/reverse/Converter.cpp
@@ -21,8 +21,8 @@ auto s_metaVisitor = [](auto... args) {
     LuaRED<Vector4, "Vector4">(),
     LuaRED<EulerAngles, "EulerAngles">(),
     LuaRED<ItemID, "gameItemID">(),
-    LuaRED<TweakDBID, "TweakDBID">(),
     CNameConverter(),
+    TweakDBIDConverter(),
     EnumConverter(),
     ClassConverter(),
     RawConverter() // Should always be last resort

--- a/src/reverse/Converter.h
+++ b/src/reverse/Converter.h
@@ -53,6 +53,38 @@ struct CNameConverter : LuaRED<CName, "CName">
     }
 };
 
+// Specialization manages special case implicit casting for TweakDBID
+struct TweakDBIDConverter : LuaRED<TweakDBID, "TweakDBID">
+{
+    RED4ext::CStackType ToRED(sol::object aObject, RED4ext::IRTTIType* apRtti, TiltedPhoques::Allocator* apAllocator)
+    {
+        RED4ext::CStackType result;
+        if (aObject.get_type() == sol::type::string)
+        {
+            result.type = apRtti;
+            result.value = apAllocator->New<TweakDBID>(aObject.as<std::string>());
+        }
+        else
+        {
+            return LuaRED<TweakDBID, "TweakDBID">::ToRED(aObject, apRtti, apAllocator);
+        }
+
+        return result;
+    }
+
+	void ToRED(sol::object aObject, RED4ext::CStackType* apType)
+    {
+        if (aObject.get_type() == sol::type::string)
+        {
+            *(TweakDBID*)apType->value = TweakDBID(aObject.as<std::string>());
+        }
+        else
+        {
+            LuaRED<TweakDBID, "TweakDBID">::ToRED(aObject, apType);
+        }
+    }
+};
+
 // Specialization manages wrapping and converting RT_Enum
 struct EnumConverter : LuaRED<Enum, "Enum">
 {

--- a/src/scripting/FunctionOverride.cpp
+++ b/src/scripting/FunctionOverride.cpp
@@ -48,7 +48,7 @@ bool FunctionOverride::HookRunPureScriptFunction(RED4ext::CClassFunction* apFunc
         const auto& calls = itor->second.Calls;
         for (const auto& call : calls)
         {
-            const auto result = call->ScriptFunction(as_args(args), call->Environment);
+            const auto result = call->ScriptFunction(as_args(args));
 
             if (!result.valid())
             {
@@ -220,7 +220,7 @@ void FunctionOverride::HandleOverridenFunction(RED4ext::IScriptable* apContext, 
         const auto& calls = context.Calls;
         for (const auto& call : calls)
         {
-            const auto result = call->ScriptFunction(as_args(args), call->Environment);
+            const auto result = call->ScriptFunction(as_args(args));
 
             if (!result.valid())
             {

--- a/src/scripting/ScriptContext.cpp
+++ b/src/scripting/ScriptContext.cpp
@@ -6,14 +6,14 @@
 
 // TODO: proper exception handling for Lua funcs!
 template <typename ...Args>
-static sol::protected_function_result TryLuaFunction(std::shared_ptr<spdlog::logger> aLogger, sol::environment& aEnv, sol::function aFunc, Args... aArgs)
+static sol::protected_function_result TryLuaFunction(std::shared_ptr<spdlog::logger> aLogger, sol::function aFunc, Args... aArgs)
 {
     sol::protected_function_result result{ };
     if (aFunc)
     {
         try
         {
-            result = aFunc(aArgs..., aEnv);
+            result = aFunc(aArgs...);
         }
         catch(std::exception& e)
         {
@@ -57,8 +57,7 @@ ScriptContext::ScriptContext(LuaSandbox& aLuaSandbox, const std::filesystem::pat
             m_logger->error("Tried to register an unknown event '{}'!", acName);
     };
 
-    env["registerHotkey"] = [this, &sb = m_sandbox, id = m_sandboxID](const std::string& acID, const std::string& acDescription,
-                                               sol::function aCallback)
+    env["registerHotkey"] = [this](const std::string& acID, const std::string& acDescription, sol::function aCallback)
     {
         if (acID.empty() ||
             (std::ranges::find_if(acID, [](char c){ return !(isalpha(c) || isdigit(c) || c == '_'); }) != acID.cend()))
@@ -75,17 +74,15 @@ ScriptContext::ScriptContext(LuaSandbox& aLuaSandbox, const std::filesystem::pat
 
         auto loggerRef = m_logger;
         std::string vkBindID = m_name + '.' + acID;
-        VKBind vkBind = {vkBindID, acDescription, [loggerRef, aCallback, &sb, id]()
+        VKBind vkBind = {vkBindID, acDescription, [loggerRef, aCallback]()
         {
-            auto& env = sb[id].GetEnvironment();
-            TryLuaFunction(loggerRef, env, aCallback);
+            TryLuaFunction(loggerRef, aCallback);
         }};
 
         m_vkBindInfos.emplace_back(VKBindInfo{vkBind});
     };
     
-    env["registerInput"] = [this, &sb = m_sandbox, id = m_sandboxID](const std::string& acID, const std::string& acDescription,
-                                              sol::function aCallback) {
+    env["registerInput"] = [this](const std::string& acID, const std::string& acDescription, sol::function aCallback) {
         if (acID.empty() ||
             (std::ranges::find_if(acID, [](char c) { return !(isalpha(c) || isdigit(c) || c == '_'); }) != acID.cend()))
         {
@@ -104,10 +101,9 @@ ScriptContext::ScriptContext(LuaSandbox& aLuaSandbox, const std::filesystem::pat
 
         auto loggerRef = m_logger;
         std::string vkBindID = m_name + '.' + acID;
-        VKBind vkBind = {vkBindID, acDescription, [loggerRef, aCallback, &sb, id](bool isDown)
+        VKBind vkBind = {vkBindID, acDescription, [loggerRef, aCallback](bool isDown)
         {
-            auto& env = sb[id].GetEnvironment();
-            TryLuaFunction(loggerRef, env, aCallback, isDown);
+            TryLuaFunction(loggerRef, aCallback, isDown);
         }};
 
         m_vkBindInfos.emplace_back(VKBindInfo{vkBind});
@@ -161,52 +157,37 @@ const std::vector<VKBindInfo>& ScriptContext::GetBinds() const
 
 void ScriptContext::TriggerOnInit() const
 {
-    auto& sb = m_sandbox[m_sandboxID];
-    auto& env = sb.GetEnvironment();
-
     auto state = m_sandbox.GetState();
 
-    TryLuaFunction(m_logger, env, m_onInit);
+    TryLuaFunction(m_logger, m_onInit);
 }
 
 void ScriptContext::TriggerOnUpdate(float aDeltaTime) const
 {
-    auto& sb = m_sandbox[m_sandboxID];
-    auto& env = sb.GetEnvironment();
-
     auto state = m_sandbox.GetState();
 
-    TryLuaFunction(m_logger, env, m_onUpdate, aDeltaTime);
+    TryLuaFunction(m_logger, m_onUpdate, aDeltaTime);
 }
 
 void ScriptContext::TriggerOnDraw() const
 {
-    auto& sb = m_sandbox[m_sandboxID];
-    auto& env = sb.GetEnvironment();
-
     auto state = m_sandbox.GetState();
 
-    TryLuaFunction(m_logger, env, m_onDraw);
+    TryLuaFunction(m_logger, m_onDraw);
 }
     
 void ScriptContext::TriggerOnOverlayOpen() const
 {
-    auto& sb = m_sandbox[m_sandboxID];
-    auto& env = sb.GetEnvironment();
-
     auto state = m_sandbox.GetState();
 
-    TryLuaFunction(m_logger, env, m_onOverlayOpen);
+    TryLuaFunction(m_logger, m_onOverlayOpen);
 }
 
 void ScriptContext::TriggerOnOverlayClose() const
 {
-    auto& sb = m_sandbox[m_sandboxID];
-    auto& env = sb.GetEnvironment();
-
     auto state = m_sandbox.GetState();
 
-    TryLuaFunction(m_logger, env, m_onOverlayClose);
+    TryLuaFunction(m_logger, m_onOverlayClose);
 }
 
 sol::object ScriptContext::GetRootObject() const
@@ -216,10 +197,7 @@ sol::object ScriptContext::GetRootObject() const
 
 void ScriptContext::TriggerOnShutdown() const
 {
-    auto& sb = m_sandbox[m_sandboxID];
-    auto& env = sb.GetEnvironment();
-
     auto state = m_sandbox.GetState();
 
-    TryLuaFunction(m_logger, env, m_onShutdown);
+    TryLuaFunction(m_logger, m_onShutdown);
 }


### PR DESCRIPTION
1. Added reporting for errors occurred in `Observe` / `Override` handlers.
This fails silently before fix:
```lua
Observe('gameObject', 'OnGameAttached', function()
    undefined.call()
end)
```

2. Added implicit string to `TweakDBID` conversion. 
```lua
print(Game.GetTransactionSystem():GetItemInSlot(Game.GetPlayer(), 'AttachmentSlots.WeaponRight'):GetItemID())
```

3. Removed redundant environment passing to Lua functions as an argument. This change addresses two issues:
a. Environment passed as an argument doesn't change the environment of the function, but goes straight to the called function as a table.
b. The function inherits environment when defined and the assignment is stored in the Lua state. There is no need to set environment for function before call unless it's intended to change the currently assigned environment to another one. Also it should be taken in account that any environment assignment is permanent and will not be reverted to previous environment in any implicit way.
