### PR TITLE
Stability hotfix for overrides

### DIFF
--- a/src/overlay/widgets/TweakDBEditor.cpp
+++ b/src/overlay/widgets/TweakDBEditor.cpp
@@ -1516,7 +1516,6 @@ bool TweakDBEditor::DrawFlatCName(RED4ext::TweakDBID aDBID, RED4ext::CStackType&
 {
     auto* pCName = static_cast<RED4ext::CName*>(aStackType.value);
 
-    ImGui::TextUnformatted("This is not just a string.");
     ImGui::TextUnformatted("Game is expecting specific values.");
     // Is it worth it to implement a dropdown like DrawTweakDBID?
 

--- a/src/reverse/RTTIMapper.h
+++ b/src/reverse/RTTIMapper.h
@@ -12,6 +12,7 @@ struct RTTIMapper
     void Register();
 
     static void SanitizeName(std::string& aName);
+    static RED4ext::CName TryResolveTypeName(sol::object aValue);
 
 private:
 

--- a/src/reverse/TweakDB.h
+++ b/src/reverse/TweakDB.h
@@ -25,6 +25,10 @@ struct TweakDB
     bool SetFlat(TweakDBID aDBID, sol::object aObject, sol::this_environment aThisEnv);
     bool SetFlatByNameAutoUpdate(const std::string& acFlatName, sol::object aObject, sol::this_environment aThisEnv);
     bool SetFlatAutoUpdate(TweakDBID aDBID, sol::object aObject, sol::this_environment aThisEnv);
+    bool SetTypedFlatByName(const std::string& acFlatName, sol::object aObject, const std::string& acTypeName,
+                            sol::this_environment aThisEnv);
+    bool SetTypedFlat(TweakDBID aDBID, sol::object aObject, const std::string& acTypeName,
+                      sol::this_environment aThisEnv);
     bool UpdateRecordByName(const std::string& acRecordName);
     bool UpdateRecordByID(TweakDBID aDBID);
     bool UpdateRecord(sol::object aValue, sol::this_environment aThisEnv);
@@ -35,8 +39,12 @@ struct TweakDB
     bool CloneRecord(const std::string& acRecordName, TweakDBID aClonedRecordDBID, sol::this_environment aThisEnv);
     bool DeleteRecord(const std::string& acRecordName, sol::this_environment aThisEnv);
 
+    static void RefreshFlatPools();
+
 protected:
     friend struct TweakDBEditor;
+    bool SetOrCreateFlat(TweakDBID aDBID, sol::object aObject, const std::string& acFlatName,
+                         const std::string& acTypeName, std::shared_ptr<spdlog::logger> aLogger = nullptr);
     static int32_t InternalSetFlat(RED4ext::TweakDBID aDBID, const RED4ext::CStackType& acStackType);
     static bool InternalCreateRecord(const std::string& acRecordName, const std::string& acRecordTypeName,
                                      std::shared_ptr<spdlog::logger> aLogger = nullptr);

--- a/src/scripting/FunctionOverride.cpp
+++ b/src/scripting/FunctionOverride.cpp
@@ -302,6 +302,9 @@ bool FunctionOverride::ExecuteChain(const CallChain& aChain, std::shared_lock<st
                                     RED4ext::CScriptStack* apStack, RED4ext::CStackFrame* apFrame,
                                     char* apCode, uint8_t aParam)
 {
+    auto lockedState = aChain.pScripting->GetState();
+    auto& luaState = lockedState.Get();
+
     if (!aChain.Before.empty())
     {
         for (const auto& call : aChain.Before)
@@ -324,9 +327,6 @@ bool FunctionOverride::ExecuteChain(const CallChain& aChain, std::shared_lock<st
         sol::object luaContext = pRealFunction->flags.isStatic ? sol::nil : apOrigArgs->at(0);
         TiltedPhoques::Vector<sol::object> luaArgs(apOrigArgs->begin() + (pRealFunction->flags.isStatic ? 0 : 1),
                                                    apOrigArgs->end());
-
-        auto lockedState = aChain.pScripting->GetState();
-        auto& luaState = lockedState.Get();
 
         auto luaWrapped = WrapNextOverride(aChain, 0, luaState, luaContext, luaArgs, pRealFunction, apContext, aLock);
         auto luaResult = luaWrapped(as_args(luaArgs));

--- a/src/scripting/FunctionOverride.cpp
+++ b/src/scripting/FunctionOverride.cpp
@@ -102,6 +102,9 @@ bool FunctionOverride::HookRunPureScriptFunction(RED4ext::CClassFunction* apFunc
 
         if (!chain.IsEmpty)
         {
+            auto lockedState = chain.pScripting->GetState();
+            auto& luaState = lockedState.Get();
+
             TiltedPhoques::StackAllocator<1 << 13> s_allocator;
 
             auto pAllocator = TiltedPhoques::Allocator::Get();
@@ -110,14 +113,12 @@ bool FunctionOverride::HookRunPureScriptFunction(RED4ext::CClassFunction* apFunc
             TiltedPhoques::Vector<RED4ext::CStackType> outArgs;
             TiltedPhoques::Allocator::Set(pAllocator);
 
-            auto state = chain.pScripting->GetState();
-
             auto pContext = apStack->GetContext();
             if (!apFunction->flags.isStatic && pContext)
             {
                 const auto weak = RED4ext::WeakHandle<RED4ext::IScriptable>(
                     *(RED4ext::WeakHandle<RED4ext::IScriptable>*)&pContext->ref);
-                auto obj = sol::make_object(state.Get(), WeakReference(state, weak));
+                auto obj = sol::make_object(luaState, WeakReference(lockedState, weak));
 
                 args.push_back(obj);
             }
@@ -130,7 +131,7 @@ bool FunctionOverride::HookRunPureScriptFunction(RED4ext::CClassFunction* apFunc
                 arg.type = p->type;
                 arg.value = pOffset;
 
-                args.push_back(Scripting::ToLua(state, arg));
+                args.push_back(Scripting::ToLua(lockedState, arg));
 
                 if (p->flags.isOut)
                     outArgs.push_back(arg);
@@ -171,7 +172,6 @@ void FunctionOverride::HandleOverridenFunction(RED4ext::IScriptable* apContext, 
     }
 
     const auto& chain = itor->second;
-    bool isOverridden = false;
 
     // Save state so we can rollback to it after we popped for ourself
     auto* pCode = apFrame->code;
@@ -179,6 +179,9 @@ void FunctionOverride::HandleOverridenFunction(RED4ext::IScriptable* apContext, 
 
     if (!chain.IsEmpty)
     {
+        auto lockedState = chain.pScripting->GetState();
+        auto& luaState = lockedState.Get();
+
         // Cheap allocation
         TiltedPhoques::StackAllocator<1 << 13> s_allocator;
 
@@ -187,8 +190,6 @@ void FunctionOverride::HandleOverridenFunction(RED4ext::IScriptable* apContext, 
         TiltedPhoques::Vector<sol::object> args;
         TiltedPhoques::Vector<RED4ext::CStackType> outArgs;
         TiltedPhoques::Allocator::Set(pAllocator);
-
-        auto state = chain.pScripting->GetState();
 
         RED4ext::CStackType self;
 
@@ -207,7 +208,7 @@ void FunctionOverride::HandleOverridenFunction(RED4ext::IScriptable* apContext, 
 
             const auto ref = (RED4ext::WeakHandle<RED4ext::IScriptable>*)&((RED4ext::IScriptable*)self.value)->ref;
             const auto weak = RED4ext::WeakHandle<RED4ext::IScriptable>(*ref);
-            auto obj = sol::make_object(state.Get(), WeakReference(state, weak));
+            auto obj = sol::make_object(luaState, WeakReference(lockedState, weak));
 
             args.push_back(obj);
         }
@@ -245,7 +246,7 @@ void FunctionOverride::HandleOverridenFunction(RED4ext::IScriptable* apContext, 
             const auto opcode = *(apFrame->code++);
             RED4ext::OpcodeHandlers::Run(opcode, (RED4ext::IScriptable*)apFrame->context, apFrame, pInstance, isScriptRef ? pInstance : nullptr);
 
-            args.push_back(Scripting::ToLua(state, arg));
+            args.push_back(Scripting::ToLua(lockedState, arg));
 
             if (pArg->flags.isOut)
             {
@@ -270,7 +271,7 @@ void FunctionOverride::HandleOverridenFunction(RED4ext::IScriptable* apContext, 
                 pAllocator->Free(pInstance);
             }
         }
-        
+
         apFrame->code++; // skip ParamEnd
 
         RED4ext::CStackType ret;
@@ -296,7 +297,7 @@ void FunctionOverride::HandleOverridenFunction(RED4ext::IScriptable* apContext, 
 }
 
 bool FunctionOverride::ExecuteChain(const CallChain& aChain, std::shared_lock<std::shared_mutex>& aLock,
-                                    RED4ext::IScriptable* apContext, TiltedPhoques::Vector<sol::object>* apOrigArgs, 
+                                    RED4ext::IScriptable* apContext, TiltedPhoques::Vector<sol::object>* apOrigArgs,
                                     RED4ext::CStackType* apResult, TiltedPhoques::Vector<RED4ext::CStackType>* apOutArgs,
                                     RED4ext::CScriptStack* apStack, RED4ext::CStackFrame* apFrame,
                                     char* apCode, uint8_t aParam)
@@ -500,7 +501,7 @@ void FunctionOverride::Hook(Options& aOptions) const
     }
 }
 
-void FunctionOverride::Override(const std::string& acTypeName, const std::string& acFullName, 
+void FunctionOverride::Override(const std::string& acTypeName, const std::string& acFullName,
                                 sol::protected_function aFunction, sol::environment aEnvironment,
                                 bool aAbsolute, bool aAfter, bool aCollectGarbage)
 {

--- a/src/scripting/ScriptContext.cpp
+++ b/src/scripting/ScriptContext.cpp
@@ -59,7 +59,7 @@ ScriptContext::ScriptContext(LuaSandbox& aLuaSandbox, const std::filesystem::pat
             m_logger->error("Tried to register an unknown event '{}'!", acName);
     };
 
-    env["registerHotkey"] = [this](const std::string& acID, const std::string& acDescription, sol::function aCallback)
+    env["registerHotkey"] = [this, &aLuaSandbox](const std::string& acID, const std::string& acDescription, sol::function aCallback)
     {
         if (acID.empty() ||
             (std::ranges::find_if(acID, [](char c){ return !(isalpha(c) || isdigit(c) || c == '_'); }) != acID.cend()))
@@ -76,15 +76,16 @@ ScriptContext::ScriptContext(LuaSandbox& aLuaSandbox, const std::filesystem::pat
 
         auto loggerRef = m_logger;
         std::string vkBindID = m_name + '.' + acID;
-        VKBind vkBind = {vkBindID, acDescription, [loggerRef, aCallback]()
+        VKBind vkBind = {vkBindID, acDescription, [&aLuaSandbox, loggerRef, aCallback]()
         {
+            auto state = aLuaSandbox.GetState();
             TryLuaFunction(loggerRef, aCallback);
         }};
 
         m_vkBindInfos.emplace_back(VKBindInfo{vkBind});
     };
     
-    env["registerInput"] = [this](const std::string& acID, const std::string& acDescription, sol::function aCallback) {
+    env["registerInput"] = [this, &aLuaSandbox](const std::string& acID, const std::string& acDescription, sol::function aCallback) {
         if (acID.empty() ||
             (std::ranges::find_if(acID, [](char c) { return !(isalpha(c) || isdigit(c) || c == '_'); }) != acID.cend()))
         {
@@ -103,8 +104,9 @@ ScriptContext::ScriptContext(LuaSandbox& aLuaSandbox, const std::filesystem::pat
 
         auto loggerRef = m_logger;
         std::string vkBindID = m_name + '.' + acID;
-        VKBind vkBind = {vkBindID, acDescription, [loggerRef, aCallback](bool isDown)
+        VKBind vkBind = {vkBindID, acDescription, [&aLuaSandbox, loggerRef, aCallback](bool isDown)
         {
+            auto state = aLuaSandbox.GetState();
             TryLuaFunction(loggerRef, aCallback, isDown);
         }};
 

--- a/src/scripting/Scripting.cpp
+++ b/src/scripting/Scripting.cpp
@@ -446,7 +446,7 @@ void Scripting::PostInitializeStage1()
         "Query", sol::overload(&TweakDB::QueryByName, &TweakDB::Query),
         "GetFlat", sol::overload(&TweakDB::GetFlatByName, &TweakDB::GetFlat),
         "SetFlats", sol::overload(&TweakDB::SetFlatsByName, &TweakDB::SetFlats),
-        "SetFlat", sol::overload(&TweakDB::SetFlatByNameAutoUpdate, &TweakDB::SetFlatAutoUpdate),
+        "SetFlat", sol::overload(&TweakDB::SetFlatByNameAutoUpdate, &TweakDB::SetFlatAutoUpdate, &TweakDB::SetTypedFlat, &TweakDB::SetTypedFlatByName),
         "SetFlatNoUpdate", sol::overload(&TweakDB::SetFlatByName, &TweakDB::SetFlat),
         "Update", sol::overload(&TweakDB::UpdateRecordByName, &TweakDB::UpdateRecordByID, &TweakDB::UpdateRecord),
         "CreateRecord", &TweakDB::CreateRecord,
@@ -565,6 +565,12 @@ void Scripting::PostInitializeStage2()
 
     luaVm["Game"] = this;
     luaGlobal["Game"] = luaVm["Game"];
+
+    // CET has its own flat pool manager
+    // If any other mod made changes to TweakDB, local flat pools will become invalid
+    // We assume that other mods only change TweakDB before the initialization state,
+    // so we refresh the local flat pools when enter this state
+    TweakDB::RefreshFlatPools();
 
     RTTIExtender::Initialize();
     m_mapper.Register();


### PR DESCRIPTION
- Fixed random crashes for very frequently called overrides (such as `GameObject.OnGameAttached` and `GameObject.OnDetach` on game reload).
- Fixed random crashes for hotkeys and inputs (for example, binding the mouse wheel had a very high chance of causing crashes).
- Fixed potential issues when CET mods that modify TweakDB are used with TweakDBext mods at the same time.
- Added the ability to add new free flats to TweakDB.

---

With more extensive use of overrides a new issue was discovered: the Lua stack could be corrupted because `TiltedPhoques::Vector<sol::object> args;` was placed before acquiring the lock `chain.pScripting->GetState()` allowing another thread in the multithreaded environment to perform garbage collection, call Lua functions, and corrupt references in `args`.

This leads to two possible outcomes based on what's currently on the Lua stack:
- A call to `sol::make_objec()` cannot push a new value onto the stack and throw.
- The elements of the `args` refer to random values on the stack and `call->ScriptFunction(as_args(args))` passes the random values to the Lua handler.
