### PR TITLE
Split update and draw handlers to RunningState and D3D12 hooks

### DIFF
--- a/src/scripting/LuaVM.cpp
+++ b/src/scripting/LuaVM.cpp
@@ -31,9 +31,14 @@ void LuaVM::Update(float aDeltaTime)
     }
 
     m_scripting.TriggerOnUpdate(aDeltaTime);
+}
 
-    if (!m_drawBlocked)
-        m_scripting.TriggerOnDraw();
+void LuaVM::Draw()
+{
+    if (!m_initialized || m_drawBlocked)
+        return;
+
+    m_scripting.TriggerOnDraw();
 }
 
 void LuaVM::ReloadAllMods()

--- a/src/scripting/LuaVM.h
+++ b/src/scripting/LuaVM.h
@@ -33,6 +33,7 @@ struct LuaVM
     bool ExecuteLua(const std::string& acCommand);
         
     void Update(float aDeltaTime);
+    void Draw();
     void ReloadAllMods();
 
     void OnOverlayOpen() const;

--- a/src/scripting/LuaVM_Hooks.cpp
+++ b/src/scripting/LuaVM_Hooks.cpp
@@ -84,10 +84,13 @@ LuaVM::LuaVM(Paths& aPaths, VKBindings& aBindings, D3D12& aD3D12, Options& aOpti
     , m_lastframe(std::chrono::high_resolution_clock::now())
 {
     Hook(aOptions);
+
+    m_connectUpdate = aD3D12.OnUpdate.Connect([this]() { Draw(); });
 }
 
 LuaVM::~LuaVM()
 {
+    m_d3d12.OnUpdate.Disconnect(m_connectUpdate);
 }
 
 TDBID* LuaVM::HookTDBIDCtor(TDBID* apThis, const char* acpName)


### PR DESCRIPTION
Calling ImGui from the `RunningState` hook causes random crashes. So this commit moves the `onDraw` handler back to the D3D12 hook, keeping the `onUpdate` in a new `RunningState` hook. 