### PR TITLE
Overrides and Variants

### DIFF
--- a/src/reverse/BasicTypes.h
+++ b/src/reverse/BasicTypes.h
@@ -203,7 +203,8 @@ struct Variant
     };
 
     const RED4ext::CBaseRTTIType* type{ nullptr };
-    union {
+    union
+    {
         uint8_t inlined[kInlineSize]{ 0 };
         RED4ext::ScriptInstance instance;
     };

--- a/src/reverse/ClassReference.cpp
+++ b/src/reverse/ClassReference.cpp
@@ -16,3 +16,8 @@ RED4ext::ScriptInstance ClassReference::GetHandle() const
 {
     return m_pInstance.get();
 }
+
+RED4ext::ScriptInstance ClassReference::GetValuePtr() const
+{
+    return GetHandle();
+}

--- a/src/reverse/ClassReference.h
+++ b/src/reverse/ClassReference.h
@@ -9,6 +9,7 @@ struct ClassReference : ClassType
                    RED4ext::ScriptInstance apInstance);
 
     virtual RED4ext::ScriptInstance GetHandle() const override;
+    virtual RED4ext::ScriptInstance GetValuePtr() const override;
 
 private:
     std::unique_ptr<uint8_t[]> m_pInstance;

--- a/src/reverse/Enum.cpp
+++ b/src/reverse/Enum.cpp
@@ -173,3 +173,8 @@ const RED4ext::CEnum* Enum::GetType() const
 {
     return m_cpType;
 }
+
+const void* Enum::GetValuePtr() const
+{
+    return &m_value;
+}

--- a/src/reverse/Enum.h
+++ b/src/reverse/Enum.h
@@ -26,6 +26,7 @@ struct Enum
 	bool operator==(const Enum& acRhs) const noexcept;
 
     const RED4ext::CEnum* GetType() const;
+    const void* GetValuePtr() const;
 
 protected:
     friend struct Scripting;

--- a/src/reverse/RTTIHelper.cpp
+++ b/src/reverse/RTTIHelper.cpp
@@ -843,18 +843,18 @@ sol::object RTTIHelper::NewHandle(RED4ext::CBaseRTTIType* apType, sol::optional<
     result.type = apType;
     result.value = NewInstance(apType, sol::nullopt, &allocator);
 
-    // Wrap IScriptable descendants in Handle
+    // Wrap ISerializable descendants in Handle
     if (result.value && apType->GetType() == RED4ext::ERTTIType::Class)
     {
         static auto* s_pHandleType = m_pRtti->GetType(RED4ext::FNV1a("handle:Activator"));
-        static auto* s_pIScriptableType = m_pRtti->GetType(RED4ext::FNV1a("IScriptable"));
+        static auto* s_pISerializableType = m_pRtti->GetType(RED4ext::FNV1a("ISerializable"));
 
         auto* pClass = reinterpret_cast<RED4ext::CClass*>(apType);
 
-        if (pClass->IsA(s_pIScriptableType))
+        if (pClass->IsA(s_pISerializableType))
         {
-            auto* pInstance = reinterpret_cast<RED4ext::IScriptable*>(result.value);
-            auto* pHandle = allocator.New<RED4ext::Handle<RED4ext::IScriptable>>(pInstance);
+            auto* pInstance = reinterpret_cast<RED4ext::ISerializable*>(result.value);
+            auto* pHandle = allocator.New<RED4ext::Handle<RED4ext::ISerializable>>(pInstance);
 
             result.type = s_pHandleType; // To trick converter and deallocator
             result.value = pHandle;

--- a/src/reverse/ResourceAsyncReference.cpp
+++ b/src/reverse/ResourceAsyncReference.cpp
@@ -28,6 +28,11 @@ RED4ext::ScriptInstance ResourceAsyncReference::GetHandle() const
     return const_cast<RED4ext::ResourceAsyncReference<void>*>(&m_reference);
 }
 
+RED4ext::ScriptInstance ResourceAsyncReference::GetValuePtr() const
+{
+    return GetHandle();
+}
+
 uint64_t ResourceAsyncReference::GetHash() const
 {
     return reinterpret_cast<uint64_t>(m_reference.ref);

--- a/src/reverse/ResourceAsyncReference.h
+++ b/src/reverse/ResourceAsyncReference.h
@@ -10,6 +10,7 @@ struct ResourceAsyncReference : ClassType
     static uint64_t Hash(const std::string& aPath);
 
     virtual RED4ext::ScriptInstance GetHandle() const override;
+    virtual RED4ext::ScriptInstance GetValuePtr() const override;
 
     uint64_t GetHash() const;
     sol::object GetLuaHash();

--- a/src/reverse/StrongReference.cpp
+++ b/src/reverse/StrongReference.cpp
@@ -47,3 +47,8 @@ RED4ext::ScriptInstance StrongReference::GetHandle() const
 {
     return m_strongHandle.instance;
 }
+
+RED4ext::ScriptInstance StrongReference::GetValuePtr() const
+{
+    return const_cast<RED4ext::Handle<RED4ext::IScriptable>*>(&m_strongHandle);
+}

--- a/src/reverse/StrongReference.h
+++ b/src/reverse/StrongReference.h
@@ -14,6 +14,7 @@ struct StrongReference : ClassType
 protected:
 
     virtual RED4ext::ScriptInstance GetHandle() const override;
+    virtual RED4ext::ScriptInstance GetValuePtr() const override;
     
 private:
     friend struct Scripting;

--- a/src/reverse/Type.h
+++ b/src/reverse/Type.h
@@ -17,6 +17,7 @@ struct Type
 
     RED4ext::CBaseRTTIType* GetType() const { return m_pType; }
     virtual RED4ext::ScriptInstance GetHandle() const { return nullptr; }
+    virtual RED4ext::ScriptInstance GetValuePtr() const { return nullptr; }
 
     sol::object Index(const std::string& acName, sol::this_environment aThisEnv);
     sol::object NewIndex(const std::string& acName, sol::object aParam);

--- a/src/reverse/WeakReference.cpp
+++ b/src/reverse/WeakReference.cpp
@@ -55,3 +55,8 @@ RED4ext::ScriptInstance WeakReference::GetHandle() const
 
     return nullptr;
 }
+
+RED4ext::ScriptInstance WeakReference::GetValuePtr() const
+{
+    return const_cast<RED4ext::WeakHandle<RED4ext::IScriptable>*>(&m_weakHandle);
+}

--- a/src/reverse/WeakReference.h
+++ b/src/reverse/WeakReference.h
@@ -14,6 +14,7 @@ struct WeakReference : ClassType
 protected:
 
     virtual RED4ext::ScriptInstance GetHandle() const override;
+    virtual RED4ext::ScriptInstance GetValuePtr() const override;
     
 private:
     friend struct Scripting;

--- a/src/scripting/Scripting.h
+++ b/src/scripting/Scripting.h
@@ -37,7 +37,7 @@ struct Scripting
     static sol::object ToLua(LockedState& aState, RED4ext::CStackType& aResult);
     static RED4ext::CStackType ToRED(sol::object aObject, RED4ext::CBaseRTTIType* apRttiType,
                                      TiltedPhoques::Allocator* apAllocator);
-    static void ToRED(sol::object aObject, RED4ext::CStackType* apType);
+    static void ToRED(sol::object aObject, RED4ext::CStackType& apType);
 
 protected:
     void RegisterOverrides();


### PR DESCRIPTION
1. Improved function overrides.
- When using `Override()` the handler receives the original function (or next in the override chain) as the last parameter
```lua
Override('PlayerPuppet', 'SetWarningMessage', function(_, message, wrappedMethod)
    wrappedMethod('[Overridden] ' .. message)
end)
```
- The wrapped function can be called multiple times
```lua
Override('PlayerPuppet', 'GetGunshotRange', function(_, originalRangeFunc)
    return originalRangeFunc() + originalRangeFunc()
end)
```
- If any of the overrides fail then the entire override chain also fails
- Observers can be called before and after the target function using `ObserveBefore()` and `ObserveAfter()`
```lua
ObserveBefore('PlayerPuppet', 'GetGunshotRange', function()
    print('PlayerPuppet::GetGunshotRange::Before')
end)
ObserveAfter('PlayerPuppet', 'GetGunshotRange', function()
    print('PlayerPuppet::GetGunshotRange::After')
end)
```
- `Observe()` is an alias for `ObserveBefore()`
- All observers are guaranteed to be called even if overrides and other observers fail
- It's possible to observe and override static class methods
```lua
Override('RPGManager', 'GetFloatItemQuality', function(value)
    print('RPGManager.GetFloatItemQuality(' .. value .. ')')
    return gamedataQuality.Legendary
end)
```
- Full name should be used when overriding a scripted static method
```lua
Observe('PlayerPuppet', 'IsSwimming;PlayerPuppet', function(player)
    print('PlayerPuppet.IsSwimming(player)')
end)
```
2. Improved `Variant` type support.
- Use `FromVariant(variant)` to extract the value 
- Use `ToVariant(value)` to pack the value when the type is unambiguous
```lua
ToVariant(Vector4.new(1, 2, 3))
ToVariant(gamedataQuality.Epic)
ToVariant("Nam libero tempore")
ToVariant(16570246047455160070ULL)
ToVariant(true)
ToVariant(TweakDBID("Items.money"))
ToVariant(CName("deflect"))
ToVariant(LocKey(12345))
ToVariant(CRUID(1337))
```
- Use `ToVariant(value, type)` when the type is ambiguous or you wanna force the type
```lua
ToVariant(1, "Int32") -- Same numeric value can be a signed integer
ToVariant(1, "Uint32") -- or unsigned integer
ToVariant(1, "Float") -- or float
ToVariant(nil, "handle:PlayerPuppet") -- Null requires a concrete type
```
- The type of the array is resolved from the first element when possible
```lua
ToVariant({ "a", "b", "c" }) -- Auto resolved as "array:String"
ToVariant({ 1, 2, 3 }, "array:Uint32") -- Ambiguous type
```
3. Improved `ISerializable` types support. They are now correctly wrapped in `ref<>` when created.