### PR TITLE
exEntitySpawner RTTIExtender

### DIFF
--- a/src/overlay/widgets/Console.cpp
+++ b/src/overlay/widgets/Console.cpp
@@ -125,6 +125,18 @@ void Console::Update()
     ImGui::SetItemDefaultFocus();
     if (execute)
     {
+        // trim end
+        {
+            size_t commandLength = strlen(m_Command);
+            for (size_t i = commandLength - 1; i != 0; --i)
+            {
+                if (std::isspace(m_Command[i]))
+                    m_Command[i] = '\0';
+                else
+                    break;
+            }
+        }
+
         auto consoleLogger = spdlog::get("scripting");
         consoleLogger->info("> {}", m_Command);
 

--- a/src/reverse/RTTIExtender.cpp
+++ b/src/reverse/RTTIExtender.cpp
@@ -1,6 +1,330 @@
 #include "RTTIExtender.h"
+#include <CET.h>
+#include <Image.h>
+#include <RED4ext/Types/SharedMutex.hpp>
+#include <RED4ext/Types/generated/Transform.hpp>
 #include <RED4ext/Types/generated/WorldTransform.hpp>
+#include <RED4ext/Types/generated/ent/Entity.hpp>
 #include <RED4ext/Types/generated/ent/EntityID.hpp>
+
+template<typename T>
+struct PatternCall
+{
+    PatternCall(const char* acPattern, const int32_t acOffset = 0)
+    {
+        const auto& gameImage = CET::Get().GetOptions().GameImage;
+        const mem::pattern cPattern(acPattern);
+        const mem::default_scanner cScanner(cPattern);
+        const auto* pLocation = cScanner(gameImage.TextRegion).as<uint8_t*>();
+        m_address = pLocation ? reinterpret_cast<T>(pLocation + acOffset) : nullptr;
+    }
+
+    operator T() const
+    {
+        assert(m_address != nullptr);
+        return m_address;
+    }
+
+private:
+    T m_address;
+};
+
+#pragma region To be moved to RED4Ext.SDK once reversed
+
+// what? why not Handle? what to call this?
+// T must have AddRef and DecRef
+template<typename T>
+struct REDSmartPtr
+{
+    REDSmartPtr(T* aData = nullptr)
+        : data(aData)
+    {
+        AddRef();
+    }
+
+    REDSmartPtr(const REDSmartPtr& acOther)
+        : data(acOther.data)
+    {
+        AddRef();
+    }
+
+    REDSmartPtr(REDSmartPtr&& aOther)
+        : data(aOther.data)
+    {
+        aOther.data = nullptr;
+    }
+
+    ~REDSmartPtr()
+    {
+        Reset();
+    }
+
+    void Reset()
+    {
+        if (data != nullptr)
+        {
+            data->DecRef();
+            data = nullptr;
+        }
+    }
+
+    REDSmartPtr& operator=(const REDSmartPtr& acOther)
+    {
+        Reset();
+        data = acOther.data;
+        AddRef();
+
+        return *this;
+    }
+
+    REDSmartPtr& operator=(REDSmartPtr&& aOther)
+    {
+        Reset();
+        data = aOther.data;
+        aOther.data = nullptr;
+
+        return *this;
+    }
+
+    [[nodiscard]] T* operator->()
+    {
+        return data;
+    }
+
+    [[nodiscard]] const T* operator->() const
+    {
+        return data;
+    }
+
+    explicit operator bool() const noexcept
+    {
+        return data != nullptr;
+    }
+
+private:
+    void AddRef()
+    {
+        if (data != nullptr)
+        {
+            data->AddRef();
+        }
+    }
+
+public:
+    T* data;
+};
+
+struct IUpdatableSystem : RED4ext::IScriptable
+{
+    virtual void sub_110(uint64_t) = 0; // probably Update
+};
+
+struct gameIGameSystem : IUpdatableSystem
+{
+    RED4ext::GameInstance* gameInstance;
+
+    static void CallConstructor(void* apAddress)
+    {
+        // expected: 5, index: 0
+        using TFunc = void (*)(void*);
+        static PatternCall<TFunc> func("48 8B D9 E8 ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ?? 48 C7 43 40 00 00 00 00", -6);
+        func(apAddress); // gameIGameSystem::ctor()
+    }
+
+    virtual void OnInitialize() = 0;                    // 118
+    virtual void OnShutdown() = 0;                      // 120
+    virtual void sub_128() = 0;
+    virtual void sub_130() = 0;
+    virtual void sub_138() = 0;
+    virtual void sub_140() = 0;
+    virtual void sub_148() = 0;
+    virtual void sub_150() = 0;
+    virtual void sub_158() = 0;
+    virtual void sub_160() = 0;
+    virtual void sub_168() = 0;
+    virtual void sub_170() = 0;
+    virtual void sub_178() = 0;
+    virtual void sub_180() = 0;
+    virtual void sub_188() = 0;
+    virtual void sub_190() = 0;
+    virtual void OnSystemInitializeAsync(void*) = 0;    // 198
+    virtual void OnSystemUnInitializeAsync(void*) = 0;  // 1A0
+};
+RED4EXT_ASSERT_OFFSET(gameIGameSystem, gameInstance, 0x40);
+
+struct TEMP_PendingEntity
+{
+    struct Unk00
+    {
+        // TEMP_SpawnSettings without the first 8 bytes???
+        uint8_t unk08[0x100];
+        RED4ext::CName entityPath;
+        RED4ext::ent::EntityID entityID;
+        RED4ext::ent::Entity* entity;
+        // ...
+
+        virtual void sub_00() = 0;
+        virtual ~Unk00() = 0;
+        virtual void sub_10() = 0;
+        virtual void sub_18() = 0;
+        virtual void sub_20() = 0;
+        virtual void DecRef() = 0;
+        virtual void AddRef() = 0;
+    };
+    RED4EXT_ASSERT_OFFSET(Unk00, entityID, 0x110);
+
+    Unk00* unk00;
+    uint64_t unk08;
+    uint64_t unk18;
+    uint64_t unk20;
+    uint64_t unk28;
+};
+RED4EXT_ASSERT_SIZE(TEMP_PendingEntity, 5 * 8);
+
+struct TEMP_SpawnSettings
+{
+    uintptr_t unk00 = 0;
+    uintptr_t unk08 = 0;
+    RED4ext::Transform transform{};
+    //uint8_t unk30[0x38]{};
+    //uintptr_t unk68 = 0;
+    std::function<void(TEMP_PendingEntity::Unk00&)> callback;
+    uint8_t unk70[0x18]{};
+    uintptr_t unk88 = 0;
+    uintptr_t unk90 = 0;
+    uintptr_t unk98 = 0;
+    RED4ext::Handle<RED4ext::IScriptable> unkA0;
+    RED4ext::Handle<RED4ext::IScriptable> unkB0;
+    RED4ext::CName appearance = "default";
+    uintptr_t unkC8 = 0;
+    uintptr_t unkD0 = 0;
+    uintptr_t unkD8 = 0;
+    RED4ext::TweakDBID DONOTUSE_recordDBID = 0;
+    uint32_t unkE8 = 0x10101FF;
+
+    void SetTransform(const RED4ext::WorldTransform& acWorldTransform)
+    {
+        constexpr auto FixedToFloat = [](const int32_t acValue)
+        {
+            return acValue * (1.f / (2 << 16));
+        };  
+
+        transform.position.X = FixedToFloat(acWorldTransform.Position.x.Bits);
+        transform.position.Y = FixedToFloat(acWorldTransform.Position.y.Bits);
+        transform.position.Z = FixedToFloat(acWorldTransform.Position.z.Bits);
+        transform.position.W = 0.0f;
+
+        // ------------------------------
+
+        // Normalize Quats
+        float quatLength = sqrtf(acWorldTransform.Orientation.i * acWorldTransform.Orientation.i +
+                                 acWorldTransform.Orientation.j * acWorldTransform.Orientation.j +
+                                 acWorldTransform.Orientation.k * acWorldTransform.Orientation.k +
+                                 acWorldTransform.Orientation.r * acWorldTransform.Orientation.r);
+        if (quatLength != 0.0f)
+        {
+            transform.orientation.i = acWorldTransform.Orientation.i / quatLength;
+            transform.orientation.j = acWorldTransform.Orientation.j / quatLength;
+            transform.orientation.k = acWorldTransform.Orientation.k / quatLength;
+            transform.orientation.r = acWorldTransform.Orientation.r / quatLength;
+        }
+    }
+
+    void SetRecordID(const RED4ext::TweakDBID acTweakDBID)
+    {
+        // Copied from the function photomode uses to spawn 3rd person puppet
+        using TFunc = void (*)(const RED4ext::TweakDBID&, RED4ext::Handle<RED4ext::IScriptable>&);
+        static PatternCall<TFunc> func("48 89 5C 24 08 48 89 74 24 18 55 57 41 56 48 8D 6C 24 B9 48 81 EC 90 00 00 00 48 8B F9");
+
+        DONOTUSE_recordDBID = acTweakDBID;
+        func(acTweakDBID, unkB0);
+    }
+};
+RED4EXT_ASSERT_OFFSET(TEMP_SpawnSettings, unk70, 0x70);
+RED4EXT_ASSERT_OFFSET(TEMP_SpawnSettings, DONOTUSE_recordDBID, 0xE0);
+RED4EXT_ASSERT_SIZE(TEMP_SpawnSettings, 0xF0); // Guessed. ctor is inlined
+
+struct TEMP_Spawner
+{
+    RED4ext::DynArray<void*> unk00;
+    RED4ext::DynArray<RED4ext::Handle<RED4ext::IScriptable>> spawnedEntities;
+    RED4ext::DynArray<TEMP_PendingEntity> pendingEntities;
+    RED4ext::DynArray<void*> unk30;
+    uint8_t unk40 = 0; // most likely a mutex
+    RED4ext::SharedMutex entitiesMtx; // used in DespawnEntity
+    RED4ext::SharedMutex pendingEntitiesMtx; // used in SpawnEntity
+    uintptr_t unk48 = 0;
+    uintptr_t unk50 = 0;
+    uintptr_t unk58 = 0;
+    uintptr_t unk60 = 0;
+
+    TEMP_Spawner(RED4ext::IMemoryAllocator* apAllocator = nullptr)
+        : unk00(apAllocator)
+        , spawnedEntities(apAllocator)
+        , pendingEntities(apAllocator)
+        , unk30(apAllocator)
+    {
+    }
+
+    void Initialize(RED4ext::GameInstance* apGameInstance)
+    {
+        using TFunc = void (*)(TEMP_Spawner*, RED4ext::GameInstance*);
+        static PatternCall<TFunc> func("48 89 5C 24 18 48 89 6C 24 20 57 48 83 EC 30 48 8B 42 78");
+        func(this, apGameInstance);
+    }
+
+    void UnInitialize()
+    {
+        using TFunc = void (*)(TEMP_Spawner*);
+        static PatternCall<TFunc> func("40 53 48 83 EC 20 48 8B D9 E8 ?? ?? ?? ?? 33 C0 48 89 43 50 48 89 43 48");
+        func(this);
+    }
+
+    RED4ext::ent::EntityID Spawn(const RED4ext::CName acEntityPath, const TEMP_SpawnSettings& acSettings)
+    {
+        // REDSmartPtr<TEMP_PendingEntity::Unk00> TEMP_Spawner::func(this, TEMP_SpawnSettings&, RED4ext::CName&)
+        using TFunc = void (*)(TEMP_Spawner*, REDSmartPtr<TEMP_PendingEntity::Unk00>*, const TEMP_SpawnSettings&, const RED4ext::CName&);
+        static PatternCall<TFunc> func("FF 90 A8 01 00 00 48 8B 00 4C 8D 85 80 00 00 00", -0x55);
+
+        REDSmartPtr<TEMP_PendingEntity::Unk00> pendingEntity;
+        func(this, &pendingEntity, acSettings, acEntityPath);
+
+        RED4ext::ent::EntityID entityID;
+        entityID.hash = pendingEntity ? pendingEntity->entityID.hash : 0;
+        return entityID;
+    }
+
+    // This is used by photomode
+    // Extracts entity path from a TDB record, spawns and assigns the record
+    RED4ext::ent::EntityID SpawnRecord(const RED4ext::TweakDBID acRecordDBID, const TEMP_SpawnSettings& acSettings)
+    {
+        // we can code this ourselves using RED4ext::TweakDB
+        // get the record and look for .entityTemplatePath or something
+        // really need to reduce the amount of patterns
+
+        // REDSmartPtr<TEMP_PendingEntity::Unk00> TEMP_Spawner::func(this, TEMP_SpawnSettings&, RED4ext::TweakDBID&)
+        using TFunc = void (*)(TEMP_Spawner*, REDSmartPtr<TEMP_PendingEntity::Unk00>*, const TEMP_SpawnSettings&, const RED4ext::TweakDBID&);
+        static PatternCall<TFunc> func("E9 29 01 00 00 49 8B D6 48 8D 4D E8", -0x2F);
+
+        REDSmartPtr<TEMP_PendingEntity::Unk00> pendingEntity;
+        func(this, &pendingEntity, acSettings, acRecordDBID);
+
+        RED4ext::ent::EntityID entityID;
+        entityID.hash = pendingEntity ? pendingEntity->entityID.hash : 0;
+        return entityID;
+    }
+
+    void Despawn(RED4ext::Handle<RED4ext::IScriptable> aEntity)
+    {
+        using TFunc = void(*)(TEMP_Spawner*, RED4ext::IScriptable*);
+        static PatternCall<TFunc> func("40 55 53 56 57 41 55 41 56 41 57 48 8B EC 48 83 EC 50");
+        func(this, aEntity.GetPtr());
+    }
+};
+RED4EXT_ASSERT_OFFSET(TEMP_Spawner, unk48, 0x48);
+RED4EXT_ASSERT_SIZE(TEMP_Spawner, 0x68);
+
+#pragma endregion
 
 void GetParameter(RED4ext::CStackFrame* apFrame, void* apInstance)
 {
@@ -10,117 +334,13 @@ void GetParameter(RED4ext::CStackFrame* apFrame, void* apInstance)
     RED4ext::OpcodeHandlers::Run(opcode, apFrame->context, apFrame, apInstance, nullptr);
 }
 
-#pragma region WorldFunctionalTests
-
-void WorldFunctionalTests_SpawnEntity(RED4ext::IScriptable* apContext, RED4ext::CStackFrame* apFrame,
-                                      RED4ext::ent::EntityID* apOut, int64_t a4)
+void CreateSingleton(RED4ext::Handle<RED4ext::IScriptable> apClassInstance)
 {
-    struct UnkStuff
-    {
-        struct UnkStuff2
-        {
-            uint8_t unk[0x110];
-            RED4ext::ent::EntityID entityID;
-        };
-
-        UnkStuff2* unk00;
-        uint64_t unk08;
-        uint64_t unk18;
-        uint64_t unk20;
-        uint64_t unk28;
-    };
-    RED4EXT_ASSERT_SIZE(UnkStuff, 5 * 8);
-    RED4EXT_ASSERT_OFFSET(UnkStuff::UnkStuff2, entityID, 0x110);
-
-    struct FunctionalTestsGameSystem
-    {
-        uint8_t unk[0xC8];
-        RED4ext::DynArray<RED4ext::Handle<RED4ext::IScriptable>> spawnedEntities;
-        RED4ext::DynArray<UnkStuff> pendingEntities;
-    };
-    RED4EXT_ASSERT_OFFSET(FunctionalTestsGameSystem, spawnedEntities, 0xC8);
-    RED4EXT_ASSERT_OFFSET(FunctionalTestsGameSystem, pendingEntities, 0xD8);
-
-    RED4ext::CString entityPath;
-    RED4ext::WorldTransform worldTransform;
-    RED4ext::CString unknown;
-
-    GetParameter(apFrame, &entityPath);
-    GetParameter(apFrame, &worldTransform);
-    GetParameter(apFrame, &unknown);
-    apFrame->code++; // skip ParamEnd
-
     auto* pRTTI = RED4ext::CRTTISystem::Get();
-    auto* pGameInstance = RED4ext::CGameEngine::Get()->framework->gameInstance;
-    auto* pFunctionalType = pRTTI->GetType("FunctionalTestsGameSystem");
-    auto* pFunctionalSystem = reinterpret_cast<FunctionalTestsGameSystem*>(pGameInstance->GetInstance(pFunctionalType));
-    uint32_t oldSize = pFunctionalSystem->pendingEntities.size;
-
-    RED4ext::ExecuteFunction("WorldFunctionalTests", "Internal_SpawnEntity", nullptr, entityPath, worldTransform,
-                             unknown);
-
-    // if any entity was spawned
-    uint32_t newSize = pFunctionalSystem->pendingEntities.size;
-    if (oldSize != newSize)
-    {
-        auto& pending = pFunctionalSystem->pendingEntities[newSize - 1];
-        *apOut = pending.unk00->entityID;
-    }
-}
-
-void WorldFunctionalTests_DespawnEntity(RED4ext::IScriptable* apContext, RED4ext::CStackFrame* apFrame, void* apOut,
-                                        int64_t a4)
-{
-    RED4ext::Handle<RED4ext::IScriptable> entity;
-
-    GetParameter(apFrame, &entity);
-    apFrame->code++; // skip ParamEnd
-
-    RED4ext::ExecuteFunction("WorldFunctionalTests", "Internal_DespawnEntity", nullptr, entity);
-}
-
-#pragma endregion
-
-void RTTIExtender::CreateSingleton(RED4ext::CName aTypeName)
-{
-    struct IUpdatableSystem : RED4ext::IScriptable
-    {
-        virtual void sub_110(uint64_t) = 0; // probably Update
-    };
-
-    struct gameIGameSystem : IUpdatableSystem
-    {
-        RED4ext::GameInstance* gameInstance;
-
-        virtual void sub_118() = 0;
-        virtual void sub_120() = 0;
-        virtual void sub_128() = 0;
-        virtual void sub_130() = 0;
-        virtual void sub_138() = 0;
-        virtual void sub_140() = 0;
-        virtual void sub_148() = 0;
-        virtual void sub_150() = 0;
-        virtual void sub_158() = 0;
-        virtual void sub_160() = 0;
-        virtual void sub_168() = 0;
-        virtual void sub_170() = 0;
-        virtual void sub_178() = 0;
-        virtual void sub_180() = 0;
-        virtual void sub_188() = 0;
-        virtual void sub_190() = 0;
-        virtual void OnInitializeAsync(void*) = 0;   // 198
-        virtual void OnUnInitializeAsync(void*) = 0; // 1A0
-    };
-    RED4EXT_ASSERT_OFFSET(gameIGameSystem, gameInstance, 0x40);
-
-    auto* pRTTI = RED4ext::CRTTISystem::Get();
-    auto* pType = reinterpret_cast<RED4ext::CClass*>(pRTTI->GetType(aTypeName));
+    auto* pType = reinterpret_cast<RED4ext::CClass*>(apClassInstance->GetNativeType());
     auto* pGameInstance = RED4ext::CGameEngine::Get()->framework->gameInstance;
     if (pGameInstance->GetInstance(pType) != nullptr)
         return; // already init
-
-    auto* pClassInstance = pType->AllocInstance();
-    RED4ext::Handle<RED4ext::IScriptable> handle(pClassInstance);
 
     auto* pGameSystemType = pRTTI->GetType("gameIGameSystem");
     if (pType->IsA(pGameSystemType))
@@ -149,34 +369,268 @@ void RTTIExtender::CreateSingleton(RED4ext::CName aTypeName)
                 uint32_t unk24 = 0;
 
             } systemInitParams;
-            static_assert(sizeof(systemInitParams) == 40);
+            RED4EXT_ASSERT_SIZE(systemInitParams, 40);
 
-            auto* pGameSystem = reinterpret_cast<gameIGameSystem*>(pClassInstance);
+            auto* pGameSystem = reinterpret_cast<gameIGameSystem*>(apClassInstance.GetPtr());
             pGameSystem->gameInstance = pGameInstance;
-            pGameSystem->OnInitializeAsync(&systemInitParams);
+            pGameSystem->OnSystemInitializeAsync(&systemInitParams);
         }
 
-        auto* pParentType = reinterpret_cast<RED4ext::CClass*>(pClassInstance->GetParentType());
-        pGameInstance->unk08.Insert(pParentType, handle);
-        pGameInstance->unk38.PushBack(handle);
+        auto* pParentType = reinterpret_cast<RED4ext::CClass*>(apClassInstance->GetParentType());
+        pGameInstance->unk08.Insert(pParentType, apClassInstance);
+        pGameInstance->unk38.PushBack(apClassInstance);
 
         pParentType = pParentType->parent;
         auto* pReplicatedGameSystemType = pRTTI->GetType("gameIReplicatedGameSystem");
         while (pParentType && pParentType != pGameSystemType && pParentType != pReplicatedGameSystemType)
         {
-            // pGameInstance->unk48.Insert(pParentType, pType);
-            pGameInstance->unk40.Insert((uintptr_t)pParentType, pType);
+            pGameInstance->unk48.Insert(pParentType, pType);
             pParentType = pParentType->parent;
         }
     }
     else
     {
-        auto* pParentType = pClassInstance->GetParentType();
-        pGameInstance->unk08.Insert(pParentType, handle);
-        // pGameInstance->unk48.Insert(pParentType, pType);
-        pGameInstance->unk40.Insert((uintptr_t)pParentType, pType);
+        auto* pParentType = apClassInstance->GetParentType();
+        pGameInstance->unk08.Insert(pParentType, apClassInstance);
+        pGameInstance->unk48.Insert(pParentType, pType);
     }
 }
+
+void CreateSingleton(const RED4ext::CName acTypeName)
+{
+    auto* pRTTI = RED4ext::CRTTISystem::Get();
+    auto* pType = pRTTI->GetClass(acTypeName);
+    auto* pGameInstance = RED4ext::CGameEngine::Get()->framework->gameInstance;
+    if (pGameInstance->GetInstance(pType) != nullptr)
+        return; // already init
+
+    auto* pClassInstance = pType->AllocInstance();
+    RED4ext::Handle<RED4ext::IScriptable> handle(pClassInstance);
+
+    CreateSingleton(handle);
+}
+
+#pragma region WorldFunctionalTests
+
+// This is kept for backward compatibility.
+// Use exEntitySpawner
+
+void WorldFunctionalTests_SpawnEntity(RED4ext::IScriptable* apContext, RED4ext::CStackFrame* apFrame,
+                                      RED4ext::ent::EntityID* apOut, int64_t a4)
+{
+    struct FunctionalTestsGameSystem
+    {
+        uint8_t unk[0xB8];
+        TEMP_Spawner spawner;
+    };
+
+    RED4ext::CString entityPath;
+    RED4ext::WorldTransform worldTransform;
+    RED4ext::CString unknown;
+
+    GetParameter(apFrame, &entityPath);
+    GetParameter(apFrame, &worldTransform);
+    GetParameter(apFrame, &unknown);
+    apFrame->code++; // skip ParamEnd
+
+    auto* pRTTI = RED4ext::CRTTISystem::Get();
+    auto* pGameInstance = RED4ext::CGameEngine::Get()->framework->gameInstance;
+    auto* pFunctionalType = pRTTI->GetType("FunctionalTestsGameSystem");
+    auto* pFunctionalSystem = reinterpret_cast<FunctionalTestsGameSystem*>(pGameInstance->GetInstance(pFunctionalType));
+    uint32_t oldSize = pFunctionalSystem->spawner.pendingEntities.size;
+
+    RED4ext::ExecuteFunction("WorldFunctionalTests", "Internal_SpawnEntity", nullptr, entityPath, worldTransform,
+        unknown);
+
+    // if any entity was spawned
+    uint32_t newSize = pFunctionalSystem->spawner.pendingEntities.size;
+    if (oldSize != newSize)
+    {
+        auto& pending = pFunctionalSystem->spawner.pendingEntities[newSize - 1];
+        *apOut = pending.unk00->entityID;
+    }
+}
+
+void WorldFunctionalTests_DespawnEntity(RED4ext::IScriptable* apContext, RED4ext::CStackFrame* apFrame, void* apOut,
+                                        int64_t a4)
+{
+    RED4ext::Handle<RED4ext::IScriptable> entity;
+
+    GetParameter(apFrame, &entity);
+    apFrame->code++; // skip ParamEnd
+
+    RED4ext::ExecuteFunction("WorldFunctionalTests", "Internal_DespawnEntity", nullptr, entity);
+}
+
+#pragma endregion
+
+#pragma region EntitySpawner
+
+struct exEntitySpawnerSystem : gameIGameSystem
+{
+    constexpr static char NATIVE_TYPE_STR[] = "exEntitySpawner";
+    constexpr static char PARENT_TYPE_STR[] = "gameIGameSystem";
+    constexpr static RED4ext::CName NATIVE_TYPE = NATIVE_TYPE_STR;
+    constexpr static RED4ext::CName PARENT_TYPE = PARENT_TYPE_STR;
+
+    static exEntitySpawnerSystem* Singleton;
+    static TEMP_Spawner exEntitySpawner_Spawner;
+
+private:
+    static exEntitySpawnerSystem* CreateNew(void* apAddress)
+    {
+        constexpr int32_t VftableSize = 0x1A8;
+        static uintptr_t* ClonedVftable = nullptr;
+
+        gameIGameSystem::CallConstructor(apAddress);
+
+        if (ClonedVftable == nullptr)
+        {
+            ClonedVftable = reinterpret_cast<uintptr_t*>(malloc(VftableSize));
+            memcpy(ClonedVftable, *reinterpret_cast<uintptr_t**>(apAddress), VftableSize);
+
+            ClonedVftable[0] = (uintptr_t)&HOOK_GetNativeType;
+            ClonedVftable[0x118 / 8] = (uintptr_t)&HOOK_OnInitialize;
+            ClonedVftable[0x120 / 8] = (uintptr_t)&HOOK_OnShutdown;
+        }
+
+        // overwrite vftable with our clone
+        *(uintptr_t**)apAddress = ClonedVftable;
+
+        return reinterpret_cast<exEntitySpawnerSystem*>(apAddress);
+    }
+
+    static RED4ext::IRTTIType* HOOK_GetNativeType(exEntitySpawnerSystem* apThis)
+    {
+        auto* pRTTI = RED4ext::CRTTISystem::Get();
+        return pRTTI->GetClass(NATIVE_TYPE_STR);
+    }
+
+    static void HOOK_OnInitialize(exEntitySpawnerSystem* apThis)
+    {
+        exEntitySpawner_Spawner.Initialize(apThis->gameInstance);
+    }
+
+    static void HOOK_OnShutdown(exEntitySpawnerSystem* apThis)
+    {
+        exEntitySpawner_Spawner.UnInitialize();
+    }
+
+    static void SpawnCallback(TEMP_PendingEntity::Unk00& aUnk)
+    {
+        using TFunc = void(*)(RED4ext::IScriptable*, RED4ext::ent::Entity*);
+        static PatternCall<TFunc> func("41 57 48 83 EC 70 48 8B E9 4C 8B FA", -0x0E);
+
+        struct GameInstance_78_Unk
+        {
+            uint8_t unk00[0xD0];
+            RED4ext::IScriptable* worldRuntimeEntityRegistry;
+        };
+
+        struct GameInstance_78
+        {
+            GameInstance_78_Unk* unk00;
+        };
+
+        auto* pGameInstance = Singleton->gameInstance;
+        func(reinterpret_cast<GameInstance_78*>(pGameInstance->unk78)->unk00->worldRuntimeEntityRegistry, aUnk.entity);
+    }
+
+public:
+    static void InitializeSingleton()
+    {
+        // should only be called once
+        assert(Singleton == nullptr);
+        auto* pRTTI = RED4ext::CRTTISystem::Get();
+
+        RED4ext::CClass::Flags classFlags{};
+        classFlags.isNative = 1;
+        RED4ext::CNamePool::Add(NATIVE_TYPE_STR);
+        pRTTI->RegisterScriptedType(NATIVE_TYPE, classFlags, pRTTI->GetClass(PARENT_TYPE));
+
+        auto* pAllocator = pRTTI->GetClass(PARENT_TYPE)->GetAllocator();
+        Singleton = CreateNew(pAllocator->AllocAligned(sizeof(exEntitySpawnerSystem), alignof(exEntitySpawnerSystem)).memory);
+        CreateSingleton(RED4ext::Handle<RED4ext::IScriptable>(Singleton));
+    }
+
+    static void Spawn(RED4ext::IScriptable* apContext, RED4ext::CStackFrame* apFrame, RED4ext::ent::EntityID* apOut,
+                      int64_t a4)
+    {
+        RED4ext::CName entityPath; // <- raRef
+        RED4ext::WorldTransform worldTransform;
+        RED4ext::CName appearance = "default";
+        RED4ext::TweakDBID recordDBID = 0;
+
+        GetParameter(apFrame, &entityPath);
+        GetParameter(apFrame, &worldTransform);
+        GetParameter(apFrame, &appearance);
+        GetParameter(apFrame, &recordDBID);
+        apFrame->code++; // skip ParamEnd
+
+        if (appearance == RED4ext::CName(""))
+        {
+            // doesn't work for vehicles
+            appearance = "default";
+        }
+
+        TEMP_SpawnSettings settings;
+        settings.appearance = appearance;
+        settings.callback = SpawnCallback;
+        settings.SetRecordID(recordDBID);
+        settings.SetTransform(worldTransform);
+
+        auto entityID = exEntitySpawner_Spawner.Spawn(entityPath, settings);
+
+        if (apOut != nullptr)
+        {
+            *apOut = entityID;
+        }
+    }
+
+    static void SpawnRecord(RED4ext::IScriptable* apContext, RED4ext::CStackFrame* apFrame,
+                            RED4ext::ent::EntityID* apOut, int64_t a4)
+    {
+        RED4ext::TweakDBID recordDBID = 0;
+        RED4ext::WorldTransform worldTransform;
+        RED4ext::CName appearance = "default";
+        GetParameter(apFrame, &recordDBID);
+        GetParameter(apFrame, &worldTransform);
+        GetParameter(apFrame, &appearance);
+        apFrame->code++; // skip ParamEnd
+
+        if (appearance == RED4ext::CName(""))
+        {
+            // doesn't work for vehicles
+            appearance = "default";
+        }
+
+        TEMP_SpawnSettings settings;
+        settings.appearance = appearance;
+        settings.callback = SpawnCallback;
+        settings.SetTransform(worldTransform);
+
+        auto entityID = exEntitySpawner_Spawner.SpawnRecord(recordDBID, settings);
+
+        if (apOut != nullptr)
+        {
+            *apOut = entityID;
+        }
+    }
+
+    static void Despawn(RED4ext::IScriptable* apContext, RED4ext::CStackFrame* apFrame, void* apOut, int64_t a4)
+    {
+        RED4ext::Handle<RED4ext::IScriptable> entity;
+
+        GetParameter(apFrame, &entity);
+        apFrame->code++; // skip ParamEnd
+
+        exEntitySpawner_Spawner.Despawn(entity);
+    }
+};
+exEntitySpawnerSystem* exEntitySpawnerSystem::Singleton = nullptr;
+TEMP_Spawner exEntitySpawnerSystem::exEntitySpawner_Spawner;
+
+#pragma endregion
 
 void RTTIExtender::AddFunctionalTests()
 {
@@ -184,7 +638,7 @@ void RTTIExtender::AddFunctionalTests()
     CreateSingleton("FunctionalTestsGameSystem");
 
     auto* pRTTI = RED4ext::CRTTISystem::Get();
-    auto* pClass = reinterpret_cast<RED4ext::CClass*>(pRTTI->GetType("WorldFunctionalTests"));
+    auto* pClass = pRTTI->GetClass("WorldFunctionalTests");
     if (pClass != nullptr)
     {
         {
@@ -214,7 +668,6 @@ void RTTIExtender::AddFunctionalTests()
 
             RED4ext::CBaseFunction::Flags flags{};
             flags.isNative = true;
-            flags.isStatic = true;
             pFunction = RED4ext::CClassStaticFunction::Create(pClass, "SpawnEntity", "SpawnEntity",
                                                               WorldFunctionalTests_SpawnEntity, flags);
             pFunction->AddParam("String", "entityPath");
@@ -233,7 +686,6 @@ void RTTIExtender::AddFunctionalTests()
 
             RED4ext::CBaseFunction::Flags flags{};
             flags.isNative = true;
-            flags.isStatic = true;
             pFunction = RED4ext::CClassStaticFunction::Create(pClass, "DespawnEntity", "DespawnEntity",
                                                               WorldFunctionalTests_DespawnEntity, flags);
             pFunction->AddParam("handle:entEntity", "entity");
@@ -242,7 +694,50 @@ void RTTIExtender::AddFunctionalTests()
     }
 }
 
+void RTTIExtender::AddEntitySpawner()
+{
+    exEntitySpawnerSystem::InitializeSingleton();
+
+    auto* pRTTI = RED4ext::CRTTISystem::Get();
+    auto* pClass = pRTTI->GetClass(exEntitySpawnerSystem::NATIVE_TYPE);
+    if (pClass)
+    {
+        RED4ext::CBaseFunction::Flags flags{};
+        flags.isNative = true;
+        RED4ext::CClassStaticFunction* pFunction;
+
+        // -------------
+
+        pFunction = RED4ext::CClassStaticFunction::Create(pClass, "Spawn", "Spawn",
+                                                          exEntitySpawnerSystem::Spawn, flags);
+        pFunction->AddParam("raRef:CResource", "entityPath");
+        pFunction->AddParam("WorldTransform", "worldTransform");
+        pFunction->AddParam("CName", "appearance", false, true);
+        pFunction->AddParam("TweakDBID", "recordID", false, true);
+        pFunction->SetReturnType("entEntityID");
+        pClass->RegisterFunction(pFunction);
+
+        // -------------
+
+        pFunction = RED4ext::CClassStaticFunction::Create(pClass, "SpawnRecord", "SpawnRecord",
+                                                          exEntitySpawnerSystem::SpawnRecord, flags);
+        pFunction->AddParam("TweakDBID", "recordID");
+        pFunction->AddParam("WorldTransform", "worldTransform");
+        pFunction->AddParam("CName", "appearance", false, true);
+        pFunction->SetReturnType("entEntityID");
+        pClass->RegisterFunction(pFunction);
+
+        // -------------
+
+        pFunction = RED4ext::CClassStaticFunction::Create(pClass, "Despawn", "Despawn",
+                                                          exEntitySpawnerSystem::Despawn, flags);
+        pFunction->AddParam("handle:entEntity", "entity");
+        pClass->RegisterFunction(pFunction);
+    }
+}
+
 void RTTIExtender::Initialize()
 {
-    AddFunctionalTests();
+    AddFunctionalTests(); // This is kept for backward compatibility with mods
+    AddEntitySpawner();
 }

--- a/src/reverse/RTTIExtender.cpp
+++ b/src/reverse/RTTIExtender.cpp
@@ -335,14 +335,6 @@ RED4EXT_ASSERT_SIZE(TEMP_Spawner, 0x68);
 
 #pragma endregion
 
-void GetParameter(RED4ext::CStackFrame* apFrame, void* apInstance)
-{
-    apFrame->unk30 = 0;
-    apFrame->unk38 = 0;
-    const auto opcode = *(apFrame->code++);
-    RED4ext::OpcodeHandlers::Run(opcode, apFrame->context, apFrame, apInstance, nullptr);
-}
-
 void CreateSingleton(RED4ext::Handle<RED4ext::IScriptable> apClassInstance)
 {
     auto* pRTTI = RED4ext::CRTTISystem::Get();
@@ -437,9 +429,9 @@ void WorldFunctionalTests_SpawnEntity(RED4ext::IScriptable* apContext, RED4ext::
     RED4ext::WorldTransform worldTransform;
     RED4ext::CString unknown;
 
-    GetParameter(apFrame, &entityPath);
-    GetParameter(apFrame, &worldTransform);
-    GetParameter(apFrame, &unknown);
+    RED4ext::GetParameter(apFrame, &entityPath);
+    RED4ext::GetParameter(apFrame, &worldTransform);
+    RED4ext::GetParameter(apFrame, &unknown);
     apFrame->code++; // skip ParamEnd
 
     auto* pRTTI = RED4ext::CRTTISystem::Get();
@@ -465,7 +457,7 @@ void WorldFunctionalTests_DespawnEntity(RED4ext::IScriptable* apContext, RED4ext
 {
     RED4ext::Handle<RED4ext::IScriptable> entity;
 
-    GetParameter(apFrame, &entity);
+    RED4ext::GetParameter(apFrame, &entity);
     apFrame->code++; // skip ParamEnd
 
     RED4ext::ExecuteFunction("WorldFunctionalTests", "Internal_DespawnEntity", nullptr, entity);
@@ -570,10 +562,10 @@ public:
         RED4ext::CName appearance = "default";
         RED4ext::TweakDBID recordDBID = 0;
 
-        GetParameter(apFrame, &entityPath);
-        GetParameter(apFrame, &worldTransform);
-        GetParameter(apFrame, &appearance);
-        GetParameter(apFrame, &recordDBID);
+        RED4ext::GetParameter(apFrame, &entityPath);
+        RED4ext::GetParameter(apFrame, &worldTransform);
+        RED4ext::GetParameter(apFrame, &appearance);
+        RED4ext::GetParameter(apFrame, &recordDBID);
         apFrame->code++; // skip ParamEnd
 
         if (appearance == RED4ext::CName(""))
@@ -602,9 +594,9 @@ public:
         RED4ext::TweakDBID recordDBID = 0;
         RED4ext::WorldTransform worldTransform;
         RED4ext::CName appearance = "default";
-        GetParameter(apFrame, &recordDBID);
-        GetParameter(apFrame, &worldTransform);
-        GetParameter(apFrame, &appearance);
+        RED4ext::GetParameter(apFrame, &recordDBID);
+        RED4ext::GetParameter(apFrame, &worldTransform);
+        RED4ext::GetParameter(apFrame, &appearance);
         apFrame->code++; // skip ParamEnd
 
         if (appearance == RED4ext::CName(""))
@@ -630,7 +622,7 @@ public:
     {
         RED4ext::Handle<RED4ext::IScriptable> entity;
 
-        GetParameter(apFrame, &entity);
+        RED4ext::GetParameter(apFrame, &entity);
         apFrame->code++; // skip ParamEnd
 
         exEntitySpawner_Spawner.Despawn(entity);

--- a/src/reverse/RTTIExtender.h
+++ b/src/reverse/RTTIExtender.h
@@ -3,8 +3,8 @@
 
 class RTTIExtender
 {
-    static void CreateSingleton(RED4ext::CName aTypeName);
     static void AddFunctionalTests();
+    static void AddEntitySpawner();
 
 public:
     static void Initialize();

--- a/src/reverse/ResourceAsyncReference.cpp
+++ b/src/reverse/ResourceAsyncReference.cpp
@@ -11,6 +11,17 @@ ResourceAsyncReference::ResourceAsyncReference(const TiltedPhoques::Locked<sol::
 {
 }
 
+uint64_t ResourceAsyncReference::Hash(const std::string& aPath)
+{
+    // Should probably be moved to RED4ext.SDK after fixing RED4ext::RaRef
+    // Needs normalization
+    // 1) all lower case
+    // 2) / becomes \
+    // 3) /\/\\ becomes \
+
+    return RED4ext::FNV1a(aPath.c_str());
+}
+
 RED4ext::ScriptInstance ResourceAsyncReference::GetHandle()
 {
     return &m_reference;

--- a/src/reverse/ResourceAsyncReference.h
+++ b/src/reverse/ResourceAsyncReference.h
@@ -7,6 +7,8 @@ struct ResourceAsyncReference : ClassType
     ResourceAsyncReference(const TiltedPhoques::Locked<sol::state, std::recursive_mutex>& aView, 
                            RED4ext::IRTTIType* apType, RED4ext::ResourceAsyncReference<void>* apReference);
 
+    static uint64_t Hash(const std::string& aPath);
+
     virtual RED4ext::ScriptInstance GetHandle();
 
     uint64_t GetHash() const;

--- a/src/reverse/Type.cpp
+++ b/src/reverse/Type.cpp
@@ -103,7 +103,8 @@ std::string Type::FunctionDescriptor(RED4ext::CBaseFunction* apFunc, bool aWithH
             continue;
         }
         param->type->GetName(typeName);
-        params.push_back(param->name.ToString() + std::string(": ") + typeName.ToString());
+        params.push_back(fmt::format("{}{}: {}", param->flags.isOptional ? "[opt] " : "",
+                                    param->name.ToString(), typeName.ToString()));
     }
 
     for (auto i = 0u; i < params.size(); ++i)

--- a/src/scripting/Scripting.cpp
+++ b/src/scripting/Scripting.cpp
@@ -833,7 +833,7 @@ RED4ext::CStackType Scripting::ToRED(sol::object aObject, RED4ext::IRTTIType* ap
                 }
                 else if (aObject.get_type() == sol::type::string)
                 {
-                    hash = RED4ext::FNV1a(aObject.as<std::string>().c_str());
+                    hash = ResourceAsyncReference::Hash(aObject.as<std::string>());
                 }
                 else if (aObject.is<CName>())
                 {


### PR DESCRIPTION
![exEntitySpawner](https://user-images.githubusercontent.com/26506177/126839985-dd249b72-fbe7-472c-a03b-dd094cd38ff0.png)

```lua

spawnPosition = Game.GetPlayer():GetWorldTransform()

-- [Simple]
-- Spawn 'Character.Judy' just like prevention system
-- Optionally set appearance to 'judy_diving_suit'
judyEntityID = exEntitySpawner.SpawnRecord('Character.Judy', spawnPosition)
judyEntityID = exEntitySpawner.SpawnRecord('Character.Judy', spawnPosition, 'judy_diving_suit')

-- [Advanced]
-- Spawn base\quest\secondary_characters\judy.ent
-- Optionally set appearance to 'default'
-- Optionally set TweakDB record to 'Character.Judy' (VO/Name/Equipment/etc)
judyEntityID = exEntitySpawner.Spawn([[base\quest\secondary_characters\judy.ent]], spawnPosition)
judyEntityID = exEntitySpawner.Spawn([[base\quest\secondary_characters\judy.ent]], spawnPosition, 'default')
judyEntityID = exEntitySpawner.Spawn([[base\quest\secondary_characters\judy.ent]], spawnPosition, 'default', 'Character.Judy')

-- Some time later...
-- entities are not spawned instantly, FindEntityByID may return nil
judy = Game.FindEntityByID(judyEntityID)

exEntitySpawner.Despawn(judy)
```
You can't mount spawned vehicles for some reasons.