### PR TITLE
docs: Fix a few typos

### DIFF
--- a/src/lsqlite3/lsqlite3.c
+++ b/src/lsqlite3/lsqlite3.c
@@ -1088,7 +1088,7 @@ static void db_sql_finalize_function(sqlite3_context *context) {
 /*
 ** Register a normal function
 ** Params: db, function name, number arguments, [ callback | step, finalize], user data
-** Returns: true on sucess
+** Returns: true on success
 **
 ** Normal function:
 ** Params: context, params
@@ -1491,7 +1491,7 @@ static int db_rollback_hook(lua_State *L) {
 **
 ** callback function:
 ** Params: userdata
-** returns: 0 to return immediatly and return SQLITE_ABORT, non-zero to continue
+** returns: 0 to return immediately and return SQLITE_ABORT, non-zero to continue
 */
 static int db_progress_callback(void *user) {
     int result = 1; /* abort by default */
@@ -1675,7 +1675,7 @@ static int dbbu_finish(lua_State *L) {
 **
 ** callback function:
 ** Params: userdata, number of tries
-** returns: 0 to return immediatly and return SQLITE_BUSY, non-zero to try again
+** returns: 0 to return immediately and return SQLITE_BUSY, non-zero to try again
 */
 static int db_busy_callback(void *user, int tries) {
     int retry = 0; /* abort by default */

--- a/src/scripting/GameDump.cpp
+++ b/src/scripting/GameDump.cpp
@@ -54,7 +54,7 @@ void DumpVTablesTask::Run()
             }
 
             // Lets just leak memory from nested objects for now, this is broken on certain classes,
-            // havent determined why
+            // haven't determined why
             // type->Destroy(buffer);
         }
     };

--- a/src/scripting/LuaSandbox.cpp
+++ b/src/scripting/LuaSandbox.cpp
@@ -410,7 +410,7 @@ void LuaSandbox::InitializeIOForSandbox(Sandbox& aSandbox, const std::string& ac
         sbEnv["io"] = ioSB;
     }
 
-    // add in rename and remove repacements for os lib
+    // add in rename and remove replacements for os lib
     {
         const auto cOS = cGlobals["os"].get<sol::table>();
         sol::table osSB = sbEnv["os"].get<sol::table>();


### PR DESCRIPTION
There are small typos in:
- src/lsqlite3/lsqlite3.c
- src/scripting/GameDump.cpp
- src/scripting/LuaSandbox.cpp

Fixes:
- Should read `immediately` rather than `immediatly`.
- Should read `success` rather than `sucess`.
- Should read `replacements` rather than `repacements`.
- Should read `haven't` rather than `havent`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md