### PR TITLE
Stricter context check, better ISerializable support, add new CNames, guaranteed observers, fixed parameterized struct constructor

### DIFF
--- a/src/reverse/BasicTypes.cpp
+++ b/src/reverse/BasicTypes.cpp
@@ -65,6 +65,11 @@ bool CName::operator==(const CName& acRhs) const noexcept
     return hash == acRhs.hash;
 }
 
+void CName::Add(const std::string& aName)
+{
+    RED4ext::CNamePool::Add(aName.c_str());
+}
+
 std::string TweakDBID::ToString() const noexcept
 {
     return fmt::format("ToTweakDBID{{ hash = 0x{0:08X}, length = {1:d} }}", name_hash, name_length);

--- a/src/reverse/BasicTypes.h
+++ b/src/reverse/BasicTypes.h
@@ -92,6 +92,8 @@ struct CName
     std::string ToString() const noexcept;
 
 	bool operator==(const CName& acRhs) const noexcept;
+
+    static void Add(const std::string& aName);
 };
 
 #pragma pack(push, 1)

--- a/src/reverse/Converter.h
+++ b/src/reverse/Converter.h
@@ -210,7 +210,7 @@ struct ClassConverter : LuaRED<ClassReference, "ClassReference">
         }
         else if (aObject == sol::nil)
         {
-            result.value = RTTIHelper::Get().NewInstance(apRtti, apAllocator);
+            result.value = RTTIHelper::Get().NewInstance(apRtti, sol::nullopt, apAllocator);
         }
         // Disabled until new allocator is implemented
         // Current implementation can leak

--- a/src/reverse/Converter.h
+++ b/src/reverse/Converter.h
@@ -210,23 +210,25 @@ struct ClassConverter : LuaRED<ClassReference, "ClassReference">
         }
         else if (aObject == sol::nil)
         {
-            result.value = RTTIHelper::Get().NewInstance(apRtti, sol::nullopt, apAllocator);
+            result.value = RTTIHelper::Get().NewInstance(apRtti, apAllocator);
         }
-        else if (aObject.get_type() == sol::type::table)
-        {
-            // The implicit table to instance conversion `Game.FindEntityByID({ hash = 1 })` has potential issue:
-            // When the overloaded function takes an array and an object for the same arg the implicit conversion
-            // can produce an empty instance making the unwanted overload callable. So for better experience it's 
-            // important to distinguish between linear array and array of props.
-            
-            // Size check excludes non-empty linear arrays since only the table with sequential and integral keys
-            // has size (length). And iterator check excludes empty tables `{}`.
-            sol::table props = aObject.as<sol::table>();
-            if (props.size() == 0 && props.begin() != props.end())
-                result.value = RTTIHelper::Get().NewInstance(apRtti, props, apAllocator);
-            else
-                result.value = nullptr;
-        }
+        // Disabled until new allocator is implemented
+        // Current implementation can leak
+        //else if (aObject.get_type() == sol::type::table)
+        //{
+        //    // The implicit table to instance conversion `Game.FindEntityByID({ hash = 1 })` has potential issue:
+        //    // When the overloaded function takes an array and an object for the same arg the implicit conversion
+        //    // can produce an empty instance making the unwanted overload callable. So for better experience it's 
+        //    // important to distinguish between linear array and array of props.
+        //    
+        //    // Size check excludes non-empty linear arrays since only the table with sequential and integral keys
+        //    // has size (length). And iterator check excludes empty tables `{}`.
+        //    sol::table props = aObject.as<sol::table>();
+        //    if (props.size() == 0 && props.begin() != props.end())
+        //        result.value = RTTIHelper::Get().NewInstance(apRtti, props, apAllocator);
+        //    else
+        //        result.value = nullptr;
+        //}
         else
         {
             result.value = nullptr;

--- a/src/reverse/RTTIHelper.h
+++ b/src/reverse/RTTIHelper.h
@@ -20,7 +20,7 @@ struct RTTIHelper
     RED4ext::ScriptInstance ResolveHandle(RED4ext::CBaseFunction* apFunc, sol::variadic_args& aArgs, uint64_t& aArgOffset) const;
     sol::variadic_results ExecuteFunction(RED4ext::CBaseFunction* apFunc, RED4ext::ScriptInstance apHandle,
                                           sol::variadic_args aLuaArgs, uint64_t aLuaArgOffset,
-                                          std::string& aErrorMessage) const;
+                                          std::string& aErrorMessage, bool aAllowNull = false) const;
     
     RED4ext::ScriptInstance NewInstance(RED4ext::CBaseRTTIType* apType, sol::optional<sol::table> aProps,
                                         TiltedPhoques::Allocator* apAllocator) const;
@@ -45,6 +45,8 @@ private:
 
     void InitializeRTTI();
     void ParseGlobalStatics();
+
+    bool IsFunctionAlias(RED4ext::CBaseFunction* apFunc);
 
     sol::function GetResolvedFunction(const uint64_t acFuncHash) const;
     sol::function GetResolvedFunction(const uint64_t acClassHash, const uint64_t acFuncHash, bool aIsMember) const;

--- a/src/reverse/RTTIHelper.h
+++ b/src/reverse/RTTIHelper.h
@@ -29,6 +29,7 @@ struct RTTIHelper
 
     sol::object GetProperty(RED4ext::CClass* apClass, RED4ext::ScriptInstance apHandle, const std::string& acPropName, bool& aSuccess) const;
     void SetProperty(RED4ext::CClass* apClass, RED4ext::ScriptInstance apHandle, const std::string& acPropName, sol::object aPropValue, bool& aSuccess) const;
+    void SetProperties(RED4ext::CClass* apClass, RED4ext::ScriptInstance apHandle, sol::optional<sol::table> aProps) const;
 
     RED4ext::CBaseFunction* FindFunction(const uint64_t acFullNameHash) const;
     RED4ext::CBaseFunction* FindFunction(RED4ext::CClass* apClass, const uint64_t acFullNameHash) const;

--- a/src/reverse/StrongReference.cpp
+++ b/src/reverse/StrongReference.cpp
@@ -1,8 +1,11 @@
 #include <stdafx.h>
 
 #include "StrongReference.h"
+#include "RTTILocator.h"
 
 #include "CET.h"
+
+static RTTILocator s_sIScriptableType{RED4ext::FNV1a("IScriptable")};
 
 StrongReference::StrongReference(const TiltedPhoques::Lockable<sol::state, std::recursive_mutex>::Ref& aView,
                                  RED4ext::Handle<RED4ext::IScriptable> aStrongHandle)
@@ -12,6 +15,20 @@ StrongReference::StrongReference(const TiltedPhoques::Lockable<sol::state, std::
     if (m_strongHandle)
     {
         m_pType = m_strongHandle->GetType();
+    }
+}
+
+StrongReference::StrongReference(const TiltedPhoques::Lockable<sol::state, std::recursive_mutex>::Ref& aView,
+                                 RED4ext::Handle<RED4ext::IScriptable> aStrongHandle,
+                                 RED4ext::CHandle* apStrongHandleType)
+    : ClassType(aView, nullptr)
+    , m_strongHandle(std::move(aStrongHandle))
+{
+    if (m_strongHandle)
+    {
+        auto const cpClass = reinterpret_cast<RED4ext::CClass*>(apStrongHandleType->GetInnerType());
+
+        m_pType = cpClass->IsA(s_sIScriptableType) ? m_strongHandle->GetType() : cpClass;
     }
 }
 

--- a/src/reverse/StrongReference.h
+++ b/src/reverse/StrongReference.h
@@ -6,6 +6,9 @@ struct StrongReference : ClassType
 {
     StrongReference(const TiltedPhoques::Lockable<sol::state, std::recursive_mutex>::Ref& aView,
                     RED4ext::Handle<RED4ext::IScriptable> aStrongHandle);
+    StrongReference(const TiltedPhoques::Lockable<sol::state, std::recursive_mutex>::Ref& aView,
+                    RED4ext::Handle<RED4ext::IScriptable> aStrongHandle, 
+                    RED4ext::CHandle* apStrongHandleType);
     virtual ~StrongReference();
 
 protected:

--- a/src/reverse/Type.h
+++ b/src/reverse/Type.h
@@ -49,6 +49,8 @@ struct ClassType : Type
     Descriptor Dump(bool aWithHashes) const override;
     sol::object Index_Impl(const std::string& acName, sol::this_environment aThisEnv) override;
     sol::object NewIndex_Impl(const std::string& acName, sol::object aParam) override;
+
+    RED4ext::CClass* GetClass() const { return reinterpret_cast<RED4ext::CClass*>(m_pType); };
 };
 
 struct UnknownType : Type

--- a/src/reverse/WeakReference.cpp
+++ b/src/reverse/WeakReference.cpp
@@ -1,8 +1,11 @@
 #include <stdafx.h>
 
 #include "WeakReference.h"
+#include "RTTILocator.h"
 
 #include "CET.h"
+
+static RTTILocator s_sIScriptableType{RED4ext::FNV1a("IScriptable")};
 
 WeakReference::WeakReference(const TiltedPhoques::Lockable<sol::state, std::recursive_mutex>::Ref& aView,
                              RED4ext::WeakHandle<RED4ext::IScriptable> aWeakHandle)
@@ -13,6 +16,21 @@ WeakReference::WeakReference(const TiltedPhoques::Lockable<sol::state, std::recu
     if (ref)
     {
         m_pType = ref->GetType();
+    }
+}
+
+WeakReference::WeakReference(const TiltedPhoques::Lockable<sol::state, std::recursive_mutex>::Ref& aView,
+                             RED4ext::WeakHandle<RED4ext::IScriptable> aWeakHandle,
+                             RED4ext::CWeakHandle* apWeakHandleType)
+    : ClassType(aView, nullptr)
+    , m_weakHandle(std::move(aWeakHandle))
+{
+    auto ref = m_weakHandle.Lock();
+    if (ref)
+    {
+        auto const cpClass = reinterpret_cast<RED4ext::CClass*>(apWeakHandleType->GetInnerType());
+
+        m_pType = cpClass->IsA(s_sIScriptableType) ? ref->GetType() : cpClass;
     }
 }
 

--- a/src/reverse/WeakReference.h
+++ b/src/reverse/WeakReference.h
@@ -6,6 +6,9 @@ struct WeakReference : ClassType
 {
     WeakReference(const TiltedPhoques::Lockable<sol::state, std::recursive_mutex>::Ref& aView,
                   RED4ext::WeakHandle<RED4ext::IScriptable> aWeakHandle);
+    WeakReference(const TiltedPhoques::Lockable<sol::state, std::recursive_mutex>::Ref& aView,
+                  RED4ext::WeakHandle<RED4ext::IScriptable> aWeakHandle,
+                  RED4ext::CWeakHandle* apWeakHandleType);
     virtual ~WeakReference();
 
 protected:

--- a/src/scripting/Scripting.cpp
+++ b/src/scripting/Scripting.cpp
@@ -309,7 +309,8 @@ void Scripting::PostInitialize()
         sol::meta_function::equal_to, &CName::operator==,
         "hash_lo", &CName::hash_lo,
         "hash_hi", &CName::hash_hi,
-        "value", sol::property(&CName::AsString));
+        "value", sol::property(&CName::AsString),
+        "add", &CName::Add);
 
     luaGlobal["CName"] = luaVm["CName"];
     luaGlobal["ToCName"] = [](sol::table table) -> CName

--- a/src/scripting/Scripting.cpp
+++ b/src/scripting/Scripting.cpp
@@ -712,13 +712,13 @@ sol::object Scripting::ToLua(LockedState& aState, RED4ext::CStackType& aResult)
     {
         const auto handle = *static_cast<RED4ext::Handle<RED4ext::IScriptable>*>(aResult.value);
         if (handle)
-            return make_object(state, StrongReference(aState, handle));
+            return make_object(state, StrongReference(aState, handle, static_cast<RED4ext::CHandle*>(pType)));
     }
     else if (pType->GetType() == RED4ext::ERTTIType::WeakHandle)
     {
         const auto handle = *static_cast<RED4ext::WeakHandle<RED4ext::IScriptable>*>(aResult.value);
         if (!handle.Expired())
-            return make_object(state, WeakReference(aState, handle));
+            return make_object(state, WeakReference(aState, handle, static_cast<RED4ext::CWeakHandle*>(pType)));
     }
     else if (pType->GetType() == RED4ext::ERTTIType::Array)
     {

--- a/src/scripting/Scripting.cpp
+++ b/src/scripting/Scripting.cpp
@@ -132,36 +132,42 @@ void Scripting::PostInitialize()
         sol::meta_function::index, &Type::Index,
         sol::meta_function::new_index, &Type::NewIndex);
 
+    luaVm.new_usertype<ClassType>("__ClassType",
+        sol::meta_function::construct, sol::no_constructor,
+        sol::base_classes, sol::bases<Type>(),
+        sol::meta_function::index, &ClassType::Index,
+        sol::meta_function::new_index, &ClassType::NewIndex);
+
     luaVm.new_usertype<Type::Descriptor>("Descriptor",
         sol::meta_function::to_string, &Type::Descriptor::ToString);
 
     luaVm.new_usertype<StrongReference>("StrongReference",
         sol::meta_function::construct, sol::no_constructor,
-        sol::base_classes, sol::bases<Type>(),
+        sol::base_classes, sol::bases<Type, ClassType>(),
         sol::meta_function::index, &StrongReference::Index,
         sol::meta_function::new_index, &StrongReference::NewIndex);
 
     luaVm.new_usertype<WeakReference>("WeakReference",
         sol::meta_function::construct, sol::no_constructor,
-        sol::base_classes, sol::bases<Type>(),
+        sol::base_classes, sol::bases<Type, ClassType>(),
         sol::meta_function::index, &WeakReference::Index,
         sol::meta_function::new_index, &WeakReference::NewIndex);
 
     luaVm.new_usertype<SingletonReference>("SingletonReference",
         sol::meta_function::construct, sol::no_constructor,
-        sol::base_classes, sol::bases<Type>(),
+        sol::base_classes, sol::bases<Type, ClassType>(),
         sol::meta_function::index, &SingletonReference::Index,
         sol::meta_function::new_index, &SingletonReference::NewIndex);
 
     luaVm.new_usertype<ClassReference>("ClassReference",
         sol::meta_function::construct, sol::no_constructor,
-        sol::base_classes, sol::bases<Type>(),
+        sol::base_classes, sol::bases<Type, ClassType>(),
         sol::meta_function::index, &ClassReference::Index,
         sol::meta_function::new_index, &ClassReference::NewIndex);
 
     luaVm.new_usertype<ResourceAsyncReference>("ResourceAsyncReference",
         sol::meta_function::construct, sol::no_constructor,
-        sol::base_classes, sol::bases<Type>(),
+        sol::base_classes, sol::bases<Type, ClassType>(),
         sol::meta_function::index, &ResourceAsyncReference::Index,
         sol::meta_function::new_index, &ResourceAsyncReference::NewIndex,
         "hash", sol::property(&ResourceAsyncReference::GetLuaHash));


### PR DESCRIPTION
- Added stricter check of the passed context when calling the RTTI function. Prevents unwanted crashes when invalid value passed as `self` / `this`. In particular, it prevents crashes when a dot is accidentally used instead of a colon. 
- Added support for `ISerializable` strong and weak references. This opens access to some new classes, but not all of them.
- Always call all function observers. Even if an override is defined, all observers will be called.
```lua
Observe('PlayerPuppet', 'IsPlayer', function() print('Observe 1') end)
Override('PlayerPuppet', 'IsPlayer', function() print('Override 1') end)
Override('PlayerPuppet', 'IsPlayer', function() print('Override 2') end)
Observe('PlayerPuppet', 'IsPlayer', function() print('Observe 2') end)
```
Output:
```
Observe 1
Override 1
Observe 2
```
- Added function to add new `CName`s to the pool:
```lua
print(CName("CET").value) -- Empty string
CName.add("CET")
print(CName("CET").value) -- CET
```
- Added workaround for parameterized struct constructor. Previously, fields of a reference type could be corrupted right after construction. 

---

Internals:

- Added `ClassType` to Lua type hierarchy.
- Disabled implicit Lua table to struct conversion.
