### PR TITLE
Allow the use of TweakDBIDs in Create, Clone and DeleteRecord

### DIFF
--- a/src/reverse/TweakDB.h
+++ b/src/reverse/TweakDB.h
@@ -34,10 +34,14 @@ struct TweakDB
     bool UpdateRecord(sol::object aValue, sol::this_environment aThisEnv);
     bool CreateRecord(const std::string& acRecordName, const std::string& acRecordTypeName,
                       sol::this_environment aThisEnv);
+    bool CreateRecordToID(TweakDBID aDBID, const std::string& acRecordTypeName,
+                      sol::this_environment aThisEnv);
     bool CloneRecordByName(const std::string& acRecordName, const std::string& acClonedRecordName,
                            sol::this_environment aThisEnv);
     bool CloneRecord(const std::string& acRecordName, TweakDBID aClonedRecordDBID, sol::this_environment aThisEnv);
+    bool CloneRecordToID(TweakDBID aDBID, TweakDBID aClonedRecordDBID, sol::this_environment aThisEnv);
     bool DeleteRecord(const std::string& acRecordName, sol::this_environment aThisEnv);
+    bool DeleteRecordByID(TweakDBID aDBID, sol::this_environment aThisEnv);
 
     static void RefreshFlatPools();
 
@@ -48,13 +52,20 @@ protected:
     static int32_t InternalSetFlat(RED4ext::TweakDBID aDBID, const RED4ext::CStackType& acStackType);
     static bool InternalCreateRecord(const std::string& acRecordName, const std::string& acRecordTypeName,
                                      std::shared_ptr<spdlog::logger> aLogger = nullptr);
+    static bool InternalCreateRecordToID(TweakDBID aDBID, const std::string& acRecordTypeName,
+                                     std::shared_ptr<spdlog::logger> aLogger = nullptr);
     static bool InternalCloneRecord(const std::string& acRecordName, RED4ext::TweakDBID aClonedRecordDBID,
+                                    std::shared_ptr<spdlog::logger> aLogger = nullptr);
+    static bool InternalCloneRecordToID(TweakDBID aDBID, RED4ext::TweakDBID aClonedRecordDBID,
                                     std::shared_ptr<spdlog::logger> aLogger = nullptr);
     // Can't figure out a good name for this function.
     // Creates a record of the same type as 'acClonedRecord'
     // Creates all of its flats
     // Setting 'cloneValues' to false will set default values
     static bool InternalCloneRecord(const std::string& acRecordName,
+                                    const RED4ext::gamedataTweakDBRecord* acClonedRecord, bool cloneValues = true,
+                                    std::shared_ptr<spdlog::logger> aLogger = nullptr);
+    static bool InternalCloneRecordToID(TweakDBID aDBID,
                                     const RED4ext::gamedataTweakDBRecord* acClonedRecord, bool cloneValues = true,
                                     std::shared_ptr<spdlog::logger> aLogger = nullptr);
     static bool InternalDeleteRecord(RED4ext::TweakDBID aDBID, std::shared_ptr<spdlog::logger> aLogger = nullptr);

--- a/src/scripting/Scripting.cpp
+++ b/src/scripting/Scripting.cpp
@@ -450,9 +450,9 @@ void Scripting::PostInitializeStage1()
         "SetFlat", sol::overload(&TweakDB::SetFlatByNameAutoUpdate, &TweakDB::SetFlatAutoUpdate, &TweakDB::SetTypedFlat, &TweakDB::SetTypedFlatByName),
         "SetFlatNoUpdate", sol::overload(&TweakDB::SetFlatByName, &TweakDB::SetFlat),
         "Update", sol::overload(&TweakDB::UpdateRecordByName, &TweakDB::UpdateRecordByID, &TweakDB::UpdateRecord),
-        "CreateRecord", &TweakDB::CreateRecord,
-        "CloneRecord", sol::overload(&TweakDB::CloneRecordByName, &TweakDB::CloneRecord),
-        "DeleteRecord", &TweakDB::DeleteRecord);
+        "CreateRecord", sol::overload(&TweakDB::CreateRecordToID, &TweakDB::CreateRecord),
+        "CloneRecord", sol::overload(&TweakDB::CloneRecordByName, &TweakDB::CloneRecordToID, &TweakDB::CloneRecord),
+        "DeleteRecord", sol::overload(&TweakDB::DeleteRecordByID, &TweakDB::DeleteRecord));
 
     luaGlobal["TweakDB"] = TweakDB(m_lua.AsRef());
 


### PR DESCRIPTION
Currently CET's implementation of `CreateRecord`, `CloneRecord`, and `DeleteRecord` only allow the first parameter to be a string value. Update the functions to allow `TweakDBID`s for the first parameter.

Example:
```lua
-- Get the sticky frag grenade record
sticky_grenade = TweakDB:GetRecord("Items.GrenadeFragSticky")

-- Create a clone of "Items.GrenadeFragSticky" with the name "Items.GrenadeFragStickyNew"
TweakDB:CloneRecord(sticky_grenade:GetID() + "New", sticky_grenade:GetID())

-- Get the new record
sticky_grenade_new = TweakDB:GetRecord("Items.GrenadeFragStickyNew")
-- or
sticky_grenade_new = TweakDB:GetRecord(sticky_grenade:GetID() + "New")

-- manipulate the new record as needed

-- delete record many different ways
TweakDB:DeleteRecord(sticky_grenade_new:GetID())
TweakDB:DeleteRecord(sticky_grenade:GetID() + "New")
TweakDB:DeleteRecord("Items.GrenadeFragStickyNew")
```

`CreateRecord` works in a similar fashion.

Only minor thing is the lack of registering the string value of the record in the LuaVM since the actual string value is never explicitly typed out by the modder. But as shown above, the value can still accessed with the new name since it is hashed before being looked up.