### PR TITLE
Register global OnAction handler, override function by full name 

### DIFF
--- a/src/reverse/RTTIHelper.h
+++ b/src/reverse/RTTIHelper.h
@@ -30,6 +30,11 @@ struct RTTIHelper
     sol::object GetProperty(RED4ext::CClass* apClass, RED4ext::ScriptInstance apHandle, const std::string& acPropName, bool& aSuccess) const;
     void SetProperty(RED4ext::CClass* apClass, RED4ext::ScriptInstance apHandle, const std::string& acPropName, sol::object aPropValue, bool& aSuccess) const;
 
+    RED4ext::CBaseFunction* FindFunction(const uint64_t acFullNameHash) const;
+    RED4ext::CBaseFunction* FindFunction(RED4ext::CClass* apClass, const uint64_t acFullNameHash) const;
+    std::map<uint64_t, RED4ext::CBaseFunction*> FindFunctions(const uint64_t acShortNameHash) const;
+    std::map<uint64_t, RED4ext::CBaseFunction*> FindFunctions(RED4ext::CClass* apClass, const uint64_t acShortNameHash, bool aIsMember) const;
+    
     static void Initialize(const LockableState& acLua);
     static void Shutdown();
     static RTTIHelper& Get();
@@ -46,11 +51,6 @@ private:
     void AddResolvedFunction(const uint64_t acFuncHash, sol::function& acFunc);
     void AddResolvedFunction(const uint64_t acClassHash, const uint64_t acFuncHash, sol::function& acFunc, bool aIsMember);
 
-    RED4ext::CBaseFunction* FindFunction(const uint64_t acFullNameHash) const;
-    RED4ext::CBaseFunction* FindFunction(RED4ext::CClass* apClass, const uint64_t acFullNameHash) const;
-    std::map<uint64_t, RED4ext::CBaseFunction*> FindFunctions(const uint64_t acShortNameHash) const;
-    std::map<uint64_t, RED4ext::CBaseFunction*> FindFunctions(RED4ext::CClass* apClass, const uint64_t acShortNameHash, bool aIsMember) const;
-    
     sol::function MakeInvokableFunction(RED4ext::CBaseFunction* apFunc);
     sol::function MakeInvokableOverload(std::map<uint64_t, RED4ext::CBaseFunction*> aOverloadedFuncs);
 

--- a/src/scripting/Scripting.cpp
+++ b/src/scripting/Scripting.cpp
@@ -472,6 +472,18 @@ void Scripting::PostInitialize()
 
 void Scripting::RegisterOverrides()
 {
+    auto lua = m_lua.Lock();
+    auto& luaVm = lua.Get();
+
+    luaVm["RegisterGlobalInputListener"] = [](StrongReference& aSelf, sol::this_environment aThisEnv) {
+        sol::protected_function unregisterInputListener = aSelf.Index("UnregisterInputListener", aThisEnv);
+        sol::protected_function registerInputListener = aSelf.Index("RegisterInputListener", aThisEnv);
+
+        unregisterInputListener(aSelf, aSelf);
+        registerInputListener(aSelf, aSelf);
+    };
+
+    m_override.Override("PlayerPuppet", "EnableUIBlackboardListener", "EnableUIBlackboardListener", false, luaVm["RegisterGlobalInputListener"], sol::nil, false);
     m_override.Override("PlayerPuppet", "OnDetach", "OnDetach", false, sol::nil, sol::nil, true);
     m_override.Override("QuestTrackerGameController", "OnUninitialize", "OnUninitialize", false, sol::nil, sol::nil, true);
 }


### PR DESCRIPTION
- Register global `PlayerPuppet.OnAction` handler as for pre patch 1.3.
- Override function by full name. Allows to observer / override all variants of overloaded function.