### PR TITLE
Add support for nulls, CRUIDs, LocKeys, IsDefined() and EnumInt() helpers

### DIFF
--- a/src/reverse/BasicTypes.cpp
+++ b/src/reverse/BasicTypes.cpp
@@ -90,6 +90,26 @@ bool ItemID::operator==(const ItemID& acRhs) const noexcept
     return id == acRhs.id && rng_seed == acRhs.rng_seed;
 }
 
+std::string CRUID::ToString() const noexcept
+{
+    return fmt::format("CRUID({0}ull)", hash);
+}
+
+bool CRUID::operator==(const CRUID& acRhs) const noexcept
+{
+    return hash == acRhs.hash;
+}
+
+std::string gamedataLocKeyWrapper::ToString() const noexcept
+{
+    return fmt::format("LocKey({0}ull)", hash);
+}
+
+bool gamedataLocKeyWrapper::operator==(const gamedataLocKeyWrapper& acRhs) const noexcept
+{
+    return hash == acRhs.hash;
+}
+
 static const unsigned int crc32_table[] =
 {
     0x00000000, 0x77073096, 0xee0e612c, 0x990951ba, 0x076dc419, 0x706af48f,

--- a/src/reverse/BasicTypes.h
+++ b/src/reverse/BasicTypes.h
@@ -182,6 +182,32 @@ struct Variant
 
 static_assert(sizeof(Variant) == 0x18);
 
+struct CRUID
+{
+    CRUID(uint64_t aHash = 0) : hash(aHash) {}
+
+    uint64_t hash;
+
+    std::string ToString() const noexcept;
+
+	bool operator==(const CRUID& acRhs) const noexcept;
+};
+
+static_assert(sizeof(CRUID) == 0x8);
+
+struct gamedataLocKeyWrapper
+{
+    gamedataLocKeyWrapper(uint64_t aHash = 0) : hash(aHash) {}
+
+    uint64_t hash;
+
+    std::string ToString() const noexcept;
+
+	bool operator==(const gamedataLocKeyWrapper& acRhs) const noexcept;
+};
+
+static_assert(sizeof(gamedataLocKeyWrapper) == 0x8);
+
 struct alignas(8) ScriptGameInstance
 {
     RED4ext::GameInstance* gameInstance;

--- a/src/reverse/Converter.cpp
+++ b/src/reverse/Converter.cpp
@@ -22,6 +22,8 @@ auto s_metaVisitor = [](auto... args) {
     LuaRED<EulerAngles, "EulerAngles">(),
     LuaRED<ItemID, "gameItemID">(),
     LuaRED<Variant, "Variant">(),
+    LuaRED<CRUID, "CRUID">(),
+    LuaRED<gamedataLocKeyWrapper, "gamedataLocKeyWrapper">(),
     CNameConverter(),
     TweakDBIDConverter(),
     EnumConverter(),

--- a/src/reverse/Enum.h
+++ b/src/reverse/Enum.h
@@ -28,6 +28,8 @@ struct Enum
     const RED4ext::CEnum* GetType() const;
 
 protected:
+    friend struct Scripting;
+
     const RED4ext::CEnum*   m_cpType{ nullptr };
     uint64_t                m_value{ 0 };
 };

--- a/src/scripting/Scripting.cpp
+++ b/src/scripting/Scripting.cpp
@@ -181,6 +181,19 @@ void Scripting::PostInitialize()
 
     luaGlobal["Enum"] = luaVm["Enum"];
 
+    luaGlobal["EnumInt"] = [this](Enum& aEnum) -> sol::object
+    {
+        static RTTILocator s_uint64Type{RED4ext::FNV1a("Uint64")};
+
+        auto lockedState = m_lua.Lock();
+
+        RED4ext::CStackType stackType;
+        stackType.type = s_uint64Type;
+        stackType.value = &aEnum.m_value;
+
+        return Converter::ToLua(stackType, lockedState);
+    };
+
     luaVm.new_usertype<Vector3>("Vector3",
         sol::constructors<Vector3(float, float, float), Vector3(float, float), Vector3(float), Vector3(const Vector3&), Vector3()>(),
         sol::meta_function::to_string, &Vector3::ToString,

--- a/src/scripting/Scripting.cpp
+++ b/src/scripting/Scripting.cpp
@@ -740,11 +740,8 @@ RED4ext::CStackType Scripting::ToRED(sol::object aObject, RED4ext::CBaseRTTIType
                 auto* pType = static_cast<RED4ext::CClass*>(aObject.as<StrongReference*>()->m_pType);
                 if (pType && pType->IsA(pSubType))
                 {
-                    if (hasData)
-                        result.value = apAllocator->New<RED4ext::Handle<RED4ext::IScriptable>>(
-                            aObject.as<StrongReference>().m_strongHandle);
-                    else
-                        result.value = apAllocator->New<RED4ext::Handle<RED4ext::IScriptable>>();
+                    result.value = apAllocator->New<RED4ext::Handle<RED4ext::IScriptable>>(
+                        aObject.as<StrongReference>().m_strongHandle);
                 }
             }
             else if (aObject.is<WeakReference>())
@@ -753,22 +750,13 @@ RED4ext::CStackType Scripting::ToRED(sol::object aObject, RED4ext::CBaseRTTIType
                 auto* pType = static_cast<RED4ext::CClass*>(aObject.as<WeakReference*>()->m_pType);
                 if (pType && pType->IsA(pSubType))
                 {
-                    if (hasData)
-                        result.value = apAllocator->New<RED4ext::Handle<RED4ext::IScriptable>>(
-                            aObject.as<WeakReference>().m_weakHandle);
-                    else
-                        result.value = apAllocator->New<RED4ext::Handle<RED4ext::IScriptable>>();
+                    result.value = apAllocator->New<RED4ext::Handle<RED4ext::IScriptable>>(
+                        aObject.as<WeakReference>().m_weakHandle);
                 }
             }
-            else if (aObject.is<ClassReference>())
+            else if (!hasData)
             {
-                auto* pSubType = static_cast<RED4ext::CClass*>(apRttiType)->parent;
-                auto* pType = static_cast<RED4ext::CClass*>(aObject.as<ClassReference*>()->m_pType);
-                if (pType && pType->IsA(pSubType))
-                {
-                    result.value = apAllocator->New<RED4ext::Handle<RED4ext::IScriptable>>(
-                        static_cast<RED4ext::IScriptable*>(aObject.as<ClassReference>().GetHandle()));
-                }
+                result.value = apAllocator->New<RED4ext::Handle<RED4ext::IScriptable>>();
             }
         }
         else if (apRttiType->GetType() == RED4ext::ERTTIType::WeakHandle)
@@ -779,11 +767,8 @@ RED4ext::CStackType Scripting::ToRED(sol::object aObject, RED4ext::CBaseRTTIType
                 auto* pType = static_cast<RED4ext::CClass*>(aObject.as<WeakReference*>()->m_pType);
                 if (pType && pType->IsA(pSubType))
                 {
-                    if (hasData)
-                        result.value = apAllocator->New<RED4ext::WeakHandle<RED4ext::IScriptable>>(
-                            aObject.as<WeakReference>().m_weakHandle);
-                    else
-                        result.value = apAllocator->New<RED4ext::WeakHandle<RED4ext::IScriptable>>();
+                    result.value = apAllocator->New<RED4ext::WeakHandle<RED4ext::IScriptable>>(
+                        aObject.as<WeakReference>().m_weakHandle);
                 }
             }
             else if (aObject.is<StrongReference>()) // Handle Implicit Cast
@@ -792,12 +777,13 @@ RED4ext::CStackType Scripting::ToRED(sol::object aObject, RED4ext::CBaseRTTIType
                 auto* pType = static_cast<RED4ext::CClass*>(aObject.as<StrongReference*>()->m_pType);
                 if (pType && pType->IsA(pSubType))
                 {
-                    if (hasData)
-                        result.value = apAllocator->New<RED4ext::WeakHandle<RED4ext::IScriptable>>(
-                            aObject.as<StrongReference>().m_strongHandle);
-                    else
-                        result.value = apAllocator->New<RED4ext::WeakHandle<RED4ext::IScriptable>>();
+                    result.value = apAllocator->New<RED4ext::WeakHandle<RED4ext::IScriptable>>(
+                        aObject.as<StrongReference>().m_strongHandle);
                 }
+            }
+            else if (!hasData)
+            {
+                result.value = apAllocator->New<RED4ext::WeakHandle<RED4ext::IScriptable>>();
             }
         }
         else if (apRttiType->GetType() == RED4ext::ERTTIType::Array)

--- a/src/scripting/Scripting.cpp
+++ b/src/scripting/Scripting.cpp
@@ -329,6 +329,24 @@ void Scripting::PostInitialize()
         };
     };
 
+    luaVm.new_usertype<CRUID>("CRUID",
+        sol::constructors<CRUID(uint64_t)>(),
+        sol::call_constructor, sol::constructors<CRUID(uint64_t)>(),
+        sol::meta_function::to_string, &CRUID::ToString,
+        sol::meta_function::equal_to, &CRUID::operator==,
+        "hash", &CRUID::hash);
+
+    luaGlobal["CRUID"] = luaVm["CRUID"];
+
+    luaVm.new_usertype<gamedataLocKeyWrapper>("LocKey",
+        sol::constructors<gamedataLocKeyWrapper(uint64_t)>(),
+        sol::call_constructor, sol::constructors<gamedataLocKeyWrapper(uint64_t)>(),
+        sol::meta_function::to_string, &gamedataLocKeyWrapper::ToString,
+        sol::meta_function::equal_to, &gamedataLocKeyWrapper::operator==,
+        "hash", &gamedataLocKeyWrapper::hash);
+
+    luaGlobal["LocKey"] = luaVm["LocKey"];
+
     luaGlobal["NewObject"] = [this](const std::string& acName, sol::this_environment aEnv) -> sol::object
     {
         auto* pRtti = RED4ext::CRTTISystem::Get();

--- a/src/scripting/Scripting.cpp
+++ b/src/scripting/Scripting.cpp
@@ -172,6 +172,24 @@ void Scripting::PostInitialize()
         sol::meta_function::index, &UnknownType::Index,
         sol::meta_function::new_index, &UnknownType::NewIndex);
 
+    luaGlobal["IsDefined"] =  sol::overload(
+        // Check if weak reference is still valid
+        [](WeakReference& aRef) -> bool
+        {
+            return !aRef.m_weakHandle.Expired();
+        },
+        // To make it callable for strong reference
+        // although it's always valid unless it's null
+        [](StrongReference& aRef) -> bool
+        {
+            return true;
+        },
+        // To make it callable for null refs
+        [](sol::nil_t aNil) -> bool
+        {
+            return false;
+        });
+
     luaVm.new_usertype<Enum>("Enum",
         sol::constructors<Enum(const std::string&, const std::string&),
                           Enum(const std::string&, uint32_t), Enum(const Enum&)>(),


### PR DESCRIPTION
1. Added support of nulls for strong and weak references.

Assignment example: 
```lua
-- Set reference to null
self.resetConfirmationToken = nil
```
Parameter example: 
```lua
-- Omit optional task data
Game.GetDelaySystem():QueueTask(this, nil, "ResolveGameplayStateTask", gameScriptTaskExecutionStage.PostPhysics)
```

2. Added `IsDefined` helper function as in redscript. 
Checks if reference is not null and valid. Can be used on game object's field and lua variable.

3. Added `EnumInt` helper function as in redscript.
```lua
print(EnumInt(GameplayTier.Tier2_StagedGameplay)) -- 2ULL
```

4. Added support for `CRUID` type.  #612
```lua
local dialogLine = scnDialogLineData.new()
dialogLine.id = CRUID(12345)
```

5. Added support for `gamedataLocKeyWrapper` type.
```lua
TweakDB:SetFlat("Items.Preset_Overture_Kerry.displayName", LocKey(40475))
```
