### PR TITLE
Overrides fixes, TweakDB hook

### DIFF
--- a/src/scripting/FunctionOverride.cpp
+++ b/src/scripting/FunctionOverride.cpp
@@ -72,45 +72,17 @@ void FunctionOverride::Clear()
     // Reverse order as we want to swap from most recent to oldest change
     for (auto& [pFunction, pContext] : m_functions)
     {
-        // Just an added function, not an override
-        if (pContext.Trampoline == nullptr)
-        {
-            auto* pClassType = pFunction->parent;
-            auto* pArray = &pClassType->funcs;
+        auto* pRealFunction = pContext.Trampoline;
 
-            if (pFunction->flags.isStatic)
-                pClassType->staticFuncs;
+        std::array<char, s_cMaxFunctionSize> tmpBuffer;
+        size_t funcSize = GetFunctionSize(pRealFunction);
 
-            for (auto*& pItor : *pArray)
-            {
-                if (pItor == pFunction)
-                {
-                    // Swap our self with the last element
-                    pItor = *(pArray->End() - 1);
-                    // Pop last
-                    pArray->size -= 1;
-
-                    break;
-                }
-            }
-        }
-        else
-        {
-            auto* pRealFunction = pContext.Trampoline;
-
-            std::array<char, s_cMaxFunctionSize> tmpBuffer;
-            size_t funcSize = GetFunctionSize(pRealFunction);
-
-            std::memcpy(&tmpBuffer, pRealFunction, funcSize);
-            std::memcpy(pRealFunction, pFunction, funcSize);
-            std::memcpy(pFunction, &tmpBuffer, funcSize);
-        }
+        std::memcpy(&tmpBuffer, pRealFunction, funcSize);
+        std::memcpy(pRealFunction, pFunction, funcSize);
+        std::memcpy(pFunction, &tmpBuffer, funcSize);
     }
 
     m_functions.clear();
-
-    m_pBuffer = m_pBufferStart;
-    m_size = kExecutableSize;
 }
 
 bool FunctionOverride::HookRunPureScriptFunction(RED4ext::CClassFunction* apFunction, RED4ext::CScriptStack* apStack, RED4ext::CStackFrame* a3)
@@ -517,7 +489,7 @@ void FunctionOverride::Hook(Options& aOptions) const
             {
                 DWORD oldProtect;
                 VirtualProtect(pLocation, 0x40, PAGE_READWRITE, &oldProtect);
-                *pFirstLocation = *pSecondLocation = std::max(sizeof(RED4ext::CClassFunction), sizeof(RED4ext::CScriptedFunction));
+                *pFirstLocation = *pSecondLocation = std::max(s_cMaxFunctionSize, sizeof(RED4ext::CScriptedFunction));
                 VirtualProtect(pLocation, 0x40, oldProtect, &oldProtect);
 
                 spdlog::info("Override function allocator patched!");
@@ -573,73 +545,82 @@ void FunctionOverride::Override(const std::string& acTypeName, const std::string
         m_functions[pRealFunction] = {};
         pEntry = &m_functions[pRealFunction];
 
-        /*
-        sub rsp, 56
-        mov rax, 0xDEADBEEFC0DEBAAD
-        mov qword ptr[rsp + 32], rax
-        mov rax, 0xDEADBEEFC0DEBAAD
-        call rax
-        add rsp, 56
-        ret
-        */
-        uint8_t payload[] = {0x48, 0x83, 0xEC, 0x38, 0x48, 0xB8, 0xAD, 0xBA, 0xDE, 0xC0, 0xEF, 0xBE,
-                             0xAD, 0xDE, 0x48, 0x89, 0x44, 0x24, 0x20, 0x48, 0xB8, 0xAD, 0xBA, 0xDE,
-                             0xC0, 0xEF, 0xBE, 0xAD, 0xDE, 0xFF, 0xD0, 0x48, 0x83, 0xC4, 0x38, 0xC3};
-
-        auto funcAddr = reinterpret_cast<uintptr_t>(&FunctionOverride::HandleOverridenFunction);
-
-        std::memcpy(payload + 6, &pRealFunction, 8);
-        std::memcpy(payload + 21, &funcAddr, 8);
-
-        using TNativeScriptFunction = void (*)(RED4ext::IScriptable*, RED4ext::CStackFrame*, void*, int64_t);
-        auto* pExecutablePayload = static_cast<TNativeScriptFunction>(MakeExecutable(payload, std::size(payload)));
-
         RED4ext::CBaseFunction* pFunc;
 
-        if (pRealFunction->flags.isStatic)
+        if (!m_trampolines.contains(pRealFunction))
         {
-            if (pRealFunction->flags.isNative)
+            /*
+            sub rsp, 56
+            mov rax, 0xDEADBEEFC0DEBAAD
+            mov qword ptr[rsp + 32], rax
+            mov rax, 0xDEADBEEFC0DEBAAD
+            call rax
+            add rsp, 56
+            ret
+            */
+            uint8_t payload[] = {0x48, 0x83, 0xEC, 0x38, 0x48, 0xB8, 0xAD, 0xBA, 0xDE, 0xC0, 0xEF, 0xBE,
+                                 0xAD, 0xDE, 0x48, 0x89, 0x44, 0x24, 0x20, 0x48, 0xB8, 0xAD, 0xBA, 0xDE,
+                                 0xC0, 0xEF, 0xBE, 0xAD, 0xDE, 0xFF, 0xD0, 0x48, 0x83, 0xC4, 0x38, 0xC3};
+
+            auto funcAddr = reinterpret_cast<uintptr_t>(&FunctionOverride::HandleOverridenFunction);
+
+            std::memcpy(payload + 6, &pRealFunction, 8);
+            std::memcpy(payload + 21, &funcAddr, 8);
+
+            using TNativeScriptFunction = void (*)(RED4ext::IScriptable*, RED4ext::CStackFrame*, void*, int64_t);
+            auto* pExecutablePayload = static_cast<TNativeScriptFunction>(MakeExecutable(payload, std::size(payload)));
+
+            if (pRealFunction->flags.isStatic)
             {
-                pFunc = RED4ext::CClassStaticFunction::Create(pClassType, acFullName.c_str(), acFullName.c_str(),
-                                                              pExecutablePayload, pRealFunction->flags);
-                reinterpret_cast<RED4ext::CClassStaticFunction*>(pFunc)->parent = pRealFunction->parent;
+                if (pRealFunction->flags.isNative)
+                {
+                    pFunc = RED4ext::CClassStaticFunction::Create(pClassType, acFullName.c_str(), acFullName.c_str(),
+                                                                  pExecutablePayload, pRealFunction->flags);
+                    reinterpret_cast<RED4ext::CClassStaticFunction*>(pFunc)->parent = pRealFunction->parent;
+                }
+                else
+                {
+                    pFunc = RED4ext::CGlobalFunction::Create(acFullName.c_str(), acFullName.c_str(), pExecutablePayload);
+                }
             }
             else
             {
-                pFunc = RED4ext::CGlobalFunction::Create(acFullName.c_str(), acFullName.c_str(), pExecutablePayload);
+                pFunc = RED4ext::CClassFunction::Create(pClassType, acFullName.c_str(), acFullName.c_str(),
+                                                        pExecutablePayload, pRealFunction->flags);
+                reinterpret_cast<RED4ext::CClassFunction*>(pFunc)->parent = pRealFunction->parent;
             }
+
+            pFunc->fullName = pRealFunction->fullName;
+            pFunc->shortName = pRealFunction->shortName;
+
+            pFunc->returnType = pRealFunction->returnType;
+            for (auto* p : pRealFunction->params)
+            {
+                pFunc->params.PushBack(p);
+            }
+
+            for (auto* p : pRealFunction->localVars)
+            {
+                pFunc->localVars.PushBack(p);
+            }
+
+            pFunc->unk20 = pRealFunction->unk20;
+            pFunc->bytecode = pRealFunction->bytecode;
+            pFunc->unk48 = pRealFunction->unk48;
+            pFunc->unkAC = pRealFunction->unkAC;
+            pFunc->flags = pRealFunction->flags;
+            pFunc->flags.isNative = true;
+
+            m_trampolines[pRealFunction] = pFunc;
         }
         else
         {
-            pFunc = RED4ext::CClassFunction::Create(pClassType, acFullName.c_str(), acFullName.c_str(),
-                                                    pExecutablePayload, pRealFunction->flags);
-            reinterpret_cast<RED4ext::CClassFunction*>(pFunc)->parent = pRealFunction->parent;
+            pFunc = m_trampolines[pRealFunction];
         }
-
-        pFunc->fullName = pRealFunction->fullName;
-        pFunc->shortName = pRealFunction->shortName;
-
-        pFunc->returnType = pRealFunction->returnType;
-        for (auto* p : pRealFunction->params)
-        {
-            pFunc->params.PushBack(p);
-        }
-
-        for (auto* p : pRealFunction->localVars)
-        {
-            pFunc->localVars.PushBack(p);
-        }
-
-        pFunc->unk20 = pRealFunction->unk20;
-        pFunc->bytecode = pRealFunction->bytecode;
-        pFunc->unk48 = pRealFunction->unk48;
-        pFunc->unkAC = pRealFunction->unkAC;
-        pFunc->flags = pRealFunction->flags;
-        pFunc->flags.isNative = true;
 
         pEntry->Trampoline = pFunc;
         pEntry->pScripting = m_pScripting;
-        pEntry->CollectGarbage = aCollectGarbage || pClassType->IsA(s_inkGameControllerType);
+        pEntry->CollectGarbage = aCollectGarbage;
         pEntry->IsEmpty = true;
 
         // Swap the content of the real function with the one we just created

--- a/src/scripting/FunctionOverride.h
+++ b/src/scripting/FunctionOverride.h
@@ -38,8 +38,8 @@ protected:
     static bool HookRunPureScriptFunction(RED4ext::CClassFunction* apFunction, RED4ext::CScriptStack* apContext, RED4ext::CStackFrame* a3);
     static bool ExecuteChain(const CallChain& aChain, std::shared_lock<std::shared_mutex>& aLock,
                              RED4ext::IScriptable* apContext, TiltedPhoques::Vector<sol::object>* apArgs,
-                             RED4ext::CStackType* apResult, RED4ext::CScriptStack* apStack,
-                             RED4ext::CStackFrame* apFrame, char* apCode, uint8_t aParam);
+                             RED4ext::CStackType* apResult, TiltedPhoques::Vector<RED4ext::CStackType>* apOutArgs, 
+                             RED4ext::CScriptStack* apStack, RED4ext::CStackFrame* apFrame, char* apCode, uint8_t aParam);
     static sol::function WrapNextOverride(const CallChain& aChain, int aStep, sol::state& aLuaState,
                                           sol::object& aLuaContext, TiltedPhoques::Vector<sol::object>& aLuaArgs,
                                           RED4ext::CBaseFunction* apRealFunction, RED4ext::IScriptable* apRealContext,

--- a/src/scripting/FunctionOverride.h
+++ b/src/scripting/FunctionOverride.h
@@ -57,7 +57,8 @@ private:
     void* m_pBufferStart;
     void* m_pBuffer;
     size_t m_size{ kExecutableSize };
-    TiltedPhoques::Map<RED4ext::CClassFunction*, CallChain> m_functions;
+    TiltedPhoques::Map<RED4ext::CBaseFunction*, CallChain> m_functions;
+    TiltedPhoques::Map<RED4ext::CBaseFunction*, RED4ext::CBaseFunction*> m_trampolines;
     Scripting* m_pScripting;
     std::shared_mutex m_lock;
 };

--- a/src/scripting/LuaVM.cpp
+++ b/src/scripting/LuaVM.cpp
@@ -25,7 +25,7 @@ void LuaVM::Update(float aDeltaTime)
     if (!m_initialized)
     {
         if (m_logCount.load(std::memory_order_relaxed) > 0)
-            PostInitialize();
+            PostInitializeStage2();
 
         return;
     }
@@ -46,6 +46,7 @@ void LuaVM::ReloadAllMods()
     if (m_initialized)
     {
         m_scripting.ReloadAllMods();
+        m_scripting.TriggerOnTweak();
         m_scripting.TriggerOnInit();
 
         if (CET::Get().GetOverlay().IsEnabled())
@@ -180,12 +181,17 @@ void LuaVM::RegisterTDBIDString(uint64_t aValue, uint64_t aBase, const std::stri
         m_tdbidDerivedLookup[aBase].insert(aValue);
 }
 
-void LuaVM::PostInitialize()
+void LuaVM::PostInitializeStage1()
+{
+    m_scripting.PostInitializeStage1();
+    m_scripting.TriggerOnTweak();
+}
+
+void LuaVM::PostInitializeStage2()
 {
     assert(!m_initialized);
 
-    m_scripting.PostInitialize();
-
+    m_scripting.PostInitializeStage2();
     m_scripting.TriggerOnInit();
     if (CET::Get().GetOverlay().IsEnabled())
         m_scripting.TriggerOnOverlayOpen();

--- a/src/scripting/LuaVM.h
+++ b/src/scripting/LuaVM.h
@@ -11,6 +11,7 @@ using TSetMousePosition = BOOL(void*, HWND, long, long);
 using TTDBIDCtorDerive = TDBID*(const TDBID*, TDBID*, const char*);
 using TRunningStateRun = bool(uintptr_t, uintptr_t);
 using TSetLoadingState = uintptr_t(uintptr_t, int);
+using TTweakDBLoad = uint64_t(uintptr_t, uintptr_t);
 
 struct TDBIDLookupEntry
 {
@@ -51,7 +52,8 @@ struct LuaVM
 
     void RegisterTDBIDString(uint64_t aValue, uint64_t aBase, const std::string& acString);
 
-    void PostInitialize();
+    void PostInitializeStage1();
+    void PostInitializeStage2();
 
 protected:
     
@@ -63,6 +65,7 @@ protected:
     static TDBID* HookTDBIDCtorDerive(TDBID* apBase, TDBID* apThis, const char* acpName);
     static bool HookRunningStateRun(uintptr_t aThis, uintptr_t aApp);
     static uintptr_t HookSetLoadingState(uintptr_t aThis, int aState);
+    static uint64_t HookTweakDBLoad(uintptr_t aThis, uintptr_t aParam);
 
 private:
   
@@ -77,6 +80,7 @@ private:
     TTDBIDCtorDerive* m_realTDBIDCtorDerive{ nullptr };
     TRunningStateRun* m_realRunningStateRun{ nullptr };
     TSetLoadingState* m_realSetLoadingState{ nullptr };
+    TTweakDBLoad* m_realTweakDBLoad{ nullptr };
 
     std::chrono::time_point<std::chrono::high_resolution_clock> m_lastframe;
 

--- a/src/scripting/ScriptContext.cpp
+++ b/src/scripting/ScriptContext.cpp
@@ -43,6 +43,8 @@ ScriptContext::ScriptContext(LuaSandbox& aLuaSandbox, const std::filesystem::pat
     {
         if(acName == "onInit")
             m_onInit = aCallback;
+        else if(acName == "onTweak")
+            m_onTweak = aCallback;
         else if(acName == "onShutdown")
             m_onShutdown = aCallback;
         else if(acName == "onUpdate")
@@ -153,6 +155,13 @@ bool ScriptContext::IsValid() const
 const TiltedPhoques::Vector<VKBindInfo>& ScriptContext::GetBinds() const
 {
     return m_vkBindInfos;
+}
+
+void ScriptContext::TriggerOnTweak() const
+{
+    auto state = m_sandbox.GetState();
+
+    TryLuaFunction(m_logger, m_onTweak);
 }
 
 void ScriptContext::TriggerOnInit() const

--- a/src/scripting/ScriptContext.h
+++ b/src/scripting/ScriptContext.h
@@ -12,6 +12,7 @@ struct ScriptContext
 
     const TiltedPhoques::Vector<VKBindInfo>& GetBinds() const;
     
+    void TriggerOnTweak() const;
     void TriggerOnInit() const;
     void TriggerOnUpdate(float aDeltaTime) const;
     void TriggerOnDraw() const;
@@ -30,6 +31,7 @@ private:
     LuaSandbox& m_sandbox;
     size_t m_sandboxID;
     sol::object m_object{ };
+    sol::function m_onTweak{ };
     sol::function m_onInit{ };
     sol::function m_onShutdown{ };
     sol::function m_onUpdate{ };

--- a/src/scripting/ScriptStore.cpp
+++ b/src/scripting/ScriptStore.cpp
@@ -25,10 +25,16 @@ void ScriptStore::LoadAll()
 
         auto fPath = file.path();
 
-        if (is_symlink(fPath))
-            fPath = read_symlink(fPath);
-        else if (is_symlink(fPath / "init.lua"))
-            fPath = read_symlink(fPath / "init.lua").parent_path();
+        try
+        {
+            if (is_symlink(fPath))
+                fPath = read_symlink(fPath);
+            else if (is_symlink(fPath / "init.lua"))
+                fPath = read_symlink(fPath / "init.lua").parent_path();
+        }
+        catch (std::exception& e)
+        {
+        }
 
         fPath = absolute(fPath);
         auto fPathStr = fPath.string();

--- a/src/scripting/ScriptStore.cpp
+++ b/src/scripting/ScriptStore.cpp
@@ -74,6 +74,12 @@ const TiltedPhoques::Vector<VKBindInfo>& ScriptStore::GetBinds() const
     return m_vkBindInfos;
 }
 
+void ScriptStore::TriggerOnTweak() const
+{
+    for (const auto& kvp : m_contexts)
+        kvp.second.TriggerOnTweak();
+}
+
 void ScriptStore::TriggerOnInit() const
 {
     for (const auto& kvp : m_contexts)

--- a/src/scripting/ScriptStore.h
+++ b/src/scripting/ScriptStore.h
@@ -11,6 +11,7 @@ struct ScriptStore
 
     const TiltedPhoques::Vector<VKBindInfo>& GetBinds() const;
     
+    void TriggerOnTweak() const;
     void TriggerOnInit() const;
     void TriggerOnUpdate(float aDeltaTime) const;
     void TriggerOnDraw() const;

--- a/src/scripting/Scripting.cpp
+++ b/src/scripting/Scripting.cpp
@@ -658,18 +658,6 @@ sol::object Scripting::Index(const std::string& acName, sol::this_state aState, 
         return itor->second;
     }
 
-    return InternalIndex(acName, aState, aEnv);
-}
-
-sol::object Scripting::InternalNewIndex(const std::string& acName, sol::object aParam)
-{
-    auto& property = m_properties[acName];
-    property = std::move(aParam);
-    return property;
-}
-
-sol::protected_function Scripting::InternalIndex(const std::string& acName, sol::this_state aState, sol::this_environment aEnv)
-{
     auto func = RTTIHelper::Get().ResolveFunction(acName);
 
     if (!func)
@@ -690,7 +678,9 @@ sol::protected_function Scripting::InternalIndex(const std::string& acName, sol:
         return sol::nil;
     }
 
-    return InternalNewIndex(acName, std::move(func));
+    auto& property = m_properties[acName];
+    property = std::move(func);
+    return property;
 }
 
 sol::object Scripting::GetSingletonHandle(const std::string& acName, sol::this_environment aThisEnv)

--- a/src/scripting/Scripting.cpp
+++ b/src/scripting/Scripting.cpp
@@ -543,7 +543,7 @@ void Scripting::RegisterOverrides()
     auto lua = m_lua.Lock();
     auto& luaVm = lua.Get();
 
-    luaVm["RegisterGlobalInputListener"] = [](StrongReference& aSelf, sol::this_environment aThisEnv) {
+    luaVm["RegisterGlobalInputListener"] = [](WeakReference& aSelf, sol::this_environment aThisEnv) {
         sol::protected_function unregisterInputListener = aSelf.Index("UnregisterInputListener", aThisEnv);
         sol::protected_function registerInputListener = aSelf.Index("RegisterInputListener", aThisEnv);
 

--- a/src/scripting/Scripting.h
+++ b/src/scripting/Scripting.h
@@ -45,7 +45,7 @@ protected:
     void RegisterOverrides();
 
     sol::object Index(const std::string& acName, sol::this_state aState, sol::this_environment aEnv);
-    sol::object NewIndex(const std::string& acName, sol::object aParam);
+    sol::object InternalNewIndex(const std::string& acName, sol::object aParam);
     sol::object GetSingletonHandle(const std::string& acName, sol::this_environment aThisEnv);
     sol::protected_function InternalIndex(const std::string& acName, sol::this_state aState,
                                           sol::this_environment aEnv);

--- a/src/scripting/Scripting.h
+++ b/src/scripting/Scripting.h
@@ -45,10 +45,7 @@ protected:
     void RegisterOverrides();
 
     sol::object Index(const std::string& acName, sol::this_state aState, sol::this_environment aEnv);
-    sol::object InternalNewIndex(const std::string& acName, sol::object aParam);
     sol::object GetSingletonHandle(const std::string& acName, sol::this_environment aThisEnv);
-    sol::protected_function InternalIndex(const std::string& acName, sol::this_state aState,
-                                          sol::this_environment aEnv);
 
 private:
     TiltedPhoques::Lockable<sol::state, std::recursive_mutex> m_lua;

--- a/src/scripting/Scripting.h
+++ b/src/scripting/Scripting.h
@@ -15,10 +15,12 @@ struct Scripting
     ~Scripting() = default;
 
     void Initialize();
-    void PostInitialize();
+    void PostInitializeStage1();
+    void PostInitializeStage2();
 
     const TiltedPhoques::Vector<VKBindInfo>& GetBinds() const;
 
+    void TriggerOnTweak() const;
     void TriggerOnInit() const;
     void TriggerOnUpdate(float aDeltaTime) const;
     void TriggerOnDraw() const;


### PR DESCRIPTION
1. Use weak handle for `self` in overrides. This should decrease the number of unreleased references and make CET less dependent on garbage collection.

2. Reuse overridden functions on mods reload. This fixes a potential issue with the native function registry, which has a hard limit on the number of registered functions.

3. Support out params in overrides.  
To properly handle out params in overrides:  
- Accept all params in the handler
- Don't pass out params to the wrapped function
- Return all results from the handler
```lua
registerForEvent('onInit', function()
    Override('SpatialQueriesSystem', 'SyncRaycastByCollisionGroup', function(_, a1, a2, a3, a4, a5, a6, wrapped)
        -- Skip a4 here because it's an out param
        local success, result = wrapped(a1, a2, a3, a5, a6)
        print(success, GameDump(result))

        -- Return all results
        return success, result
    end)
end)

registerHotkey('SyncRaycastByCollisionGroup', 'SyncRaycastByCollisionGroup', function()
    local from, forward = Game.GetTargetingSystem():GetCrosshairData(GetPlayer())
    local to = Vector4.new(from.x + forward.x * 100, from.y + forward.y * 100, from.z + forward.z * 100, from.w)

    local success, result = Game.GetSpatialQueriesSystem():SyncRaycastByCollisionGroup(from, to, 'Static', false, false)
    print(success, GameDump(result))
end)
```

4. Added event for early TweakDB changes:
```lua
registerForEvent('onTweak', function()
	TweakDB:SetFlat('PreventionSystem.setup.totalEntitiesLimit', 20)
end)
```