### PR TITLE
New Script API, fixed crashes and memory leaks

### DIFF
--- a/scripts/autoexec.lua
+++ b/scripts/autoexec.lua
@@ -1,11 +1,3 @@
 json = require 'json/json'
 
-Game['DebugGiveHotkeys'] = Game['DebugGiveHotkeys;GameInstance']
-Game['DebugNPCs_NonExec'] = Game['DebugNPCs_NonExec;GameInstanceStringStringString;GameInstance']
-Game['GetPlayer'] = Game['GetPlayer;GameInstance']
-Game['GetPlayerObject'] = Game['GetPlayerObject;GameInstance']
-Game['PlayFinisher'] = Game['PlayFinisher;GameInstance']
-Game['PlayFinisherSingle'] = Game['PlayFinisherSingle;GameInstance']
-Game['PPS'] = Game['PPS;GameInstance']
-
 print("Cyber Engine Tweaks startup complete.")

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -136,3 +136,13 @@ void MakeSolUsertypeImmutable(sol::object aObj, const sol::state_view& aStateVie
     // prevent overriding metatable
     metatable[sol::meta_function::metatable] = []() { return sol::nil; };
 }
+
+// Check if Lua object is of cdata type
+bool IsLuaCData(sol::object aObject)
+{
+    // Sol doesn't have enum for LuaJIT's cdata type since it's not a standard type.
+    // But it's possible to check the type using numeric code (10).
+    // LuaJIT packs int64/uint64 into cdata and some other types.
+    // Since we're not using other types, this should be enough to check for int64/uint64 value.
+    return (static_cast<int>(aObject.get_type()) == 10);
+}

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -110,10 +110,10 @@ sol::object DeepCopySolObject(sol::object aObj, const sol::state_view& aStateVie
     return copy;
 }
 
-// makes sol object immutable when accessed from lua
-void MakeSolObjectImmutable(sol::object aObj, const sol::state_view& aStateView)
+// makes sol usertype or userdata immutable when accessed from lua
+void MakeSolUsertypeImmutable(sol::object aObj, const sol::state_view& aStateView)
 {
-    if (aObj.get_type() != sol::type::table && aObj.get_type() != sol::type::userdata)
+    if (!aObj.is<sol::metatable>() && !aObj.is<sol::userdata>())
         return;
 
     sol::table target = aObj;
@@ -130,9 +130,9 @@ void MakeSolObjectImmutable(sol::object aObj, const sol::state_view& aStateView)
         target[sol::metatable_key] = metatable;
     }
 
-    // prevent overriding metatable
-    metatable[sol::meta_function::metatable] = []() { return sol::nil; };
-
     // prevent adding new properties
     metatable[sol::meta_function::new_index] = []() {};
+
+    // prevent overriding metatable
+    metatable[sol::meta_function::metatable] = []() { return sol::nil; };
 }

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -11,5 +11,23 @@ std::shared_ptr<spdlog::logger> CreateLogger(const std::filesystem::path& aPath,
 // deep copies sol object (doesnt take into account potential duplicates)
 sol::object DeepCopySolObject(sol::object aObj, const sol::state_view& aStateView);
 
-// makes sol object immutable when accessed from lua
-void MakeSolObjectImmutable(sol::object aObj, const sol::state_view& aStateView);
+// makes sol usertype or userdata immutable when accessed from lua
+void MakeSolUsertypeImmutable(sol::object aObj, const sol::state_view& aStateView);
+
+// Add unnamed function to the Lua registry
+template<typename F>
+sol::function MakeSolFunction(sol::state& aState, F aFunc)
+{
+    // This is slightly better than wrapping lambdas in sol::object:
+    // 1. When the lambda is wrapped in an object sol registers additional usertype for the lambda type.
+    // 2. Calling a lambda as an object has a tiny overhead of dealing with metatables.
+    // 3. In Lua `type(f)` for a lambda as an object will return "userdata" instead of the expected "function".
+
+    static constexpr const char* s_cTempFuncName = "___func_temp_holder_";
+
+    aState[s_cTempFuncName] = aFunc;
+    sol::function luaFunc = aState[s_cTempFuncName];
+    aState[s_cTempFuncName] = sol::nil;
+
+    return luaFunc;
+}

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -31,3 +31,6 @@ sol::function MakeSolFunction(sol::state& aState, F aFunc)
 
     return luaFunc;
 }
+
+// Check if Lua object is of cdata type
+bool IsLuaCData(sol::object aObject);

--- a/src/reverse/BasicTypes.h
+++ b/src/reverse/BasicTypes.h
@@ -157,4 +157,21 @@ struct ItemID
 
 static_assert(sizeof(ItemID) == 0x10);
 
+struct Variant
+{
+    Variant() = default;
+
+    Variant(uint64_t aType, uint64_t aValue)
+        : type(aType), value(aValue), unknown(0) {}
+
+    Variant(RED4ext::IRTTIType* aType, RED4ext::ScriptInstance aValue)
+        : type(reinterpret_cast<std::uintptr_t>(aType)), value(reinterpret_cast<std::uintptr_t>(aValue)), unknown(0) {}
+
+    uint64_t type{ 0 };
+    uint64_t value{ 0 };
+    uint64_t unknown{ 0 };
+};
+
+static_assert(sizeof(Variant) == 0x18);
+
 #pragma pack(pop)

--- a/src/reverse/ClassStatic.cpp
+++ b/src/reverse/ClassStatic.cpp
@@ -1,0 +1,31 @@
+#include <stdafx.h>
+
+#include "ClassStatic.h"
+
+#include "RTTIHelper.h"
+#include "StrongReference.h"
+#include "scripting/Scripting.h"
+#include "Utils.h"
+
+ClassStatic::ClassStatic(const TiltedPhoques::Lockable<sol::state, std::recursive_mutex>::Ref& aView,
+                         RED4ext::IRTTIType* apClass)
+    : ClassType(aView, apClass)
+{
+}
+
+ClassStatic::~ClassStatic() = default;
+
+sol::function ClassStatic::GetFactory()
+{
+    if (!m_factory)
+    {
+        auto lockedState = m_lua.Lock();
+        auto& luaState = lockedState.Get();
+
+        m_factory = MakeSolFunction(luaState, [this](sol::optional<sol::table> aProps) {
+            return RTTIHelper::Get().NewHandle(m_pType, aProps);
+        });
+    }
+
+    return m_factory;
+}

--- a/src/reverse/ClassStatic.h
+++ b/src/reverse/ClassStatic.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "Type.h"
+
+struct ClassStatic : ClassType
+{
+    ClassStatic(const TiltedPhoques::Lockable<sol::state, std::recursive_mutex>::Ref& aView,
+                       RED4ext::IRTTIType* apClass);
+    ~ClassStatic();
+    
+    sol::function GetFactory();
+
+private:
+
+    sol::function m_factory;
+};

--- a/src/reverse/Converter.cpp
+++ b/src/reverse/Converter.cpp
@@ -21,6 +21,7 @@ auto s_metaVisitor = [](auto... args) {
     LuaRED<Vector4, "Vector4">(),
     LuaRED<EulerAngles, "EulerAngles">(),
     LuaRED<ItemID, "gameItemID">(),
+    LuaRED<Variant, "Variant">(),
     CNameConverter(),
     TweakDBIDConverter(),
     EnumConverter(),

--- a/src/reverse/Enum.cpp
+++ b/src/reverse/Enum.cpp
@@ -115,6 +115,9 @@ void Enum::Set(RED4ext::CStackType& acStackType) const noexcept
 
 std::string Enum::GetValueName() const
 {
+    if (!m_cpType)
+        return "";
+    
     for (auto i = 0; i < m_cpType->valueList.size; ++i)
     {
         if (m_cpType->valueList[i] == m_value)
@@ -129,6 +132,9 @@ std::string Enum::GetValueName() const
 
 void Enum::SetValueByName(const std::string& acValue)
 {
+    if (!m_cpType)
+        return;
+    
     const RED4ext::CName cValueName(acValue.c_str());
 
     for (auto i = 0; i < m_cpType->hashList.size; ++i)

--- a/src/reverse/EnumStatic.cpp
+++ b/src/reverse/EnumStatic.cpp
@@ -1,0 +1,32 @@
+#include <stdafx.h>
+
+#include "EnumStatic.h"
+#include "Enum.h"
+
+#include "scripting/Scripting.h"
+
+EnumStatic::EnumStatic(const TiltedPhoques::Lockable<sol::state, std::recursive_mutex>::Ref& aView,
+                                       RED4ext::IRTTIType* apClass)
+    : ClassType(aView, apClass)
+{
+}
+
+EnumStatic::~EnumStatic() = default;
+
+sol::object EnumStatic::Index_Impl(const std::string& acName, sol::this_environment aThisEnv)
+{
+    auto result = Type::Index_Impl(acName, aThisEnv);
+
+    if (result != sol::nil)
+        return result;
+
+    auto* pEnum = static_cast<RED4ext::CEnum*>(m_pType);
+
+    if (!pEnum)
+        return sol::nil;
+
+    auto lockedState = m_lua.Lock();
+    auto& luaState = lockedState.Get();
+
+    return Type::NewIndex_Impl(acName, std::move(sol::make_object(luaState, Enum(pEnum, acName))));
+}

--- a/src/reverse/EnumStatic.h
+++ b/src/reverse/EnumStatic.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "Type.h"
+
+struct EnumStatic : ClassType
+{
+    EnumStatic(const TiltedPhoques::Lockable<sol::state, std::recursive_mutex>::Ref& aView,
+                       RED4ext::IRTTIType* apClass);
+    ~EnumStatic();
+    
+    sol::object Index_Impl(const std::string& acName, sol::this_environment aThisEnv) override;
+};

--- a/src/reverse/LuaRED.h
+++ b/src/reverse/LuaRED.h
@@ -41,6 +41,16 @@ struct LuaRED
                 else
                     result.value = apAllocator->New<T>(std::stoull(str));
             }
+            else if constexpr (std::is_same_v<T, bool>)
+            {
+                if (aObject.get_type() == sol::type::boolean)
+                    result.value = apAllocator->New<T>(aObject.as<T>());
+            }
+            else if constexpr (std::is_arithmetic_v<T>)
+            {
+                if (aObject.get_type() == sol::type::number)
+                    result.value = apAllocator->New<T>(aObject.as<T>());
+            }
             else
             {
                 result.value = apAllocator->New<T>(aObject.as<T>());
@@ -66,6 +76,16 @@ struct LuaRED
                     *reinterpret_cast<T*>(apType->value) = std::stoll(str);
                 else
                     *reinterpret_cast<T*>(apType->value) = std::stoull(str);
+            }
+            else if constexpr (std::is_same_v<T, bool>)
+            {
+                if (aObject.get_type() == sol::type::boolean)
+                    *reinterpret_cast<T*>(apType->value) = aObject.as<T>();
+            }
+            else if constexpr (std::is_arithmetic_v<T>)
+            {
+                if (aObject.get_type() == sol::type::number)
+                    *reinterpret_cast<T*>(apType->value) = aObject.as<T>();
             }
             else
             {

--- a/src/reverse/LuaRED.h
+++ b/src/reverse/LuaRED.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include "common/Meta.h"
+#include "Utils.h"
 
-template<class T, FixedString REDName, bool CheckObjectType = !std::is_arithmetic_v<T>>
+template<class T, FixedString REDName>
 struct LuaRED
 {
     static constexpr char const* Name = REDName;
@@ -30,9 +31,15 @@ struct LuaRED
         {
             result.value = apAllocator->New<T>();
         }
-        else if (!CheckObjectType || aObject.is<T>())
+        else if constexpr (std::is_integral_v<T> && (sizeof(T) == sizeof(uint64_t)))
         {
-            if constexpr (std::is_integral_v<T> && (sizeof(T) == sizeof(uint64_t)))
+            if (aObject.get_type() == sol::type::number)
+            {
+                sol::state_view v(aObject.lua_state());
+                double value = v["tonumber"](aObject);
+                result.value = apAllocator->New<T>(value);
+            }
+            else if (IsLuaCData(aObject))
             {
                 sol::state_view v(aObject.lua_state());
                 std::string str = v["tostring"](aObject);
@@ -41,20 +48,28 @@ struct LuaRED
                 else
                     result.value = apAllocator->New<T>(std::stoull(str));
             }
-            else if constexpr (std::is_same_v<T, bool>)
-            {
-                if (aObject.get_type() == sol::type::boolean)
-                    result.value = apAllocator->New<T>(aObject.as<T>());
-            }
-            else if constexpr (std::is_arithmetic_v<T>)
-            {
-                if (aObject.get_type() == sol::type::number)
-                    result.value = apAllocator->New<T>(aObject.as<T>());
-            }
-            else
+        }
+        else if constexpr (std::is_same_v<T, bool>)
+        {
+            if (aObject.get_type() == sol::type::boolean)
+                result.value = apAllocator->New<T>(aObject.as<T>());
+        }
+        else if constexpr (std::is_arithmetic_v<T>)
+        {
+            if (aObject.get_type() == sol::type::number)
             {
                 result.value = apAllocator->New<T>(aObject.as<T>());
             }
+            else if (IsLuaCData(aObject))
+            {
+                sol::state_view v(aObject.lua_state());
+                double value = v["tonumber"](aObject);
+                result.value = apAllocator->New<T>(value);
+            }
+        }
+        else if (aObject.is<T>())
+        {
+            result.value = apAllocator->New<T>(aObject.as<T>());
         }
 
         return result;
@@ -66,9 +81,15 @@ struct LuaRED
         {
             *reinterpret_cast<T*>(apType->value) = T{};
         }
-        else if (!CheckObjectType || aObject.is<T>())
+        else if constexpr (std::is_integral_v<T> && (sizeof(T) == sizeof(uint64_t)))
         {
-            if constexpr (std::is_integral_v<T> && (sizeof(T) == sizeof(uint64_t)))
+            if (aObject.get_type() == sol::type::number)
+            {
+                sol::state_view v(aObject.lua_state());
+                double value = v["tonumber"](aObject);
+                *reinterpret_cast<T*>(apType->value) = value;
+            }
+            else if (IsLuaCData(aObject))
             {
                 sol::state_view v(aObject.lua_state());
                 std::string str = v["tostring"](aObject);
@@ -77,20 +98,28 @@ struct LuaRED
                 else
                     *reinterpret_cast<T*>(apType->value) = std::stoull(str);
             }
-            else if constexpr (std::is_same_v<T, bool>)
-            {
-                if (aObject.get_type() == sol::type::boolean)
-                    *reinterpret_cast<T*>(apType->value) = aObject.as<T>();
-            }
-            else if constexpr (std::is_arithmetic_v<T>)
-            {
-                if (aObject.get_type() == sol::type::number)
-                    *reinterpret_cast<T*>(apType->value) = aObject.as<T>();
-            }
-            else
+        }
+        else if constexpr (std::is_same_v<T, bool>)
+        {
+            if (aObject.get_type() == sol::type::boolean)
+                *reinterpret_cast<T*>(apType->value) = aObject.as<T>();
+        }
+        else if constexpr (std::is_arithmetic_v<T>)
+        {
+            if (aObject.get_type() == sol::type::number)
             {
                 *reinterpret_cast<T*>(apType->value) = aObject.as<T>();
             }
+            else if (IsLuaCData(aObject))
+            {
+                sol::state_view v(aObject.lua_state());
+                double value = v["tonumber"](aObject);
+                *reinterpret_cast<T*>(apType->value) = value;
+            }
+        }
+        else if (aObject.is<T>())
+        {
+            *reinterpret_cast<T*>(apType->value) = aObject.as<T>();
         }
     }
 

--- a/src/reverse/RTTIHelper.cpp
+++ b/src/reverse/RTTIHelper.cpp
@@ -861,7 +861,20 @@ void RTTIHelper::FreeInstance(RED4ext::IRTTIType* apType, void* apValue, bool aO
     }
     case RED4ext::ERTTIType::Array:
     {
-        apType->Destroy(apValue);
+        // Free array recursively
+        auto* pArrayType = reinterpret_cast<RED4ext::CArray*>(apType);
+        auto* pInnerType = pArrayType->GetInnerType();
+
+        if (pInnerType->GetType() == RED4ext::ERTTIType::Handle ||
+            pInnerType->GetType() == RED4ext::ERTTIType::WeakHandle ||
+            pInnerType->GetType() == RED4ext::ERTTIType::Array)
+        {
+            const auto cLength = pArrayType->GetLength(apValue);
+            for (auto i = 0u; i < cLength; ++i)
+                FreeInstance(pInnerType, pArrayType->GetElement(apValue, i), aOwn, aNew, apAllocator);
+        }
+
+        pArrayType->Destroy(apValue);
         break;
     }
     }

--- a/src/reverse/RTTIHelper.cpp
+++ b/src/reverse/RTTIHelper.cpp
@@ -1,0 +1,877 @@
+#include <stdafx.h>
+
+#include "RTTIHelper.h"
+
+#include "Type.h"
+#include "ClassReference.h"
+#include "StrongReference.h"
+#include "scripting/Scripting.h"
+#include "Utils.h"
+
+static constexpr const bool s_cEnableOverloads = true;
+static constexpr const bool s_cLogAllOverloadVariants = true;
+
+static std::unique_ptr<RTTIHelper> s_pInstance{ nullptr };
+
+void RTTIHelper::Initialize(const LockableState& aLua)
+{
+    s_pInstance.reset(new RTTIHelper(aLua));
+}
+
+void RTTIHelper::Shutdown()
+{
+    // Since m_resolvedFunctions contains references to Lua state
+    // it's important to call destructor while Lua state exists.
+    // Otherwise sol will throw invalid reference exception.
+    s_pInstance.reset(nullptr);
+}
+
+RTTIHelper& RTTIHelper::Get()
+{
+    return *s_pInstance;
+}
+
+RTTIHelper::RTTIHelper(const LockableState& aLua)
+    : m_lua(aLua)
+{
+    InitializeRTTI();
+    ParseGlobalStatics();
+}
+
+void RTTIHelper::InitializeRTTI()
+{
+    m_pRtti = RED4ext::CRTTISystem::Get();
+    m_pEngine = RED4ext::CGameEngine::Get();
+    m_pGameInstanceType = m_pRtti->GetClass(RED4ext::FNV1a("ScriptGameInstance"));
+
+    const auto pGameInstance = m_pEngine->framework->gameInstance;
+    const auto pPlayerSystemType = m_pRtti->GetType(RED4ext::FNV1a("cpPlayerSystem"));
+    m_pPlayerSystem = reinterpret_cast<RED4ext::ScriptInstance>(pGameInstance->GetInstance(pPlayerSystemType));
+}
+
+void RTTIHelper::ParseGlobalStatics()
+{
+    m_pRtti->funcs.for_each([this](RED4ext::CName aOrigName, RED4ext::CGlobalFunction* apFunc) {
+        const std::string cOrigName = aOrigName.ToString();
+        const auto cClassSep = cOrigName.find("::");
+
+        if (cClassSep != std::string::npos)
+        {
+            const auto cClassName = cOrigName.substr(0, cClassSep);
+            const auto cFullName = cOrigName.substr(cClassSep + 2);
+
+            const auto cClassHash = RED4ext::FNV1a(cClassName.c_str());
+            const auto cFullHash = RED4ext::FNV1a(cFullName.c_str());
+
+            if (!m_extendedFunctions.contains(cClassHash))
+                m_extendedFunctions.emplace(cClassHash, 0);
+
+            m_extendedFunctions.at(cClassHash).emplace(cFullHash, apFunc);
+        }
+        });
+}
+
+void RTTIHelper::AddFunctionAlias(const std::string& acAliasFuncName, const std::string& acOrigClassName, const std::string& acOrigFuncName)
+{
+    auto* pClass = m_pRtti->GetClass(RED4ext::FNV1a(acOrigClassName.c_str()));
+    if (pClass)
+    {
+        auto* pFunc = FindFunction(pClass, RED4ext::FNV1a(acOrigFuncName.c_str()));
+
+        if (pFunc)
+        {
+            if (!m_extendedFunctions.contains(kGlobalHash))
+                m_extendedFunctions.emplace(kGlobalHash, 0);
+
+            m_extendedFunctions.at(kGlobalHash).emplace(pFunc->shortName.hash, pFunc);
+        }
+    }
+}
+
+void RTTIHelper::AddFunctionAlias(const std::string& acAliasClassName, const std::string& acAliasFuncName,
+                                  const std::string& acOrigClassName, const std::string& acOrigFuncName)
+{
+    auto* pClass = m_pRtti->GetClass(RED4ext::FNV1a(acOrigClassName.c_str()));
+    if (pClass)
+    {
+        auto* pFunc = FindFunction(pClass, RED4ext::FNV1a(acOrigFuncName.c_str()));
+
+        if (pFunc)
+        {
+            const auto classHash = RED4ext::FNV1a(acAliasClassName.c_str());
+
+            if (!m_extendedFunctions.contains(classHash))
+                m_extendedFunctions.emplace(classHash, 0);
+
+            m_extendedFunctions.at(classHash).emplace(pFunc->shortName.hash, pFunc);
+        }
+    }
+}
+
+sol::function RTTIHelper::GetResolvedFunction(const uint64_t acFuncHash) const
+{
+    return GetResolvedFunction(kGlobalHash, acFuncHash, false);
+}
+
+sol::function RTTIHelper::GetResolvedFunction(const uint64_t acClassHash, const uint64_t acFuncHash, bool aIsMember) const
+{
+    const auto cScope = aIsMember ? kMemberScope : kStaticScope;
+
+    if (m_resolvedFunctions[cScope].contains(acClassHash))
+    {
+        auto& classFuncs = m_resolvedFunctions[cScope].at(acClassHash);
+
+        if (classFuncs.contains(acFuncHash))
+            return classFuncs.at(acFuncHash);
+    }
+
+    return sol::nil;
+}
+
+// Add global function to resolved map
+void RTTIHelper::AddResolvedFunction(const uint64_t acFuncHash, sol::function& acFunc)
+{
+    AddResolvedFunction(kGlobalHash, acFuncHash, acFunc, false);
+}
+
+// Add class function to resolved map
+void RTTIHelper::AddResolvedFunction(const uint64_t acClassHash, const uint64_t acFuncHash, sol::function& acFunc, bool aIsMember)
+{
+    const auto cScope = aIsMember ? kMemberScope : kStaticScope;
+
+    if (!m_resolvedFunctions[cScope].contains(acClassHash))
+        m_resolvedFunctions[cScope].emplace(acClassHash, 0);
+
+    m_resolvedFunctions[cScope].at(acClassHash).emplace(acFuncHash, acFunc);
+}
+
+// Find global function matching full name
+RED4ext::CBaseFunction* RTTIHelper::FindFunction(const uint64_t acFullNameHash) const
+{
+    RED4ext::CBaseFunction* pFunc = m_pRtti->GetFunction(acFullNameHash);
+
+    if (!pFunc && m_extendedFunctions.contains(kGlobalHash))
+    {
+        auto& extendedFuncs = m_extendedFunctions.at(kGlobalHash);
+
+        if (extendedFuncs.contains(acFullNameHash))
+            pFunc = extendedFuncs.at(acFullNameHash);
+    }
+
+    return pFunc;
+}
+
+// Find class function matching full name
+RED4ext::CBaseFunction* RTTIHelper::FindFunction(RED4ext::CClass* apClass, const uint64_t acFullNameHash) const
+{
+    while (apClass != nullptr)
+    {
+        if (m_extendedFunctions.contains(apClass->name.hash))
+        {
+            auto& extendedFuncs = m_extendedFunctions.at(apClass->name.hash);
+
+            if (extendedFuncs.contains(acFullNameHash))
+                return extendedFuncs.at(acFullNameHash);
+        }
+
+        for (uint32_t i = 0; i < apClass->funcs.size; ++i)
+        {
+            if (apClass->funcs.entries[i]->fullName.hash == acFullNameHash)
+                return apClass->funcs.entries[i];
+        }
+
+        for (uint32_t i = 0; i < apClass->staticFuncs.size; ++i)
+        {
+            if (apClass->staticFuncs.entries[i]->fullName.hash == acFullNameHash)
+                return apClass->staticFuncs.entries[i];
+        }
+
+        apClass = apClass->parent;
+    }
+
+    return nullptr;
+}
+
+// Find all global functions matching short name
+std::map<uint64_t, RED4ext::CBaseFunction*> RTTIHelper::FindFunctions(const uint64_t acShortNameHash) const
+{
+    std::map<uint64_t, RED4ext::CBaseFunction*> results{ };
+
+    m_pRtti->funcs.for_each([&results, &acShortNameHash](RED4ext::CName aFullName, RED4ext::CGlobalFunction* apFunction) {
+        if (apFunction->shortName.hash == acShortNameHash)
+            results.emplace(aFullName.hash, apFunction);
+        });
+
+    if (m_extendedFunctions.contains(kGlobalHash))
+    {
+        auto& extendedFuncs = m_extendedFunctions.at(kGlobalHash);
+
+        for (const auto& entry : extendedFuncs)
+        {
+            if (entry.second->shortName.hash == acShortNameHash)
+                results.emplace(entry.first, entry.second);
+        }
+    }
+
+    return results;
+}
+
+// Find all class functions matching short name
+std::map<uint64_t, RED4ext::CBaseFunction*> RTTIHelper::FindFunctions(RED4ext::CClass* apClass, const uint64_t acShortNameHash, bool aIsMember) const
+{
+    std::map<uint64_t, RED4ext::CBaseFunction*> results{ };
+
+    while (apClass != nullptr)
+    {
+        if (aIsMember)
+        {
+            for (uint32_t i = 0; i < apClass->funcs.size; ++i)
+            {
+                if (apClass->funcs.entries[i]->shortName.hash == acShortNameHash)
+                    results.emplace(apClass->funcs.entries[i]->fullName.hash, apClass->funcs.entries[i]);
+            }
+        }
+        else
+        {
+            for (uint32_t i = 0; i < apClass->staticFuncs.size; ++i)
+            {
+                if (apClass->staticFuncs.entries[i]->shortName.hash == acShortNameHash)
+                    results.emplace(apClass->staticFuncs.entries[i]->fullName.hash, apClass->staticFuncs.entries[i]);
+            }
+
+            if (m_extendedFunctions.contains(apClass->name.hash))
+            {
+                auto& extendedFuncs = m_extendedFunctions.at(apClass->name.hash);
+
+                for (const auto& entry : extendedFuncs)
+                {
+                    if (entry.second->shortName.hash == acShortNameHash)
+                        results.emplace(entry.first, entry.second);
+                }
+            }
+        }
+
+        apClass = apClass->parent;
+    }
+
+    return results;
+}
+
+// Resolve global function to Lua function
+sol::function RTTIHelper::ResolveFunction(const std::string& acFuncName)
+{
+    if (!m_pRtti)
+        return sol::nil;
+
+    const auto cFuncHash = RED4ext::FNV1a(acFuncName.c_str());
+    
+    auto invokable = GetResolvedFunction(cFuncHash);
+    if (invokable != sol::nil)
+        return invokable;
+    
+    const auto cIsFullName = acFuncName.find(';') != std::string::npos;
+
+    if (cIsFullName)
+    {
+        auto pFunc = FindFunction(cFuncHash);
+
+        if (!pFunc)
+        {
+            pFunc = FindFunction(m_pGameInstanceType, cFuncHash);
+
+            if (!pFunc)
+                return sol::nil;
+        }
+
+        invokable = MakeInvokableFunction(pFunc);
+        AddResolvedFunction(cFuncHash, invokable);
+    }
+    else
+    {
+        auto overloads = FindFunctions(cFuncHash);
+
+        if (overloads.empty())
+        {
+            overloads = FindFunctions(m_pGameInstanceType, cFuncHash, false);
+
+            if (overloads.empty())
+                return sol::nil;
+        }
+
+        if (!s_cEnableOverloads || overloads.size() == 1)
+            invokable = MakeInvokableFunction(overloads.begin()->second);
+        else
+            invokable = MakeInvokableOverload(overloads);
+
+        AddResolvedFunction(cFuncHash, invokable);
+    }
+
+    return invokable;
+}
+
+// Resolve class function to Lua function
+sol::function RTTIHelper::ResolveFunction(RED4ext::CClass* apClass, const std::string& acFuncName, bool aIsMember)
+{
+    if (!m_pRtti)
+        return sol::nil;
+
+    if (apClass == nullptr)
+        return ResolveFunction(acFuncName);
+
+    const auto cClassHash = RED4ext::FNV1a(apClass->name.ToString());
+    const auto cFuncHash = RED4ext::FNV1a(acFuncName.c_str());
+
+    auto invokable = GetResolvedFunction(cClassHash, cFuncHash, aIsMember);
+    if (invokable != sol::nil)
+        return invokable;
+
+    const auto cIsFullName = acFuncName.find(';') != std::string::npos;
+
+    if (cIsFullName)
+    {
+        auto pFunc = FindFunction(apClass, cFuncHash);
+
+        if (!pFunc)
+            return sol::nil;
+
+        invokable = MakeInvokableFunction(pFunc);
+        AddResolvedFunction(cClassHash, cFuncHash, invokable, aIsMember);
+    }
+    else
+    {
+        auto overloads = FindFunctions(apClass, cFuncHash, aIsMember);
+
+        if (overloads.empty())
+        {
+            // Try different scope if nothing was found in the needed one
+            // Allows static functions to be called from the instance
+            overloads = FindFunctions(apClass, cFuncHash, !aIsMember);
+
+            if (overloads.empty())
+                return sol::nil;
+        }
+
+        if (!s_cEnableOverloads || overloads.size() == 1)
+            invokable = MakeInvokableFunction(overloads.begin()->second);
+        else
+            invokable = MakeInvokableOverload(overloads);
+
+        AddResolvedFunction(cClassHash, cFuncHash, invokable, aIsMember);
+    }
+
+    return invokable;
+}
+
+sol::function RTTIHelper::MakeInvokableFunction(RED4ext::CBaseFunction* apFunc)
+{
+    auto lockedState = m_lua.Lock();
+    auto& luaState = lockedState.Get();
+
+    return MakeSolFunction(luaState, [this, apFunc](sol::variadic_args aArgs, sol::this_environment aEnv) -> sol::variadic_results {
+        uint32_t argOffset = 0;
+        RED4ext::ScriptInstance pHandle = ResolveHandle(apFunc, aArgs, argOffset);
+
+        std::string error;
+        auto result = ExecuteFunction(apFunc, pHandle, aArgs, argOffset, false, error);
+
+        if (!error.empty())
+        {
+            const sol::environment cEnv = aEnv;
+            auto logger = cEnv["__logger"].get<std::shared_ptr<spdlog::logger>>();
+            logger->error("Error: {}", error);
+        }
+
+        return result;
+    });
+}
+
+sol::function RTTIHelper::MakeInvokableOverload(std::map<uint64_t, RED4ext::CBaseFunction*> aOverloadedFuncs)
+{
+    auto lockedState = m_lua.Lock();
+    auto& luaState = lockedState.Get();
+
+    std::vector<Overload> variants;
+
+    for (const auto& cFunc : aOverloadedFuncs)
+        variants.emplace_back(cFunc.second);
+
+    return MakeSolFunction(luaState, [this, variants](sol::variadic_args aArgs, sol::this_environment aEnv) mutable -> sol::variadic_results {
+        for (auto variant = variants.begin(); variant != variants.end(); variant++)
+        {
+            uint32_t argOffset = 0;
+            RED4ext::ScriptInstance pHandle = ResolveHandle(variant->func, aArgs, argOffset);
+
+            auto result = ExecuteFunction(variant->func, pHandle, aArgs, argOffset, true, variant->lastError);
+
+            if (variant->lastError.empty())
+            {
+                ++variant->totalCalls;
+
+                if (variant != variants.begin())
+                {
+                    auto previous = variant - 1;
+
+                    if (variant->totalCalls > previous->totalCalls)
+                        std::iter_swap(previous, variant);
+                }
+
+                return result;
+            }
+        }
+
+        const sol::environment cEnv = aEnv;
+        auto logger = cEnv["__logger"].get<std::shared_ptr<spdlog::logger>>();
+        logger->error("Error: No matching overload of '{}' function.", variants.begin()->func->shortName.ToString());
+
+        if constexpr (s_cLogAllOverloadVariants)
+        {
+            for (auto variant = variants.begin(); variant != variants.end(); variant++)
+                logger->info("{}: {}", variant->func->fullName.ToString(), variant->lastError);
+
+            logger->flush();
+        }
+
+        return {};
+    });
+}
+
+RED4ext::ScriptInstance RTTIHelper::ResolveHandle(RED4ext::CBaseFunction* apFunc, sol::variadic_args& aArgs, uint32_t& argOffset) const
+{
+    // Case 1: obj:Member() -- Skip the first arg and pass it as a handle
+    // Case 2: obj:Static() -- Pass args as is, including the implicit self
+    // Case 3: Type.Static() -- Pass args as is
+    // Case 4: Type.Member() -- Skip the first arg and pass it as a handle
+    // Case 5: Singleton("Type"):Static() -- Skip the first arg as it's a dummy
+    // Case 6: Singleton("Type"):Member() -- Skip the first arg as it's a dummy
+
+    RED4ext::ScriptInstance pHandle = nullptr;
+
+    if (apFunc->flags.isStatic)
+    {
+        if (aArgs.size() > argOffset && aArgs[argOffset].is<SingletonReference>())
+            ++argOffset;
+    }
+    else
+    {
+        if (aArgs.size() > argOffset)
+        {
+            const auto& cArg = aArgs[argOffset];
+
+            if (cArg.is<Type>())
+            {
+                pHandle = cArg.as<Type>().GetHandle();
+
+                if (pHandle || cArg.is<SingletonReference>())
+                    ++argOffset;
+            }
+        }
+    }
+
+    return pHandle;
+}
+
+sol::variadic_results RTTIHelper::ExecuteFunction(RED4ext::CBaseFunction* apFunc, RED4ext::ScriptInstance apHandle,
+                                                  sol::variadic_args aLuaArgs, uint32_t aLuaArgOffset,
+                                                  bool aExactNumArgs, std::string& aErrorMessage) const
+{
+    if (!m_pRtti || !m_pEngine->framework)
+        return {};
+
+    // Optional params
+    // Passing nullptr for optional parameters causes a lot of crashes.
+    // Users are forced to pass in the actual value anyway, so it is best
+    // to require the value until the optional parameters are implemented.
+
+    // Out params
+    // There are cases when out param must be passed to the function.
+    // These functions cannot be used until more complex logic for input
+    // args is implemented (should check if a compatible arg is actually
+    // passed at the expected position + same for optionals).
+
+    // Overloads
+    // When dealing with overloads, it's better to require the exact
+    // number of arguments passed instead of the minimum number.
+
+    auto numArgs = aLuaArgs.size() - aLuaArgOffset;
+    auto reqArgs = 0u; // required number of args
+
+    for (auto i = 0u; i < apFunc->params.size; ++i)
+    {
+        const auto cpParam = apFunc->params[i];
+
+        if (!cpParam->flags.isOut && cpParam->type != m_pGameInstanceType)
+            reqArgs++;
+    }
+
+    if (numArgs != reqArgs && (aExactNumArgs || numArgs < reqArgs))
+    {
+        aErrorMessage = fmt::format("Function '{}' requires {} parameter(s).", apFunc->shortName.ToString(), reqArgs);
+        return {};
+    }
+
+    static thread_local TiltedPhoques::ScratchAllocator s_scratchMemory(1 << 13);
+    struct ResetAllocator
+    {
+        ~ResetAllocator()
+        {
+            s_scratchMemory.Reset();
+        }
+    };
+    ResetAllocator ___allocatorReset;
+
+    std::vector<RED4ext::CStackType> callArgs(apFunc->params.size);
+
+    for (auto i = 0u; i < apFunc->params.size; ++i)
+    {
+        const auto cpParam = apFunc->params[i];
+
+        if (cpParam->type == m_pGameInstanceType)
+        {
+            callArgs[i].type = m_pGameInstanceType;
+            callArgs[i].value = &m_pEngine->framework->gameInstance;
+        }
+        else if (cpParam->flags.isOut)
+        {
+            // It looks like constructing value with ToRED for out params is not required,
+            // and memory allocation is enough.
+            callArgs[i].type = cpParam->type;
+            callArgs[i].value = NewPlaceholder(cpParam->type, &s_scratchMemory);
+
+            // But ToRED conversion is necessary for implementing required out params.
+            //callArgs[i] = Scripting::ToRED(sol::nil, cpParam->type, &s_scratchMemory);
+        }
+        else if (aLuaArgOffset < aLuaArgs.size())
+        {
+            callArgs[i] = Scripting::ToRED(aLuaArgs[aLuaArgOffset], cpParam->type, &s_scratchMemory);
+            ++aLuaArgOffset;
+        }
+
+        if (!callArgs[i].value)
+        {
+            RED4ext::CName typeName;
+            cpParam->type->GetName(typeName);
+            aErrorMessage = fmt::format("Function '{}' parameter {} must be {}.", apFunc->shortName.ToString(), i + 1, typeName.ToString());
+
+            if (i > 0)
+            {
+                for (auto j = 0u; j < i; ++j)
+                {
+                    if (apFunc->params[j]->flags.isOut)
+                        FreeInstance(callArgs[j], false, true, &s_scratchMemory);
+                    else
+                        FreeInstance(callArgs[j], true, false, &s_scratchMemory);
+                }
+            }
+
+            return {};
+        }
+    }
+
+    const bool hasReturnType = (apFunc->returnType) != nullptr && (apFunc->returnType->type) != nullptr;
+
+    uint8_t buffer[1000]{ 0 };
+    RED4ext::CStackType result;
+
+    if (hasReturnType)
+    {
+        result.value = &buffer;
+        result.type = apFunc->returnType->type;
+    }
+
+    // Needs more investigation, but if you do something like GetSingleton('inkMenuScenario'):GetSystemRequestsHandler()
+    // which actually does not need the 'this' object, you can trick it into calling it as long as you pass something for the handle
+
+    RED4ext::ScriptInstance pContext = apHandle ? apHandle : m_pPlayerSystem;
+    RED4ext::CStack stack(pContext, callArgs.data(), callArgs.size(), hasReturnType ? &result : nullptr, 0);
+
+    const auto success = apFunc->Execute(&stack);
+
+    if (!success)
+    {
+        aErrorMessage = fmt::format("Function '{}' failed to execute.", apFunc->shortName.ToString());
+
+        for (auto i = 0u; i < apFunc->params.size; ++i)
+        {
+            if (apFunc->params[i]->flags.isOut)
+                FreeInstance(callArgs[i], false, true, &s_scratchMemory);
+            else
+                FreeInstance(callArgs[i], true, false, &s_scratchMemory);
+        }
+
+        return {};
+    }
+
+    auto lockedState = m_lua.Lock();
+
+    sol::variadic_results results;
+
+    if (hasReturnType)
+    {
+        // There is a special case when a non-native function returns a specific class or something that holds that class,
+        // which leads to another memory leak. So far the only known class that is causing the issue is gameTargetSearchFilter.
+        // When it returned by a non-native function it is wrapped in the Variant or similar structure. To prevent the leak
+        // the underlying value must be unwrapped and the wrapper explicitly destroyed. The workaround has been proven to work,
+        // but it seems too much for only one known case, so it is not included for now.
+
+        results.push_back(Scripting::ToLua(lockedState, result));
+        FreeInstance(result, false, false, &s_scratchMemory);
+    }
+
+    for (auto i = 0u; i < apFunc->params.size; ++i)
+    {
+        if (apFunc->params[i]->flags.isOut)
+        {
+            results.push_back(Scripting::ToLua(lockedState, callArgs[i]));
+            FreeInstance(callArgs[i], false, true, &s_scratchMemory);
+        }
+        else
+        {
+            FreeInstance(callArgs[i], true, false, &s_scratchMemory);
+        }
+    }
+
+    return results;
+}
+
+RED4ext::ScriptInstance RTTIHelper::NewPlaceholder(RED4ext::IRTTIType* apType, TiltedPhoques::Allocator* apAllocator) const
+{
+    auto* pMemory = apAllocator->Allocate(apType->GetSize());
+    memset(pMemory, 0, apType->GetSize());
+    apType->Init(pMemory);
+
+    return pMemory;
+}
+
+RED4ext::ScriptInstance RTTIHelper::NewInstance(RED4ext::IRTTIType* apType, sol::optional<sol::table> aProps, TiltedPhoques::Allocator* apAllocator) const
+{
+    if (!m_pRtti || !m_pEngine->framework)
+        return nullptr;
+
+    RED4ext::CClass* pClass = nullptr;
+
+    if (apType->GetType() == RED4ext::ERTTIType::Class)
+    {
+        pClass = reinterpret_cast<RED4ext::CClass*>(apType);
+    }
+    else if (apType->GetType() == RED4ext::ERTTIType::Handle)
+    {
+        auto* pInnerType = reinterpret_cast<RED4ext::CHandle*>(apType)->GetInnerType();
+
+        if (pInnerType->GetType() == RED4ext::ERTTIType::Class)
+            pClass = reinterpret_cast<RED4ext::CClass*>(pInnerType);
+    }
+
+    if (!pClass || pClass->flags.isAbstract || !IsClassReferenceType(pClass))
+        return nullptr;
+
+    // AllocInstance() seems to be the only function that initializes an instance.
+    // Neither Init() nor InitCls() initializes properties.
+    auto* pInstance = pClass->AllocInstance();
+
+    if (aProps.has_value())
+    {
+        bool success;
+        for (const auto& cProp : aProps.value())
+            SetProperty(pClass, pInstance, cProp.first.as<std::string>(), cProp.second, success);
+    }
+
+    if (apType->GetType() == RED4ext::ERTTIType::Handle)
+        return apAllocator->New<RED4ext::Handle<RED4ext::IScriptable>>(pInstance);
+    else
+        return pInstance;
+}
+
+sol::object RTTIHelper::NewInstance(RED4ext::IRTTIType* apType, sol::optional<sol::table> aProps) const
+{
+    if (!m_pRtti || !m_pEngine->framework)
+        return sol::nil;
+
+    TiltedPhoques::StackAllocator<1 << 10> allocator;
+
+    RED4ext::CStackType result;
+    result.type = apType;
+    result.value = NewInstance(apType, aProps, &allocator);
+
+    auto lockedState = m_lua.Lock();
+    auto instance = Scripting::ToLua(lockedState, result);
+
+    FreeInstance(result, true, true, &allocator);
+
+    return instance;
+}
+
+// Create new instance and wrap it in Handle<> if possible
+sol::object RTTIHelper::NewHandle(RED4ext::IRTTIType* apType, sol::optional<sol::table> aProps) const
+{
+    // This method should be preferred over NewInstance() for creating objects in Lua userland.
+    // The behavior is similar to what can be seen in scripts, where variables of IScriptable
+    // types are declared with the ref<> modifier (which means Handle<>).
+
+    // The Handle<> wrapper prevents memory leaks that can occur in IRTTIType::Assign()
+    // when called directly on an IScriptable instance.
+
+    if (!m_pRtti || !m_pEngine->framework)
+        return sol::nil;
+
+    TiltedPhoques::StackAllocator<1 << 10> allocator;
+
+    RED4ext::CStackType result;
+    result.type = apType;
+    result.value = NewInstance(apType, aProps, &allocator);
+
+    // Wrap IScriptable descendants in Handle
+    if (result.value && apType->GetType() == RED4ext::ERTTIType::Class)
+    {
+        static auto* s_pHandleType = m_pRtti->GetType(RED4ext::FNV1a("handle:Activator"));
+        static auto* s_pIScriptableType = m_pRtti->GetType(RED4ext::FNV1a("IScriptable"));
+
+        auto* pClass = reinterpret_cast<RED4ext::CClass*>(apType);
+
+        if (pClass->IsA(s_pIScriptableType))
+        {
+            auto* pInstance = reinterpret_cast<RED4ext::IScriptable*>(result.value);
+            auto* pHandle = allocator.New<RED4ext::Handle<RED4ext::IScriptable>>(pInstance);
+
+            result.type = s_pHandleType; // To trick converter and deallocator
+            result.value = pHandle;
+        }
+    }
+
+    auto lockedState = m_lua.Lock();
+    auto instance = Scripting::ToLua(lockedState, result);
+
+    FreeInstance(result, true, true, &allocator);
+
+    return instance;
+}
+
+sol::object RTTIHelper::GetProperty(RED4ext::CClass* apClass, RED4ext::ScriptInstance apHandle, const std::string& acPropName, bool& aSuccess) const
+{
+    aSuccess = false;
+
+    if (!m_pRtti || !m_pEngine->framework)
+        return sol::nil;
+
+    auto* pProp = apClass->GetProperty(acPropName.c_str());
+
+    if (!pProp)
+        return sol::nil;
+
+    auto lockedState = m_lua.Lock();
+    RED4ext::CStackType stackType(pProp->type, pProp->GetValue<uintptr_t*>(apHandle));
+    aSuccess = true;
+
+    return Scripting::ToLua(lockedState, stackType);
+}
+
+void RTTIHelper::SetProperty(RED4ext::CClass* apClass, RED4ext::ScriptInstance apHandle, const std::string& acPropName, sol::object aPropValue, bool& aSuccess) const
+{
+    aSuccess = false;
+
+    if (!m_pRtti || !m_pEngine->framework)
+        return;
+
+    auto* pProp = apClass->GetProperty(acPropName.c_str());
+
+    if (!pProp)
+        return;
+
+    static thread_local TiltedPhoques::ScratchAllocator s_scratchMemory(1 << 10);
+    struct ResetAllocator
+    {
+        ~ResetAllocator()
+        {
+            s_scratchMemory.Reset();
+        }
+    };
+    ResetAllocator ___allocatorReset;
+
+    RED4ext::CStackType stackType = Scripting::ToRED(aPropValue, pProp->type, &s_scratchMemory);
+
+    if (stackType.value)
+    {
+        pProp->SetValue<RED4ext::ScriptInstance>(apHandle, static_cast<uintptr_t*>(stackType.value));
+
+        FreeInstance(stackType, true, false, &s_scratchMemory);
+        aSuccess = true;
+    }
+}
+
+// Check if type is implemented using ClassReference
+bool RTTIHelper::IsClassReferenceType(RED4ext::CClass* apClass) const
+{
+    static const auto s_cHashVector3 = RED4ext::FNV1a("Vector3");
+    static const auto s_cHashVector4 = RED4ext::FNV1a("Vector4");
+    static const auto s_cHashEulerAngles = RED4ext::FNV1a("EulerAngles");
+    static const auto s_cHashQuaternion = RED4ext::FNV1a("Quaternion");
+    static const auto s_cHashItemID = RED4ext::FNV1a("gameItemID");
+
+    return apClass->name != s_cHashVector3 && apClass->name != s_cHashVector4 &&
+           apClass->name != s_cHashEulerAngles && apClass->name != s_cHashQuaternion &&
+           apClass->name != s_cHashItemID;
+}
+
+void RTTIHelper::FreeInstance(RED4ext::CStackType& aStackType, bool aOwn, bool aNew, TiltedPhoques::Allocator* apAllocator) const
+{
+    FreeInstance(aStackType.type, aStackType.value, aOwn, aNew, apAllocator);
+}
+
+void RTTIHelper::FreeInstance(RED4ext::IRTTIType* apType, void* apValue, bool aOwn, bool aNew, TiltedPhoques::Allocator* apAllocator) const
+{
+    if (!apValue)
+        return;
+
+    if (!aOwn)
+    {
+        if (aNew || apType->GetType() != RED4ext::ERTTIType::Class)
+            apType->Destroy(apValue);
+
+        return;
+    }
+
+    switch (apType->GetType())
+    {
+    case RED4ext::ERTTIType::Class:
+    {
+        // Free instances created with AllocInstance()
+        if (aNew)
+        {
+            auto* pClass = reinterpret_cast<RED4ext::CClass*>(apType);
+
+            // Skip basic types
+            if (IsClassReferenceType(pClass))
+            {
+                pClass->DestroyCls(reinterpret_cast<RED4ext::IScriptable*>(apValue));
+                pClass->GetAllocator()->Free(apValue);
+            }
+        }
+        break;
+    }
+    case RED4ext::ERTTIType::Handle:
+    {
+        // Control the ref count
+        apAllocator->Delete(reinterpret_cast<RED4ext::Handle<RED4ext::IScriptable>*>(apValue));
+        break;
+    }
+    case RED4ext::ERTTIType::WeakHandle:
+    {
+        // Control the ref count
+        apAllocator->Delete(reinterpret_cast<RED4ext::WeakHandle<RED4ext::IScriptable>*>(apValue));
+        break;
+    }
+    case RED4ext::ERTTIType::Array:
+    {
+        apType->Destroy(apValue);
+        break;
+    }
+    }
+
+    // Right now it's a workaround that doesn't cover all cases but most.
+    // It also requires explicit calls to FreeInstance().
+    // Should probably be refactored into a custom allocator that
+    // combines ScratchAllocator and managed logic for:
+    // 1. Instances created with AllocInstance()
+    // 2. DynArray
+    // 3. Handle
+    // 4. WeakHandle
+}

--- a/src/reverse/RTTIHelper.h
+++ b/src/reverse/RTTIHelper.h
@@ -1,0 +1,80 @@
+#pragma once
+
+struct RTTIHelper
+{
+    using LockableState = TiltedPhoques::Lockable<sol::state, std::recursive_mutex>::Ref;
+    using RedFunctionMap = std::unordered_map<uint64_t, std::unordered_map<uint64_t, RED4ext::CBaseFunction*>>;
+    using LuaFunctionMap = std::unordered_map<uint64_t, std::unordered_map<uint64_t, sol::function>>;
+
+    ~RTTIHelper() = default;
+
+    void AddFunctionAlias(const std::string& acAliasFuncName, const std::string& acOrigClassName, const std::string& acOrigFuncName);
+    void AddFunctionAlias(const std::string& acAliasClassName, const std::string& acAliasFuncName,
+                          const std::string& acOrigClassName, const std::string& acOrigFuncName);
+
+    sol::function ResolveFunction(const std::string& acFuncName);
+    sol::function ResolveFunction(RED4ext::CClass* apClass, const std::string& acFuncName, bool aIsMember);
+    
+    RED4ext::ScriptInstance ResolveHandle(RED4ext::CBaseFunction* apFunc, sol::variadic_args& aArgs, uint32_t& argOffset) const;
+    sol::variadic_results ExecuteFunction(RED4ext::CBaseFunction* apFunc, RED4ext::ScriptInstance apHandle,
+                                          sol::variadic_args aLuaArgs, uint32_t aLuaArgOffset,
+                                          bool aExactNumArgs, std::string& aErrorMessage) const;
+    
+    RED4ext::ScriptInstance NewInstance(RED4ext::IRTTIType* apType, sol::optional<sol::table> aProps, TiltedPhoques::Allocator* apAllocator) const;
+    sol::object NewInstance(RED4ext::IRTTIType* apType, sol::optional<sol::table> aProps) const;
+    sol::object NewHandle(RED4ext::IRTTIType* apType, sol::optional<sol::table> aProps) const;
+
+    sol::object GetProperty(RED4ext::CClass* apClass, RED4ext::ScriptInstance apHandle, const std::string& acPropName, bool& aSuccess) const;
+    void SetProperty(RED4ext::CClass* apClass, RED4ext::ScriptInstance apHandle, const std::string& acPropName, sol::object aPropValue, bool& aSuccess) const;
+
+    static void Initialize(const LockableState& aLua);
+    static void Shutdown();
+    static RTTIHelper& Get();
+
+private:
+
+    RTTIHelper(const LockableState& aLua);
+
+    void InitializeRTTI();
+    void ParseGlobalStatics();
+
+    sol::function GetResolvedFunction(const uint64_t acFuncHash) const;
+    sol::function GetResolvedFunction(const uint64_t acClassHash, const uint64_t acFuncHash, bool aIsMember) const;
+    void AddResolvedFunction(const uint64_t acFuncHash, sol::function& acFunc);
+    void AddResolvedFunction(const uint64_t acClassHash, const uint64_t acFuncHash, sol::function& acFunc, bool aIsMember);
+
+    RED4ext::CBaseFunction* FindFunction(const uint64_t acFullNameHash) const;
+    RED4ext::CBaseFunction* FindFunction(RED4ext::CClass* apClass, const uint64_t acFullNameHash) const;
+    std::map<uint64_t, RED4ext::CBaseFunction*> FindFunctions(const uint64_t acShortNameHash) const;
+    std::map<uint64_t, RED4ext::CBaseFunction*> FindFunctions(RED4ext::CClass* apClass, const uint64_t acShortNameHash, bool aIsMember) const;
+    
+    sol::function MakeInvokableFunction(RED4ext::CBaseFunction* apFunc);
+    sol::function MakeInvokableOverload(std::map<uint64_t, RED4ext::CBaseFunction*> aOverloadedFuncs);
+
+    RED4ext::ScriptInstance NewPlaceholder(RED4ext::IRTTIType* apType, TiltedPhoques::Allocator* apAllocator) const;
+    bool IsClassReferenceType(RED4ext::CClass* apClass) const;
+    void FreeInstance(RED4ext::CStackType& aStackType, bool aOwnValue, bool aNewValue, TiltedPhoques::Allocator* apAllocator) const;
+    void FreeInstance(RED4ext::IRTTIType* apType, void* apValue, bool aOwnValue, bool aNewValue, TiltedPhoques::Allocator* apAllocator) const;
+
+    enum
+    {
+        kGlobalHash = 0,
+        kStaticScope = 0,
+        kMemberScope = 1,
+    };
+
+    struct Overload
+    {
+        RED4ext::CBaseFunction* func;
+        std::string lastError;
+        uint32_t totalCalls;
+    };
+
+    LockableState m_lua;
+    RED4ext::CRTTISystem* m_pRtti;
+    RED4ext::CGameEngine* m_pEngine;
+    RED4ext::CClass* m_pGameInstanceType;
+    RED4ext::ScriptInstance m_pPlayerSystem;
+    RedFunctionMap m_extendedFunctions;
+    LuaFunctionMap m_resolvedFunctions[2];
+};

--- a/src/reverse/RTTIHelper.h
+++ b/src/reverse/RTTIHelper.h
@@ -15,7 +15,7 @@ struct RTTIHelper
     sol::function ResolveFunction(const std::string& acFuncName);
     sol::function ResolveFunction(RED4ext::CClass* apClass, const std::string& acFuncName, bool aIsMember);
     
-    RED4ext::ScriptInstance ResolveHandle(RED4ext::CBaseFunction* apFunc, sol::variadic_args& aArgs, uint32_t& argOffset) const;
+    RED4ext::ScriptInstance ResolveHandle(RED4ext::CBaseFunction* apFunc, sol::variadic_args& aArgs, uint32_t& aArgOffset) const;
     sol::variadic_results ExecuteFunction(RED4ext::CBaseFunction* apFunc, RED4ext::ScriptInstance apHandle,
                                           sol::variadic_args aLuaArgs, uint32_t aLuaArgOffset,
                                           bool aExactNumArgs, std::string& aErrorMessage) const;
@@ -27,13 +27,13 @@ struct RTTIHelper
     sol::object GetProperty(RED4ext::CClass* apClass, RED4ext::ScriptInstance apHandle, const std::string& acPropName, bool& aSuccess) const;
     void SetProperty(RED4ext::CClass* apClass, RED4ext::ScriptInstance apHandle, const std::string& acPropName, sol::object aPropValue, bool& aSuccess) const;
 
-    static void Initialize(const LockableState& aLua);
+    static void Initialize(const LockableState& acLua);
     static void Shutdown();
     static RTTIHelper& Get();
 
 private:
 
-    RTTIHelper(const LockableState& aLua);
+    RTTIHelper(const LockableState& acLua);
 
     void InitializeRTTI();
     void ParseGlobalStatics();

--- a/src/reverse/RTTIMapper.cpp
+++ b/src/reverse/RTTIMapper.cpp
@@ -1,0 +1,157 @@
+#include <stdafx.h>
+
+#include "RTTIMapper.h"
+#include "RTTIHelper.h"
+#include "BasicTypes.h"
+#include "Type.h"
+#include "EnumStatic.h"
+#include "ClassStatic.h"
+#include "scripting/Scripting.h"
+#include "Utils.h"
+
+RTTIMapper::RTTIMapper(const LockableState& aLua, const std::string& acGlobal)
+    : m_lua(aLua)
+    , m_global(acGlobal)
+{
+}
+
+RTTIMapper::~RTTIMapper()
+{
+    RTTIHelper::Shutdown();
+}
+
+void RTTIMapper::Register()
+{
+    RTTIHelper::Initialize(m_lua);
+
+    auto lockedState = m_lua.Lock();
+    auto& luaState = lockedState.Get();
+
+    sol::table luaGlobal = luaState.get<sol::table>(m_global);
+
+    auto* pRtti = RED4ext::CRTTISystem::Get();
+
+    RegisterSimpleTypes(luaState, luaGlobal);
+    RegisterDirectTypes(luaState, luaGlobal, pRtti);
+    RegisterScriptAliases(luaGlobal, pRtti);
+    RegisterSpecialAccessors(luaState, luaGlobal);
+}
+
+void RTTIMapper::RegisterSimpleTypes(sol::state& aLuaState, sol::table& aLuaGlobal)
+{
+    aLuaState.new_usertype<Variant>("Variant",
+        sol::meta_function::construct, sol::no_constructor);
+
+    MakeSolUsertypeImmutable(aLuaState["Variant"], aLuaState);
+
+    aLuaGlobal["ToVariant"] = [this](Type& aInstance) -> sol::object {
+        auto* pType = aInstance.GetType();
+        auto* pHandle = aInstance.GetHandle();
+
+        if (!pType || !pHandle)
+            return sol::nil;
+
+        auto lockedState = m_lua.Lock();
+        auto& luaState = lockedState.Get();
+
+        return sol::object(luaState, sol::in_place, Variant(pType, pHandle));
+    };
+
+    aLuaGlobal["FromVariant"] = [this](const Variant& aVariant) -> sol::object {
+        if (aVariant.type == 0 || aVariant.unknown != 0)
+            return sol::nil;
+
+        RED4ext::CStackType result;
+        result.type = reinterpret_cast<RED4ext::IRTTIType*>(aVariant.type);
+        result.value = reinterpret_cast<RED4ext::ScriptInstance>(aVariant.value);
+
+        auto lockedState = m_lua.Lock();
+        
+        return Scripting::ToLua(lockedState, result);
+    };
+}
+
+void RTTIMapper::RegisterDirectTypes(sol::state& aLuaState, sol::table& aLuaGlobal, RED4ext::CRTTISystem* apRtti)
+{
+    aLuaState.new_usertype<EnumStatic>("EnumStatic",
+        sol::meta_function::construct, sol::no_constructor,
+        sol::base_classes, sol::bases<Type>(),
+        sol::meta_function::index, &EnumStatic::Index,
+        sol::meta_function::new_index, &EnumStatic::NewIndex);
+
+    aLuaState.new_usertype<ClassStatic>("ClassStatic",
+        sol::meta_function::construct, sol::no_constructor,
+        sol::base_classes, sol::bases<Type>(),
+        sol::meta_function::index, &ClassStatic::Index,
+        sol::meta_function::new_index, &ClassStatic::NewIndex,
+        "new", sol::property(&ClassStatic::GetFactory));
+
+    MakeSolUsertypeImmutable(aLuaState["EnumStatic"], aLuaState);
+    MakeSolUsertypeImmutable(aLuaState["ClassStatic"], aLuaState);
+
+    apRtti->types.for_each([&](RED4ext::CName aTypeName, RED4ext::IRTTIType* apType) {
+        switch (apType->GetType())
+        {
+        case RED4ext::ERTTIType::Enum:
+        {
+            auto* pEnum = static_cast<RED4ext::CEnum*>(apType);
+            auto luaEnum = make_object(aLuaState, EnumStatic(m_lua, apType));
+
+            MakeSolUsertypeImmutable(luaEnum, aLuaState);
+
+            aLuaGlobal[aTypeName.ToString()] = luaEnum;
+            break;
+        }
+        case RED4ext::ERTTIType::Class:
+        {
+            auto* pClass = static_cast<RED4ext::CClass*>(apType);
+            auto luaClass = make_object(aLuaState, ClassStatic(m_lua, apType));
+
+            MakeSolUsertypeImmutable(luaClass, aLuaState);
+
+            aLuaGlobal[aTypeName.ToString()] = luaClass;
+            break;
+        }
+        }
+        });
+}
+
+void RTTIMapper::RegisterScriptAliases(sol::table& aLuaGlobal, RED4ext::CRTTISystem* apRtti)
+{
+    apRtti->scriptToNative.for_each([&aLuaGlobal](RED4ext::CName aScriptName, RED4ext::CName aNativeName) {
+        aLuaGlobal[aScriptName.ToString()] = aLuaGlobal[aNativeName.ToString()];
+        });
+}
+
+void RTTIMapper::RegisterSpecialAccessors(sol::state& aLuaState, sol::table& aLuaGlobal)
+{
+    // Replace RTTI version of class with our own version
+    aLuaGlobal["Vector3"] = aLuaState["Vector3"];
+
+    // Merge RTTI versions of basic types with our own versions
+    // Allows usertype and RTTI functions to be used under the same name 
+    ExtendUsertype<Vector4>("Vector4", aLuaState, aLuaGlobal);
+    ExtendUsertype<EulerAngles>("EulerAngles", aLuaState, aLuaGlobal);
+    ExtendUsertype<Quaternion>("Quaternion", aLuaState, aLuaGlobal);
+    ExtendUsertype<ItemID>("ItemID", aLuaState, aLuaGlobal);
+
+    // Add global alias `Game.GetSystemRequestsHandler()`
+    // Replacement for `GetSingleton("inkMenuScenario"):GetSystemRequestsHandler()`
+    RTTIHelper::Get().AddFunctionAlias("GetSystemRequestsHandler", "inkMenuScenario", "GetSystemRequestsHandler");
+}
+
+template <class T>
+void RTTIMapper::ExtendUsertype(const std::string acTypeName, sol::state& aLuaState, sol::table& aLuaGlobal)
+{
+    auto& classStatic = aLuaGlobal.get<ClassStatic>(acTypeName);
+    auto classIndexer = [&classStatic](const sol::object& acSelf, const std::string& acName, sol::this_environment aEnv) {
+        return classStatic.Index(acName, aEnv);
+    };
+
+    auto usertype = aLuaState.get<sol::usertype<T>>(acTypeName);
+    usertype[sol::meta_function::index] = classIndexer;
+    usertype[sol::meta_function::static_index] = classIndexer;
+
+    aLuaState["__" + acTypeName] = aLuaGlobal[acTypeName];
+    aLuaGlobal[acTypeName] = aLuaState[acTypeName];
+}

--- a/src/reverse/RTTIMapper.cpp
+++ b/src/reverse/RTTIMapper.cpp
@@ -9,8 +9,8 @@
 #include "scripting/Scripting.h"
 #include "Utils.h"
 
-RTTIMapper::RTTIMapper(const LockableState& aLua, const std::string& acGlobal)
-    : m_lua(aLua)
+RTTIMapper::RTTIMapper(const LockableState& acLua, const std::string& acGlobal)
+    : m_lua(acLua)
     , m_global(acGlobal)
 {
 }
@@ -57,13 +57,13 @@ void RTTIMapper::RegisterSimpleTypes(sol::state& aLuaState, sol::table& aLuaGlob
         return sol::object(luaState, sol::in_place, Variant(pType, pHandle));
     };
 
-    aLuaGlobal["FromVariant"] = [this](const Variant& aVariant) -> sol::object {
-        if (aVariant.type == 0 || aVariant.unknown != 0)
+    aLuaGlobal["FromVariant"] = [this](const Variant& acVariant) -> sol::object {
+        if (acVariant.type == 0 || acVariant.unknown != 0)
             return sol::nil;
 
         RED4ext::CStackType result;
-        result.type = reinterpret_cast<RED4ext::IRTTIType*>(aVariant.type);
-        result.value = reinterpret_cast<RED4ext::ScriptInstance>(aVariant.value);
+        result.type = reinterpret_cast<RED4ext::IRTTIType*>(acVariant.type);
+        result.value = reinterpret_cast<RED4ext::ScriptInstance>(acVariant.value);
 
         auto lockedState = m_lua.Lock();
         

--- a/src/reverse/RTTIMapper.h
+++ b/src/reverse/RTTIMapper.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "ClassStatic.h"
+
+struct RTTIMapper
+{
+    using LockableState = TiltedPhoques::Lockable<sol::state, std::recursive_mutex>::Ref;
+
+    RTTIMapper(const LockableState& aLua, const std::string& acGlobal);
+    ~RTTIMapper();
+
+    void Register();
+
+private:
+
+    void RegisterSimpleTypes(sol::state& aLuaState, sol::table& aLuaGlobal);
+    void RegisterDirectTypes(sol::state& aLuaState, sol::table& aLuaGlobal, RED4ext::CRTTISystem* apRtti);
+    void RegisterScriptAliases(sol::table& aLuaGlobal, RED4ext::CRTTISystem* apRtti);
+    void RegisterSpecialAccessors(sol::state& aLuaState, sol::table& aLuaGlobal);
+
+    template <class T>
+    void ExtendUsertype(const std::string acTypeName, sol::state& aLuaState, sol::table& aLuaGlobal);
+
+    LockableState m_lua;
+    std::string m_global;
+};

--- a/src/reverse/RTTIMapper.h
+++ b/src/reverse/RTTIMapper.h
@@ -6,7 +6,7 @@ struct RTTIMapper
 {
     using LockableState = TiltedPhoques::Lockable<sol::state, std::recursive_mutex>::Ref;
 
-    RTTIMapper(const LockableState& aLua, const std::string& acGlobal);
+    RTTIMapper(const LockableState& acLua, const std::string& acGlobal);
     ~RTTIMapper();
 
     void Register();

--- a/src/reverse/SingletonReference.cpp
+++ b/src/reverse/SingletonReference.cpp
@@ -9,13 +9,3 @@ SingletonReference::SingletonReference(const TiltedPhoques::Lockable<sol::state,
 }
 
 SingletonReference::~SingletonReference() = default;
-
-RED4ext::ScriptInstance SingletonReference::GetHandle()
-{
-    auto* engine = RED4ext::CGameEngine::Get();
-    auto* pGameInstance = engine->framework->gameInstance;
-
-    return pGameInstance->GetInstance(m_pType);
-}
-
-

--- a/src/reverse/SingletonReference.h
+++ b/src/reverse/SingletonReference.h
@@ -7,11 +7,4 @@ struct SingletonReference : ClassType
     SingletonReference(const TiltedPhoques::Lockable<sol::state, std::recursive_mutex>::Ref& aView,
                        RED4ext::IRTTIType* apClass);
     ~SingletonReference();
-    
-protected:
-
-    virtual RED4ext::ScriptInstance GetHandle();
-    
-private:
-    uint64_t m_hash;
 };

--- a/src/reverse/Type.h
+++ b/src/reverse/Type.h
@@ -15,6 +15,9 @@ struct Type
     Type(const TiltedPhoques::Lockable<sol::state, std::recursive_mutex>::Ref& aView, RED4ext::IRTTIType* apClass);
     virtual ~Type(){};
 
+    RED4ext::IRTTIType* GetType() { return m_pType; }
+    virtual RED4ext::ScriptInstance GetHandle() { return nullptr; }
+
     sol::object Index(const std::string& acName, sol::this_environment aThisEnv);
     sol::object NewIndex(const std::string& acName, sol::object aParam);
 
@@ -26,11 +29,8 @@ struct Type
     std::string GameDump();
 
     std::string FunctionDescriptor(RED4ext::CBaseFunction* apFunc, bool aWithHashes) const;
-    sol::variadic_results Execute(RED4ext::CBaseFunction* apFunc, const std::string& acName, sol::variadic_args args, std::string& aReturnMessage);
 
 protected:
-    virtual RED4ext::ScriptInstance GetHandle() { return nullptr; }
-
     RED4ext::IRTTIType* m_pType{ nullptr };
 
     friend struct Scripting;
@@ -56,7 +56,7 @@ struct UnknownType : Type
                 RED4ext::ScriptInstance apInstance);
 
     Descriptor Dump(bool aWithHashes) const override;
-    RED4ext::ScriptInstance GetHandle()  override { return m_pInstance.get(); }
+    RED4ext::ScriptInstance GetHandle() override { return m_pInstance.get(); }
 
 private:
     std::unique_ptr<uint8_t[]> m_pInstance;

--- a/src/scripting/FunctionOverride.cpp
+++ b/src/scripting/FunctionOverride.cpp
@@ -54,13 +54,11 @@ bool FunctionOverride::HookRunPureScriptFunction(RED4ext::CClassFunction* apFunc
             {
                 auto logger = call->Environment["__logger"].get<std::shared_ptr<spdlog::logger>>();
                 logger->error(result.get<sol::error>().what());
-
-                continue;
             }
 
             if (!call->Forward)
             {
-                if (ret.value && ret.type)
+                if (result.valid() && ret.value && ret.type)
                     Scripting::ToRED(result.get<sol::object>(), &ret);
 
                 return true;
@@ -226,10 +224,7 @@ void FunctionOverride::HandleOverridenFunction(RED4ext::IScriptable* apContext, 
             {
                 auto logger = call->Environment["__logger"].get<std::shared_ptr<spdlog::logger>>();
                 logger->error(result.get<sol::error>().what());
-
-                continue;
             }
-
 
             if (!call->Forward)
             {
@@ -239,7 +234,7 @@ void FunctionOverride::HandleOverridenFunction(RED4ext::IScriptable* apContext, 
                     redResult.type = apFunction->returnType->type;
                     redResult.value = apOut;
 
-                    if (apOut)
+                    if (result.valid() && apOut)
                         Scripting::ToRED(result.get<sol::object>(), &redResult);
                 }
 

--- a/src/scripting/LuaSandbox.h
+++ b/src/scripting/LuaSandbox.h
@@ -8,6 +8,7 @@ struct LuaSandbox
     ~LuaSandbox() = default;
 
     void Initialize();
+    void PostInitialize();
     void ResetState();
 
     size_t CreateSandbox(const std::filesystem::path& acPath = "", const std::string& acName = "", bool aEnableExtraLibs = true, bool aEnableDB = true, bool aEnableIO = true, bool aEnableLogger = true);

--- a/src/scripting/LuaVM.cpp
+++ b/src/scripting/LuaVM.cpp
@@ -177,6 +177,8 @@ void LuaVM::PostInitialize()
 {
     assert(!m_initialized);
 
+    m_scripting.PostInitialize();
+
     m_scripting.TriggerOnInit();
     if (CET::Get().GetOverlay().IsEnabled())
         m_scripting.TriggerOnOverlayOpen();

--- a/src/scripting/Sandbox.cpp
+++ b/src/scripting/Sandbox.cpp
@@ -14,6 +14,11 @@ Sandbox::Sandbox(Scripting* apScripting, sol::environment aBaseEnvironment, cons
     sol::state_view sv = apScripting->GetState().Get();
     for (const auto& cKV : aBaseEnvironment)
         m_env[cKV.first] = DeepCopySolObject(cKV.second, sv);
+
+    // set global fallback table for the environment
+    sol::table metatable(sv, sol::create);
+    metatable[sol::meta_function::index] = sv.get<sol::table>(apScripting->GetGlobalName());
+    m_env[sol::metatable_key] = metatable;
 }
 
 sol::protected_function_result Sandbox::ExecuteFile(const std::string& acPath) const

--- a/src/scripting/Scripting.h
+++ b/src/scripting/Scripting.h
@@ -2,6 +2,7 @@
 
 #include "FunctionOverride.h"
 #include "ScriptStore.h"
+#include "reverse/RTTIMapper.h"
 #include "reverse/SingletonReference.h"
 
 struct D3D12;
@@ -14,6 +15,7 @@ struct Scripting
     ~Scripting() = default;
 
     void Initialize();
+    void PostInitialize();
 
     const std::vector<VKBindInfo>& GetBinds() const;
 
@@ -29,6 +31,7 @@ struct Scripting
 
     bool ExecuteLua(const std::string& acCommand);
     LockedState GetState() const noexcept;
+    std::string GetGlobalName() const noexcept;
 
     static size_t Size(RED4ext::IRTTIType* apRttiType);
     static sol::object ToLua(LockedState& aState, RED4ext::CStackType& aResult);
@@ -41,13 +44,13 @@ protected:
     sol::object NewIndex(const std::string& acName, sol::object aParam);
     sol::object GetSingletonHandle(const std::string& acName, sol::this_environment aThisEnv);
     sol::protected_function InternalIndex(const std::string& acName, sol::this_environment aThisEnv);
-    
-    sol::variadic_results Execute(const std::string& aFuncName, sol::variadic_args aArgs, std::string& aReturnMessage, sol::this_state aState) const;
 
 private:
     TiltedPhoques::Lockable<sol::state, std::recursive_mutex> m_lua;
     std::unordered_map<std::string, sol::object> m_properties{ };
     std::unordered_map<std::string, SingletonReference> m_singletons{ };
+    std::string m_global{ "Global" };
+    RTTIMapper m_mapper;
     LuaSandbox m_sandbox;
     ScriptStore m_store;
     FunctionOverride m_override;


### PR DESCRIPTION
## Script API

- All game classes are directly accessible by name. For example, `entEntityId`, `PlayerPuppet`.
- All game enums are directly accessible by name. For example, `gamedataStatType.BaseDamage`, `gameGameVersion.Current`.
- Classes can also be accessed by their aliases from redscript. For example, `WeaponObject` instead of `gameweaponObject`.
- Classes have the conventional `.new()` constructor. For example, `MappinData.new()`.
- A constructor can take an array of properties to create and initialize an object in a single statement. For example, `EntityID.new({ hash = 12345 })`.
- Static methods are accessible from classes using the dot. For example, `ScriptedPuppet.IsDefeated(npc)`.
- A static method can be called from an instance if the first parameter is of the same type. For example, `vec4:Length()` instead of `Vector4.Length(vec4)`.
- The overloaded function is resolved based on passed parameters when called by its short name. For example, `StatusEffectHelper.HasStatusEffect(target, gamedataStatusEffectType.Overheat)`.
- Partial `Variant` type support. `ToVariant()` and `FromVariant()` are only applicable to classes.
- New `Game.GetSystemRequestsHandler()` alias as an alternative to singleton version.

[Additional info with examples](https://github.com/psiberx/CyberEngineTweaks/wiki/Lua-Script-API)

## Changes and fixes
- The `GetMod()` is only available after `onInit` as there is no guarantee that the required mod will be loaded before this event.
- Types and functions that rely on RTTI are only available after `onInit` event to prevent some unwanted crashes and unexpected behavior.
- Optional function parameters are required now to prevent more unexpected crashes. 
  * Passing nulls for optional parameters was causing a lot of crashes. Users are forced to pass an actual value anyway. So it's better to require the value explicitly until optional parameters are fully implemented.
- Fixed `DumpType("Type")` returning empty result.
- Fixed crash when accessing properties of invalid `Enum`, eg. `Enum.new('', '').value`.
- Fixed crash when setting an incompatible value for an object property.
- Fixed crash when calling function with out parameters of `Enum`, `CName` or `TweakDBID` type.
- Fixed memory leaks when passing strong or weak references to the function. 
  * Each function call incremented ref count by one permanently.
- Fixed memory leaks when invalid parameters passed to the function.
  * The LuaRED converter was failing silently without calling the `ResetAllocator` if parameter is of primitive type and passed value is not compatible.
- Fixed memory leaks for function results and out parameters of certain types.
- Fixed memory leaks when creating new objects.
- Fixed memory leaks when setting object properties.
- Added workaround to avoid excessive memory consumption when setting properties for the objects of certain types.
- Reverted `Override()` to the previous behavior so when the handler fails, the original game function is not called. 

## Internals
- Global fallback table is used now for all mod environments. No need to whitelist what's defined there.
- Aliases like `Game['GetPlayer'] = Game['GetPlayer;GameInstance']` aren't needed in `autoexec.lua`. All global and class functions are automatically resolved by short name now.
- Added implicit class to strong reference conversion.

---

#### Update 05.05.21

- Merged LuaRED changes by Sombra from PR #552.
- Added implicit conversion from Int64/UInt64 to other arithmetic types.
- Added type safety checks for Int64/UInt64.
- Fixed typos and minor naming inaccuracies.

#### Update 06.05.21

- Added recursive freeing of arrays. This was a known case, but has not been sufficiently tested.
- Info about table to instance implicit conversion is temporarily hidden. This can lead to memory leaks until `FreeInstance` is refactored to a custom allocator that can keep track of all new allocations. 
