### PR TITLE
TweakDBEditor: Add support for REDMod modified TweakDB

### DIFF
--- a/src/Paths.cpp
+++ b/src/Paths.cpp
@@ -35,6 +35,11 @@ const std::filesystem::path& Paths::ArchiveModsRoot() const
     return m_archiveModsRoot; 
 }
 
+const std::filesystem::path& Paths::R6CacheModdedRoot() const
+{
+    return m_r6CacheModdedRoot;
+}
+
 Paths::Paths()
 {
     TCHAR exePathBuf[MAX_PATH] = { 0 };
@@ -67,4 +72,11 @@ Paths::Paths()
     m_archiveModsRoot /= "archive";
     m_archiveModsRoot /= "pc";
     m_archiveModsRoot /= "mod";
+
+    m_r6CacheModdedRoot = m_gameRoot;
+    m_r6CacheModdedRoot /= "..";
+    m_r6CacheModdedRoot /= "..";
+    m_r6CacheModdedRoot /= "r6";
+    m_r6CacheModdedRoot /= "cache";
+    m_r6CacheModdedRoot /= "modded";
 }

--- a/src/Paths.h
+++ b/src/Paths.h
@@ -11,6 +11,7 @@ struct Paths
     const std::filesystem::path& VKBindings() const;
     const std::filesystem::path& ModsRoot() const;
     const std::filesystem::path& ArchiveModsRoot() const;
+    const std::filesystem::path& R6CacheModdedRoot() const;
 
 private:
 
@@ -25,4 +26,5 @@ private:
     std::filesystem::path m_vkBindings{ };
     std::filesystem::path m_modsRoot{ };
     std::filesystem::path m_archiveModsRoot{ };
+    std::filesystem::path m_r6CacheModdedRoot{};
 };


### PR DESCRIPTION
Adds support for reading and importing entries from the TweakDB created by REDMod.

The `HasREDModTweakDB` function isn't really needed since you can just check the file directly and doesn't have to be public if it's kept, but maybe it's good to have it in there if there's a need to check later. Not sure where though. Maybe it could be used to update the TweakDB Editor window to reflect that CET found a modified TweakDB. But if that's the case it might be better to move it to a function that checks that it was properly loaded like how `IsInitialized` is used.

Let me know what you think.