### PR TITLE
Fix crash to desktop on Windows 7

### DIFF
--- a/src/kiero/kiero.cpp
+++ b/src/kiero/kiero.cpp
@@ -215,7 +215,9 @@ kiero::Status::Enum kiero::init()
 
     g_methodsTable = (uint150_t*)::calloc(176, sizeof(uint150_t));
 
-    g_swapChainVtable = *(void***)swapChain.operator IDXGISwapChain3 *();
+    if (!g_isDownLevelDevice)
+        g_swapChainVtable = *(void***)swapChain.operator IDXGISwapChain3 *();
+
     g_commandListVtable = *(void***)commandList.operator ID3D12GraphicsCommandList *();
     g_commandQueueVtable = *(void***)commandQueue.operator ID3D12CommandQueue*();
 


### PR DESCRIPTION
See title.

The vtable globals are actually never used (they were added in f21c0b2 but their usage was reverted in 246af04 without removing the globals themselves). So simply removing them completely would also work, especially since the Win 10 D3D12 hooks are now applied to the game instead of the D3D12/DXGI vtables anyway, and Win 7 also doesn't actually need them either, but I've left them for now.

It's possible that the new D3D12 hooking method can be made to work with D3D12on7 as well so that kiero can just be removed entirely, but I haven't really looked into that because the current method is pretty low maintenance at least.