### PR TITLE
Expose extra properties in ImGuiListClipper

### DIFF
--- a/src/sol_imgui/sol_imgui.h
+++ b/src/sol_imgui/sol_imgui.h
@@ -1797,7 +1797,9 @@ namespace sol_ImGui
 
         luaGlobals.new_usertype<ImGuiListClipper>("ImGuiListClipper", sol::constructors<ImGuiListClipper()>(),
             "Begin"                              , &ImGuiListClipper::Begin,
-            "Step"                               , &ImGuiListClipper::Step
+            "Step"                               , &ImGuiListClipper::Step,
+            "DisplayStart"                       , &ImGuiListClipper::DisplayStart,
+            "DisplayEnd"                         , &ImGuiListClipper::DisplayEnd
         );
     }
 


### PR DESCRIPTION
Forgot to expose DisplayStart and DisplayEnd in #739 