### PR TITLE
Fix "disable AA" and "disable async compute" patches

### DIFF
--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -12,7 +12,6 @@
 void EnableDebugPatch(const Image* apImage);
 void StartScreenPatch(const Image* apImage);
 void RemovePedsPatch(const Image* apImage);
-void OptionsPatch(const Image* apImage);
 void OptionsInitHook(const Image* apImage);
 void DisableIntroMoviesPatch(const Image* apImage);
 void DisableVignettePatch(const Image* apImage);
@@ -48,9 +47,6 @@ static void Initialize()
 
         if (options.PatchRemovePedestrians)
             RemovePedsPatch(&options.GameImage);
-
-        if (options.PatchAsyncCompute || options.PatchAntialiasing)
-            OptionsPatch(&options.GameImage);
 
         if (options.PatchDisableIntroMovies)
             DisableIntroMoviesPatch(&options.GameImage);


### PR DESCRIPTION
As noted in #542, these two patches have been broken since v1.2.

After obtaining an old version of the game for comparison, I found the cause of the breakage: in v1.0x and v1.1x, `GameOptionInit()` used to be called twice for each setting, with the second call eventually ending up in `GameOption::Get()` (hooked by CET to redirect to `HookGameOptionGetBoolean()`). This is no longer the case, and `GameOptionInit()` is now only called once per setting, with the default value already provided.

This means that hooking `GameOption::Get()` (which was already failing anyway due to an outdated signature scan) no longer does anything useful, because the function is never called. Instead I have moved these settings to `HookGameOptionInit()`, and added explicit `SetBool()` calls for the settings that match (and if the relevant option is enabled obviously).

NB: there is no need to revert the settings modified here to the default values if the patches are disabled again later in `config.json`, because, being hidden settings, they are not persisted to disk by the game and are always initialized to the same values.

This PR should also fix the `DumpGameOptions` debug option, which relied on the fact that `GameOptionInit()` would be called a second time for the same setting.