### PR TITLE
Fix Console history registering empty entries and LogWindow issues

### DIFF
--- a/src/overlay/widgets/LogWindow.cpp
+++ b/src/overlay/widgets/LogWindow.cpp
@@ -85,7 +85,10 @@ void LogWindow::Draw(const ImVec2& size)
                 ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0, 0));
 
                 ImGui::SetNextItemWidth(listItemWidth);
+
+                ImGui::PushID(i);
                 ImGui::InputText(("##" + item).c_str(), item.data(), item.size(), ImGuiInputTextFlags_ReadOnly);
+                ImGui::PopID();
 
                 ImGui::PopStyleVar(2);
                 ImGui::PopStyleColor(4);

--- a/src/scripting/LuaVM_Hooks.cpp
+++ b/src/scripting/LuaVM_Hooks.cpp
@@ -251,7 +251,7 @@ void LuaVM::HookLogChannel(RED4ext::IScriptable*, RED4ext::CStackFrame* apStack,
         if (channel == s_debugChannel)
             spdlog::get("gamelog")->debug("[{}] {}", channelSV, ref.ref->c_str());
         else if (channel == s_assertionChannel)
-            spdlog::get("gamelog")->warn("[{}] {}", channelSV, ref.ref->c_str());
+            spdlog::get("gamelog")->error("[{}] {}", channelSV, ref.ref->c_str());
         else
             spdlog::get("gamelog")->info("[{}] {}", channelSV, ref.ref->c_str());
     }


### PR DESCRIPTION
Smaller inconveniences fixed, not major bugs.
Concerns Console and LogWindow mostly.

Console trims commands now and also checks for empty strings before execution and saving command to history.
LogWindow should not allow you to start selecting multiple lines (at least visually).
LogChannel color changes for ~DEBUG~ and ASSERT channels (ASSERT is now red, ~DEBUG logs in Console window are printed as regular info~).

Striked got merged with previous PR from psiberx (missed it)