### PR TITLE
Add ResourceAsyncReference support, small fixes and improvements

### DIFF
--- a/src/reverse/BasicTypes.h
+++ b/src/reverse/BasicTypes.h
@@ -67,8 +67,16 @@ uint32_t crc32(const char* buf, size_t len, uint32_t seed);
 struct CName
 {
     CName(uint64_t aHash = 0) : hash(aHash){}
+
     CName(uint32_t aHashLo, uint32_t aHashHi) : hash_lo(aHashLo), hash_hi(aHashHi) {}
-    CName(const std::string& aName) : hash(RED4ext::FNV1a(aName.c_str())){}
+
+    CName(const std::string& aName)
+    {
+        if (aName != "None")
+            hash = RED4ext::FNV1a(aName.c_str());
+        else
+            hash = 0;
+    }
 
     union
     {

--- a/src/reverse/RTTIHelper.cpp
+++ b/src/reverse/RTTIHelper.cpp
@@ -41,10 +41,10 @@ RTTIHelper::RTTIHelper(const LockableState& acLua)
 void RTTIHelper::InitializeRTTI()
 {
     m_pRtti = RED4ext::CRTTISystem::Get();
-    m_pEngine = RED4ext::CGameEngine::Get();
     m_pGameInstanceType = m_pRtti->GetClass(RED4ext::FNV1a("ScriptGameInstance"));
 
-    const auto cpGameInstance = m_pEngine->framework->gameInstance;
+    const auto cpEngine = RED4ext::CGameEngine::Get();
+    const auto cpGameInstance = cpEngine->framework->gameInstance;
     const auto cpPlayerSystemType = m_pRtti->GetType(RED4ext::FNV1a("cpPlayerSystem"));
     m_pPlayerSystem = reinterpret_cast<RED4ext::ScriptInstance>(cpGameInstance->GetInstance(cpPlayerSystemType));
 }
@@ -479,7 +479,12 @@ sol::variadic_results RTTIHelper::ExecuteFunction(RED4ext::CBaseFunction* apFunc
                                                   sol::variadic_args aLuaArgs, uint32_t aLuaArgOffset,
                                                   bool aExactNumArgs, std::string& aErrorMessage) const
 {
-    if (!m_pRtti || !m_pEngine->framework)
+    if (!m_pRtti)
+        return {};
+
+    const auto* cpEngine = RED4ext::CGameEngine::Get();
+
+    if (!cpEngine || !cpEngine->framework)
         return {};
 
     // Optional params
@@ -533,7 +538,7 @@ sol::variadic_results RTTIHelper::ExecuteFunction(RED4ext::CBaseFunction* apFunc
         if (cpParam->type == m_pGameInstanceType)
         {
             callArgs[i].type = m_pGameInstanceType;
-            callArgs[i].value = &m_pEngine->framework->gameInstance;
+            callArgs[i].value = &cpEngine->framework->gameInstance;
         }
         else if (cpParam->flags.isOut)
         {
@@ -649,7 +654,7 @@ RED4ext::ScriptInstance RTTIHelper::NewPlaceholder(RED4ext::IRTTIType* apType, T
 
 RED4ext::ScriptInstance RTTIHelper::NewInstance(RED4ext::IRTTIType* apType, sol::optional<sol::table> aProps, TiltedPhoques::Allocator* apAllocator) const
 {
-    if (!m_pRtti || !m_pEngine->framework)
+    if (!m_pRtti)
         return nullptr;
 
     RED4ext::CClass* pClass = nullptr;
@@ -688,7 +693,7 @@ RED4ext::ScriptInstance RTTIHelper::NewInstance(RED4ext::IRTTIType* apType, sol:
 
 sol::object RTTIHelper::NewInstance(RED4ext::IRTTIType* apType, sol::optional<sol::table> aProps) const
 {
-    if (!m_pRtti || !m_pEngine->framework)
+    if (!m_pRtti)
         return sol::nil;
 
     TiltedPhoques::StackAllocator<1 << 10> allocator;
@@ -715,7 +720,7 @@ sol::object RTTIHelper::NewHandle(RED4ext::IRTTIType* apType, sol::optional<sol:
     // The Handle<> wrapper prevents memory leaks that can occur in IRTTIType::Assign()
     // when called directly on an IScriptable instance.
 
-    if (!m_pRtti || !m_pEngine->framework)
+    if (!m_pRtti)
         return sol::nil;
 
     TiltedPhoques::StackAllocator<1 << 10> allocator;
@@ -754,7 +759,7 @@ sol::object RTTIHelper::GetProperty(RED4ext::CClass* apClass, RED4ext::ScriptIns
 {
     aSuccess = false;
 
-    if (!m_pRtti || !m_pEngine->framework)
+    if (!m_pRtti)
         return sol::nil;
 
     auto* pProp = apClass->GetProperty(acPropName.c_str());
@@ -773,7 +778,7 @@ void RTTIHelper::SetProperty(RED4ext::CClass* apClass, RED4ext::ScriptInstance a
 {
     aSuccess = false;
 
-    if (!m_pRtti || !m_pEngine->framework)
+    if (!m_pRtti)
         return;
 
     auto* pProp = apClass->GetProperty(acPropName.c_str());

--- a/src/reverse/RTTIHelper.cpp
+++ b/src/reverse/RTTIHelper.cpp
@@ -542,8 +542,9 @@ sol::variadic_results RTTIHelper::ExecuteFunction(RED4ext::CBaseFunction* apFunc
     };
     ResetAllocator ___allocatorReset;
 
-    std::vector<RED4ext::CStackType> callArgs(apFunc->params.size);
-    std::vector<uint32_t> callArgToParam(apFunc->params.size);
+    TiltedPhoques::ScopedAllocator _(&s_scratchMemory);
+    TiltedPhoques::Vector<RED4ext::CStackType> callArgs(apFunc->params.size);
+    TiltedPhoques::Vector<uint32_t> callArgToParam(apFunc->params.size);
     uint32_t callArgOffset = 0u;
 
     for (auto i = 0u; i < apFunc->params.size; ++i)

--- a/src/reverse/RTTIHelper.cpp
+++ b/src/reverse/RTTIHelper.cpp
@@ -827,7 +827,7 @@ void RTTIHelper::SetProperty(RED4ext::CClass* apClass, RED4ext::ScriptInstance a
     if (!pProp)
         return;
 
-    static thread_local TiltedPhoques::ScratchAllocator s_scratchMemory(1 << 10);
+    static thread_local TiltedPhoques::ScratchAllocator s_scratchMemory(1 << 13);
     struct ResetAllocator
     {
         ~ResetAllocator()

--- a/src/reverse/RTTIHelper.h
+++ b/src/reverse/RTTIHelper.h
@@ -61,6 +61,7 @@ private:
         kGlobalHash = 0,
         kStaticScope = 0,
         kMemberScope = 1,
+        kTrackedOverloadCalls = 256,
     };
 
     struct Overload

--- a/src/reverse/RTTIHelper.h
+++ b/src/reverse/RTTIHelper.h
@@ -18,7 +18,7 @@ struct RTTIHelper
     RED4ext::ScriptInstance ResolveHandle(RED4ext::CBaseFunction* apFunc, sol::variadic_args& aArgs, uint64_t& aArgOffset) const;
     sol::variadic_results ExecuteFunction(RED4ext::CBaseFunction* apFunc, RED4ext::ScriptInstance apHandle,
                                           sol::variadic_args aLuaArgs, uint64_t aLuaArgOffset,
-                                          bool aExactNumArgs, std::string& aErrorMessage) const;
+                                          std::string& aErrorMessage) const;
     
     RED4ext::ScriptInstance NewInstance(RED4ext::IRTTIType* apType, sol::optional<sol::table> aProps, TiltedPhoques::Allocator* apAllocator) const;
     sol::object NewInstance(RED4ext::IRTTIType* apType, sol::optional<sol::table> aProps) const;

--- a/src/reverse/RTTIHelper.h
+++ b/src/reverse/RTTIHelper.h
@@ -15,9 +15,9 @@ struct RTTIHelper
     sol::function ResolveFunction(const std::string& acFuncName);
     sol::function ResolveFunction(RED4ext::CClass* apClass, const std::string& acFuncName, bool aIsMember);
     
-    RED4ext::ScriptInstance ResolveHandle(RED4ext::CBaseFunction* apFunc, sol::variadic_args& aArgs, uint32_t& aArgOffset) const;
+    RED4ext::ScriptInstance ResolveHandle(RED4ext::CBaseFunction* apFunc, sol::variadic_args& aArgs, uint64_t& aArgOffset) const;
     sol::variadic_results ExecuteFunction(RED4ext::CBaseFunction* apFunc, RED4ext::ScriptInstance apHandle,
-                                          sol::variadic_args aLuaArgs, uint32_t aLuaArgOffset,
+                                          sol::variadic_args aLuaArgs, uint64_t aLuaArgOffset,
                                           bool aExactNumArgs, std::string& aErrorMessage) const;
     
     RED4ext::ScriptInstance NewInstance(RED4ext::IRTTIType* apType, sol::optional<sol::table> aProps, TiltedPhoques::Allocator* apAllocator) const;

--- a/src/reverse/RTTIHelper.h
+++ b/src/reverse/RTTIHelper.h
@@ -73,7 +73,6 @@ private:
 
     LockableState m_lua;
     RED4ext::CRTTISystem* m_pRtti;
-    RED4ext::CGameEngine* m_pEngine;
     RED4ext::CClass* m_pGameInstanceType;
     RED4ext::ScriptInstance m_pPlayerSystem;
     RedFunctionMap m_extendedFunctions;

--- a/src/reverse/ResourceAsyncReference.cpp
+++ b/src/reverse/ResourceAsyncReference.cpp
@@ -1,0 +1,36 @@
+#include <stdafx.h>
+
+#include "ResourceAsyncReference.h"
+#include "RTTILocator.h"
+#include "Converter.h"
+
+ResourceAsyncReference::ResourceAsyncReference(const TiltedPhoques::Locked<sol::state, std::recursive_mutex>& aView,
+                                               RED4ext::IRTTIType* apType, RED4ext::ResourceAsyncReference<void>* apReference)
+    : ClassType(aView, reinterpret_cast<RED4ext::CResourceAsyncReference*>(apType)->innerType)
+    , m_reference(*apReference)
+{
+}
+
+RED4ext::ScriptInstance ResourceAsyncReference::GetHandle()
+{
+    return &m_reference;
+}
+
+uint64_t ResourceAsyncReference::GetHash() const
+{
+    return reinterpret_cast<uint64_t>(m_reference.ref);
+}
+
+// Manual uint64 to Lua conversion because sol + LuaJIT can't do it
+sol::object ResourceAsyncReference::GetLuaHash()
+{
+    static RTTILocator s_uint64Type{RED4ext::FNV1a("Uint64")};
+
+    auto lockedState = m_lua.Lock();
+
+    RED4ext::CStackType stackType;
+    stackType.type = s_uint64Type;
+    stackType.value = GetHandle();
+
+    return Converter::ToLua(stackType, lockedState);
+}

--- a/src/reverse/ResourceAsyncReference.h
+++ b/src/reverse/ResourceAsyncReference.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "Type.h"
+
+struct ResourceAsyncReference : ClassType
+{
+    ResourceAsyncReference(const TiltedPhoques::Locked<sol::state, std::recursive_mutex>& aView, 
+                           RED4ext::IRTTIType* apType, RED4ext::ResourceAsyncReference<void>* apReference);
+
+    virtual RED4ext::ScriptInstance GetHandle();
+
+    uint64_t GetHash() const;
+    sol::object GetLuaHash();
+
+private:
+    RED4ext::ResourceAsyncReference<void> m_reference;
+};

--- a/src/scripting/FunctionOverride.cpp
+++ b/src/scripting/FunctionOverride.cpp
@@ -316,8 +316,15 @@ void FunctionOverride::Override(const std::string& acTypeName, const std::string
 
     if (!pClassType)
     {
-        spdlog::get("scripting")->error("Class type {} not found", acTypeName);
-        return;
+        auto* pNativeCName = pRtti->scriptToNative.Get(RED4ext::CName(acTypeName.c_str()));
+
+        if (!pNativeCName)
+        {
+            spdlog::get("scripting")->error("Class type {} not found", acTypeName);
+            return;
+        }
+
+        pClassType = pRtti->GetClass(*pNativeCName);
     }
 
     auto pContext = TiltedPhoques::MakeUnique<Context>();

--- a/src/scripting/FunctionOverride.h
+++ b/src/scripting/FunctionOverride.h
@@ -18,7 +18,8 @@ struct FunctionOverride
     void Clear();
 
     void Override(const std::string& acTypeName, const std::string& acFullName, const std::string& acShortName,
-                  bool aAbsolute, sol::protected_function aFunction, sol::this_environment aEnvironment);
+                  bool aAbsolute, sol::protected_function aFunction, sol::environment aEnvironment,
+                  bool aCollectGarbage = false);
 
 protected:
 
@@ -39,6 +40,7 @@ private:
         RED4ext::CClassFunction* Trampoline;
         Scripting* pScripting;
         TiltedPhoques::Vector<TiltedPhoques::UniquePtr<Context>> Calls;
+        bool CollectGarbage;
     };
 
     void* m_pBufferStart;

--- a/src/scripting/Scripting.cpp
+++ b/src/scripting/Scripting.cpp
@@ -14,13 +14,14 @@
 #include <reverse/BasicTypes.h>
 #include <reverse/SingletonReference.h>
 #include <reverse/StrongReference.h>
-#include <reverse/Converter.h>
 #include <reverse/WeakReference.h>
+#include <reverse/ResourceAsyncReference.h>
 #include <reverse/Enum.h>
 #include <reverse/TweakDB.h>
 #include <reverse/RTTILocator.h>
 #include <reverse/RTTIHelper.h>
 #include <reverse/RTTIExtender.h>
+#include <reverse/Converter.h>
 
 #include "Utils.h"
 
@@ -152,6 +153,13 @@ void Scripting::PostInitialize()
         sol::base_classes, sol::bases<Type>(),
         sol::meta_function::index, &ClassReference::Index,
         sol::meta_function::new_index, &ClassReference::NewIndex);
+
+    luaVm.new_usertype<ResourceAsyncReference>("ResourceAsyncReference",
+        sol::meta_function::construct, sol::no_constructor,
+        sol::base_classes, sol::bases<Type>(),
+        sol::meta_function::index, &ResourceAsyncReference::Index,
+        sol::meta_function::new_index, &ResourceAsyncReference::NewIndex,
+        "hash", sol::property(&ResourceAsyncReference::GetLuaHash));
 
     luaVm.new_usertype<UnknownType>("Unknown",
         sol::meta_function::construct, sol::no_constructor,
@@ -629,6 +637,12 @@ sol::object Scripting::ToLua(LockedState& aState, RED4ext::CStackType& aResult)
 
         return result;
     }
+    else if (pType->GetType() == RED4ext::ERTTIType::ResourceAsyncReference)
+    {
+        auto* pInstance = static_cast<RED4ext::ResourceAsyncReference<void>*>(aResult.value);
+        if (pInstance)
+            return make_object(state, ResourceAsyncReference(aState, aResult.type, pInstance));
+    }
     else
     {
         auto result = Converter::ToLua(aResult, aState);
@@ -781,6 +795,44 @@ RED4ext::CStackType Scripting::ToRED(sol::object aObject, RED4ext::IRTTIType* ap
                 pScriptRef->ref = pClassRef->GetHandle();
                 apRttiType->GetName(pScriptRef->hash);
                 result.value = pScriptRef;
+            }
+        }
+        else if (apRttiType->GetType() == RED4ext::ERTTIType::ResourceAsyncReference)
+        {
+            if (hasData)
+            {
+                uint64_t hash = 0;
+
+                if (aObject.is<ResourceAsyncReference>())
+                {
+                    hash = aObject.as<ResourceAsyncReference*>()->GetHash();
+                }
+                else if (aObject.get_type() == sol::type::string)
+                {
+                    hash = RED4ext::FNV1a(aObject.as<std::string>().c_str());
+                }
+                else if (aObject.is<CName>())
+                {
+                    hash = aObject.as<CName*>()->hash;
+                }
+                else if (aObject.get_type() == sol::type::number)
+                {
+                    hash = aObject.as<uint64_t>();
+                }
+                else if (IsLuaCData(aObject))
+                {
+                    sol::state_view v(aObject.lua_state());
+                    std::string str = v["tostring"](aObject);
+                    hash = std::stoull(str);
+                }
+
+                if (hash != 0)
+                {
+                    auto* pRaRef = apAllocator->New<RED4ext::ResourceAsyncReference<void>>();
+                    pRaRef->ref = reinterpret_cast<void*>(hash);
+
+                    result.value = pRaRef;
+                }
             }
         }
         else

--- a/src/scripting/Scripting.h
+++ b/src/scripting/Scripting.h
@@ -22,14 +22,14 @@ struct Scripting
     void TriggerOnInit() const;
     void TriggerOnUpdate(float aDeltaTime) const;
     void TriggerOnDraw() const;
-    
     void TriggerOnOverlayOpen() const;
     void TriggerOnOverlayClose() const;
 
     sol::object GetMod(const std::string& acName) const;
     void ReloadAllMods();
-
     bool ExecuteLua(const std::string& acCommand);
+    void CollectGarbage();
+
     LockedState GetState() const noexcept;
     std::string GetGlobalName() const noexcept;
 
@@ -39,6 +39,7 @@ struct Scripting
     static void ToRED(sol::object aObject, RED4ext::CStackType* apType);
 
 protected:
+    void RegisterOverrides();
 
     sol::object Index(const std::string& acName, sol::this_environment aThisEnv);
     sol::object NewIndex(const std::string& acName, sol::object aParam);


### PR DESCRIPTION
- `Observe()` and `Override()` now accept both native and scripted type names.
- Improved overloaded functions handling. Prevents constant swapping when two overloads are used at the same rate.
- Improved detection of whether the game is running. Prevents more crashes when exiting the game.
- Added support for old style static calls `obj:Static(obj, args)`. Improves backward compatibility with 1.13 mods.
- Added support for `ResourceAsyncReference`. Allows editing of TweakDB props of that type by the mods,
- Fixed `CName` calculation for "None" (mirrors RED4ext logic).
- Added logging for errors occurred in the module loaded with `require()`. Should make the transition to the new version less painful.
- Added optional params support. For example, `Game.GetTimeSystem():SetTimeDilation("deflect", 0.1, 2.5)`.
- Fixed disappearing footsteps issue. If the mod stores a reference to the player entity, then it must release the reference when a new game session is loaded. Otherwise the issue of disappearing steps will occur.
- Fixed inconsistent `self` and random crashes for overridden functions.