### PR TITLE
Fix nested RTTI calls and onInit handler

### DIFF
--- a/src/reverse/RTTIHelper.cpp
+++ b/src/reverse/RTTIHelper.cpp
@@ -532,12 +532,19 @@ sol::variadic_results RTTIHelper::ExecuteFunction(RED4ext::CBaseFunction* apFunc
         return {};
     }
 
-    static thread_local TiltedPhoques::ScratchAllocator s_scratchMemory(1 << 13);
+    static thread_local TiltedPhoques::ScratchAllocator s_scratchMemory(1 << 14);
+    static thread_local uint32_t s_callDepth = 0u;
+
+    ++s_callDepth;
+
     struct ResetAllocator
     {
         ~ResetAllocator()
         {
-            s_scratchMemory.Reset();
+            --s_callDepth;
+
+            if (s_callDepth == 0u)
+                s_scratchMemory.Reset();
         }
     };
     ResetAllocator ___allocatorReset;

--- a/src/scripting/LuaVM.cpp
+++ b/src/scripting/LuaVM.cpp
@@ -23,7 +23,12 @@ bool LuaVM::ExecuteLua(const std::string& acCommand)
 void LuaVM::Update(float aDeltaTime)
 {
     if (!m_initialized)
+    {
+        if (m_logCount.load(std::memory_order_relaxed) > 0)
+            PostInitialize();
+
         return;
+    }
 
     m_scripting.TriggerOnUpdate(aDeltaTime);
 

--- a/src/scripting/LuaVM_Hooks.cpp
+++ b/src/scripting/LuaVM_Hooks.cpp
@@ -326,22 +326,24 @@ void LuaVM::Hook(Options& aOptions)
         }
     }
 
-    {
-        const mem::pattern cPattern("48 89 5C 24 18 89 54 24 10 57 48 83 EC 20 48 8B D9 C7");
-        const mem::default_scanner cScanner(cPattern);
-        uint8_t* pLocation = cScanner(gameImage.TextRegion).as<uint8_t*>();
-
-        if (pLocation)
-        {
-            if (MH_CreateHook(pLocation, &HookSetLoadingState, reinterpret_cast<void**>(&m_realSetLoadingState)) != MH_OK
-             || MH_EnableHook(pLocation) != MH_OK)
-                spdlog::error("Could not hook SetLoadingState function!");
-            else
-            {
-                spdlog::info("SetLoadingState function hook complete!");
-            }
-        }
-    }
+    // Disable SetLoadingState hook temporarily and get back to log count workaround
+    // as it introduces major breaking change for onInit handler.
+    //{
+    //    const mem::pattern cPattern("48 89 5C 24 18 89 54 24 10 57 48 83 EC 20 48 8B D9 C7");
+    //    const mem::default_scanner cScanner(cPattern);
+    //    uint8_t* pLocation = cScanner(gameImage.TextRegion).as<uint8_t*>();
+    //
+    //    if (pLocation)
+    //    {
+    //        if (MH_CreateHook(pLocation, &HookSetLoadingState, reinterpret_cast<void**>(&m_realSetLoadingState)) != MH_OK
+    //         || MH_EnableHook(pLocation) != MH_OK)
+    //            spdlog::error("Could not hook SetLoadingState function!");
+    //        else
+    //        {
+    //            spdlog::info("SetLoadingState function hook complete!");
+    //        }
+    //    }
+    //}
 
     
 }


### PR DESCRIPTION
1. Fix when `s_scratchMemory.Reset()` is called for nested RTTI calls (can happen when overridden function is called by mod).
2. Bring back log count workaround for `onInit` handler as relying entirely on `SetLoadingState` introduces major breaking changes (player entity and some systems are not yet initialized).