### PR TITLE
D3D12 - Ensure that ImGui_ImplDX12_CreateDeviceObjects never receives a nullptr command queue

### DIFF
--- a/src/d3d12/D3D12_Functions.cpp
+++ b/src/d3d12/D3D12_Functions.cpp
@@ -165,6 +165,12 @@ bool D3D12::Initialize(IDXGISwapChain* apSwapChain)
     for (auto& context : m_frameContexts)
         m_pd3d12Device->CreateRenderTargetView(context.BackBuffer, nullptr, context.MainRenderTargetDescriptor);
 
+    if (!checkCmdQueue(this))
+    {
+        spdlog::error("D3D12::Initialize() - missing command queue!");
+        return false;
+    }
+
     if (!InitializeImGui(buffersCounts))
     {
         spdlog::error("D3D12::Initialize() - failed to initialize ImGui!");
@@ -173,12 +179,6 @@ bool D3D12::Initialize(IDXGISwapChain* apSwapChain)
 
     spdlog::info("D3D12::Initialize() - initialization successful!");
     m_initialized = true;
-
-    if (!checkCmdQueue(this))
-    {
-        spdlog::error("D3D12::Initialize() - missing command queue!");
-        return false;
-    }
 
     OnInitialized.Emit();
 


### PR DESCRIPTION
This small change should fix CET shutting down when executing D3D12::Initialize before D3D12::ExecuteCommandLists. This happens because ImGui relies on an existing commandQueue. Normally this isn't a problem because the game always calls those hooks in the correct order but some overlay software might call present before executecommandlist during initialization (In my case the specialK framework) and can cause cet to break. 
It even seems like the original code tries to take something like this into account but the order of the functions is mixed up.