### PR TITLE
Fix function override in some cases, add support for namespaced types from redscript

### DIFF
--- a/src/reverse/RTTIMapper.cpp
+++ b/src/reverse/RTTIMapper.cpp
@@ -104,7 +104,10 @@ void RTTIMapper::RegisterDirectTypes(sol::state& aLuaState, sol::table& aLuaGlob
 
             MakeSolUsertypeImmutable(luaEnum, aLuaState);
 
-            aLuaGlobal[aTypeName.ToString()] = luaEnum;
+            std::string typeName = aTypeName.ToString();
+            SanitizeName(typeName);
+
+            aLuaGlobal[typeName] = luaEnum;
             break;
         }
         case RED4ext::ERTTIType::Class:
@@ -114,7 +117,10 @@ void RTTIMapper::RegisterDirectTypes(sol::state& aLuaState, sol::table& aLuaGlob
 
             MakeSolUsertypeImmutable(luaClass, aLuaState);
 
-            aLuaGlobal[aTypeName.ToString()] = luaClass;
+            std::string typeName = aTypeName.ToString();
+            SanitizeName(typeName);
+
+            aLuaGlobal[typeName] = luaClass;
             break;
         }
         }
@@ -179,4 +185,9 @@ void RTTIMapper::ExtendUsertype(const std::string acTypeName, sol::state& aLuaSt
 
     aLuaState["__" + acTypeName] = aLuaGlobal[acTypeName];
     aLuaGlobal[acTypeName] = aLuaState[acTypeName];
+}
+
+void RTTIMapper::SanitizeName(std::string& aName)
+{
+    std::replace(aName.begin(), aName.end(), '.', '_');
 }

--- a/src/reverse/RTTIMapper.h
+++ b/src/reverse/RTTIMapper.h
@@ -11,6 +11,8 @@ struct RTTIMapper
 
     void Register();
 
+    static void SanitizeName(std::string& aName);
+
 private:
 
     struct FuncFlags

--- a/src/scripting/FunctionOverride.cpp
+++ b/src/scripting/FunctionOverride.cpp
@@ -4,9 +4,11 @@
 #include "Scripting.h"
 #include <reverse/StrongReference.h>
 #include <reverse/RTTIHelper.h>
+#include <reverse/RTTILocator.h>
 
 
 static FunctionOverride* s_pOverride = nullptr;
+static RTTILocator s_inkGameControllerType("gameuiWidgetGameController");
 
 using TRunPureScriptFunction = bool (*)(RED4ext::CClassFunction* apFunction, RED4ext::CScriptStack*, void*);
 static TRunPureScriptFunction RealRunPureScriptFunction = nullptr;
@@ -472,7 +474,7 @@ void FunctionOverride::Override(const std::string& acTypeName, const std::string
 
         pEntry->Trampoline = pFunc;
         pEntry->pScripting = m_pScripting;
-        pEntry->CollectGarbage = aCollectGarbage;
+        pEntry->CollectGarbage = aCollectGarbage || pClassType->IsA(s_inkGameControllerType);
 
         // Swap the content of the real function with the one we just created
         std::array<char, sizeof(RED4ext::CClassFunction)> tmpBuffer;


### PR DESCRIPTION
1. Sanitize type names to be a valid Lua identifier.
This makes namespaced types added by redscript accessible in Lua. 

2. Force garbage collection for overridden functions of `inkGameController` and it's descendants.
In some cases, there seem to be issues with unreleased instances of `inkGameController` leading to crashes.
This was introduced when we started to properly wrap the context in `Handle<>`.
