### PR TITLE
Fix script references in overrides, fix structs

### DIFF
--- a/src/reverse/ClassReference.h
+++ b/src/reverse/ClassReference.h
@@ -7,10 +7,12 @@ struct ClassReference : ClassType
     ClassReference(const TiltedPhoques::Locked<sol::state, std::recursive_mutex>& aView,
                    RED4ext::CBaseRTTIType* apClass,
                    RED4ext::ScriptInstance apInstance);
+    ClassReference(ClassReference&& aOther) noexcept;
+    virtual ~ClassReference();
 
     virtual RED4ext::ScriptInstance GetHandle() const override;
     virtual RED4ext::ScriptInstance GetValuePtr() const override;
 
 private:
-    std::unique_ptr<uint8_t[]> m_pInstance;
+    RED4ext::ScriptInstance m_pInstance;
 };


### PR DESCRIPTION
- Fixed random crashes when overridden method has a script reference parameter. 
- Fixed random crashes when working with game structs.