### PR TITLE
More hotfixes for 1.21.0

### DIFF
--- a/src/reverse/RTTIMapper.cpp
+++ b/src/reverse/RTTIMapper.cpp
@@ -217,11 +217,13 @@ void RTTIMapper::RegisterSpecialAccessors(sol::state& aLuaState, sol::table& aLu
 
     // Merge RTTI versions of basic types with our own versions
     // Allows usertype and RTTI functions to be used under the same name
-    ExtendUsertype<Vector3>("Vector3", aLuaState, aLuaGlobal);
     ExtendUsertype<Vector4>("Vector4", aLuaState, aLuaGlobal);
     ExtendUsertype<EulerAngles>("EulerAngles", aLuaState, aLuaGlobal);
     ExtendUsertype<Quaternion>("Quaternion", aLuaState, aLuaGlobal);
     ExtendUsertype<ItemID>("ItemID", aLuaState, aLuaGlobal);
+
+    // Replace RTTI version of class with our own version
+    aLuaGlobal["Vector3"] = aLuaState["Vector3"];
 }
 
 template <class T>

--- a/src/reverse/RTTIMapper.cpp
+++ b/src/reverse/RTTIMapper.cpp
@@ -29,11 +29,11 @@ void RTTIMapper::Register()
 
     auto* pRtti = RED4ext::CRTTISystem::Get();
 
-    RegisterSimpleTypes(luaState, m_sandbox.GetEnvironment());
-    RegisterDirectTypes(luaState, m_sandbox.GetEnvironment(), pRtti);
-    RegisterDirectGlobals(m_sandbox.GetEnvironment(), pRtti);
-    RegisterScriptAliases(m_sandbox.GetEnvironment(), pRtti);
-    RegisterSpecialAccessors(luaState, m_sandbox.GetEnvironment());
+    RegisterSimpleTypes(luaState, m_sandbox.GetGlobals());
+    RegisterDirectTypes(luaState, m_sandbox.GetGlobals(), pRtti);
+    RegisterDirectGlobals(m_sandbox.GetGlobals(), pRtti);
+    RegisterScriptAliases(m_sandbox.GetGlobals(), pRtti);
+    RegisterSpecialAccessors(luaState, m_sandbox.GetGlobals());
 }
 
 void RTTIMapper::Refresh()

--- a/src/reverse/Type.cpp
+++ b/src/reverse/Type.cpp
@@ -258,12 +258,7 @@ sol::object ClassType::Index_Impl(const std::string& acName, sol::this_environme
     const auto func = RTTIHelper::Get().ResolveFunction(pClass, acName, pHandle != nullptr);
 
     if (!func)
-    {
-        const sol::environment cEnv = aThisEnv;
-        const auto logger = cEnv["__logger"].get<std::shared_ptr<spdlog::logger>>();
-        logger->warn("Warning: {} not found in {}.", acName, GetName());
         return sol::nil;
-    }
 
     return NewIndex(acName, func);
 }

--- a/src/scripting/LuaSandbox.cpp
+++ b/src/scripting/LuaSandbox.cpp
@@ -106,6 +106,10 @@ static constexpr const char* s_cPostInitializeScriptingProtectedList[] =
     "CRUID",
     "LocKey",
     "GameOptions",
+    "Override",
+    "ObserveBefore",
+    "ObserveAfter",
+    "Observe",
 };
 
 static constexpr const char* s_cPostInitializeTweakDBProtectedList[] =
@@ -119,10 +123,6 @@ static constexpr const char* s_cPostInitializeModsProtectedList[] =
     // initialized by Scripting
     "NewObject",
     "GetSingleton",
-    "Override",
-    "ObserveBefore",
-    "ObserveAfter",
-    "Observe",
     "GetMod",
     "GameDump",
     "Dump",

--- a/src/scripting/LuaSandbox.cpp
+++ b/src/scripting/LuaSandbox.cpp
@@ -131,7 +131,6 @@ static constexpr const char* s_cPostInitializeModsProtectedList[] =
     "DumpVtables",
     "DumpReflection",
     "Game",
-    "RegisterGlobalInputListener",
 
     // initialized by RTTIMapper
     "Vector3",
@@ -265,16 +264,6 @@ uint64_t LuaSandbox::CreateSandbox(const std::filesystem::path& acPath, const st
     return cResID;
 }
 
-sol::protected_function_result LuaSandbox::ExecuteFile(const std::string& acPath) const
-{
-    return m_pScripting->GetLockedState().Get().script_file(acPath, m_env, sol::load_mode::text);
-}
-
-sol::protected_function_result LuaSandbox::ExecuteString(const std::string& acString) const
-{
-    return m_pScripting->GetLockedState().Get().script(acString, m_env, sol:: detail::default_chunk_name(), sol::load_mode::text);
-}
-
 Sandbox& LuaSandbox::operator[](uint64_t aID)
 {
     assert(aID < m_sandboxes.size());
@@ -304,7 +293,7 @@ bool LuaSandbox::GetImGuiAvailable() const
     return m_imguiAvailable;
 }
 
-sol::environment& LuaSandbox::GetEnvironment()
+sol::table& LuaSandbox::GetEnvironment()
 {
     return m_env;
 }

--- a/src/scripting/LuaSandbox.h
+++ b/src/scripting/LuaSandbox.h
@@ -24,7 +24,7 @@ struct LuaSandbox
     void SetImGuiAvailable(bool aAvailable);
     bool GetImGuiAvailable() const;
 
-    sol::table& GetEnvironment();
+    sol::table& GetGlobals();
 
 private:
 
@@ -37,7 +37,7 @@ private:
 
     Scripting* m_pScripting;
     const VKBindings& m_vkBindings;
-    sol::table m_env{};
+    sol::table m_globals{};
     TiltedPhoques::Vector<Sandbox> m_sandboxes{};
     TiltedPhoques::Map<std::string, sol::object> m_modules{};
 

--- a/src/scripting/LuaSandbox.h
+++ b/src/scripting/LuaSandbox.h
@@ -16,9 +16,6 @@ struct LuaSandbox
 
     uint64_t CreateSandbox(const std::filesystem::path& acPath = "", const std::string& acName = "", bool aEnableExtraLibs = true, bool aEnableDB = true, bool aEnableIO = true, bool aEnableLogger = true);
 
-    sol::protected_function_result ExecuteFile(const std::string& acPath) const;
-    sol::protected_function_result ExecuteString(const std::string& acString) const;
-
     Sandbox& operator[](uint64_t aID);
     const Sandbox& operator[](uint64_t aID) const;
 
@@ -27,7 +24,7 @@ struct LuaSandbox
     void SetImGuiAvailable(bool aAvailable);
     bool GetImGuiAvailable() const;
 
-    sol::environment& GetEnvironment();
+    sol::table& GetEnvironment();
 
 private:
 
@@ -40,7 +37,7 @@ private:
 
     Scripting* m_pScripting;
     const VKBindings& m_vkBindings;
-    sol::environment m_env{};
+    sol::table m_env{};
     TiltedPhoques::Vector<Sandbox> m_sandboxes{};
     TiltedPhoques::Map<std::string, sol::object> m_modules{};
 

--- a/src/scripting/Sandbox.cpp
+++ b/src/scripting/Sandbox.cpp
@@ -3,7 +3,7 @@
 #include "Sandbox.h"
 #include "Scripting.h"
 
-Sandbox::Sandbox(uint64_t aId, Scripting* apScripting, sol::environment aBaseEnvironment, const std::filesystem::path& acRootPath)
+Sandbox::Sandbox(uint64_t aId, Scripting* apScripting, sol::table aBaseEnvironment, const std::filesystem::path& acRootPath)
     : m_id(aId)
     , m_pScripting(apScripting)
     , m_env(apScripting->GetLockedState().Get(), sol::create, aBaseEnvironment)

--- a/src/scripting/Sandbox.h
+++ b/src/scripting/Sandbox.h
@@ -4,7 +4,7 @@ struct Scripting;
 
 struct Sandbox
 {
-    Sandbox(uint64_t aId, Scripting* apScripting, sol::environment aBaseEnvironment, const std::filesystem::path& acRootPath);
+    Sandbox(uint64_t aId, Scripting* apScripting, sol::table aBaseEnvironment, const std::filesystem::path& acRootPath);
     ~Sandbox() = default;
 
     sol::protected_function_result ExecuteFile(const std::string& acPath) const;

--- a/src/scripting/Scripting.cpp
+++ b/src/scripting/Scripting.cpp
@@ -64,7 +64,7 @@ void Scripting::Initialize()
     // initialize sandbox
     m_sandbox.Initialize();
 
-    auto& globals = m_sandbox.GetEnvironment();
+    auto& globals = m_sandbox.GetGlobals();
 
     // load in imgui bindings
     sol_ImGui::InitBindings(luaVm, globals);
@@ -151,7 +151,7 @@ void Scripting::PostInitializeScripting()
 {
     auto lua = m_lua.Lock();
     auto& luaVm = lua.Get();
-    auto& globals = m_sandbox.GetEnvironment();
+    auto& globals = m_sandbox.GetGlobals();
 
     if (luaVm["__Game"] != sol::nil)
     {
@@ -488,7 +488,7 @@ void Scripting::PostInitializeTweakDB()
 {
     auto lua = m_lua.Lock();
     auto& luaVm = lua.Get();
-    auto& globals = m_sandbox.GetEnvironment();
+    auto& globals = m_sandbox.GetGlobals();
 
     luaVm.new_usertype<TweakDB>("__TweakDB",
         sol::meta_function::construct, sol::no_constructor,
@@ -516,7 +516,7 @@ void Scripting::PostInitializeMods()
 {
     auto lua = m_lua.Lock();
     auto& luaVm = lua.Get();
-    auto& globals = m_sandbox.GetEnvironment();
+    auto& globals = m_sandbox.GetGlobals();
 
     globals["NewObject"] = [this](const std::string& acName, sol::this_environment aEnv) -> sol::object
     {

--- a/src/scripting/Scripting.cpp
+++ b/src/scripting/Scripting.cpp
@@ -616,9 +616,8 @@ void Scripting::RegisterOverrides()
 {
     auto lua = m_lua.Lock();
     auto& luaVm = lua.Get();
-    auto& globals = m_sandbox.GetEnvironment();
 
-    globals["RegisterGlobalInputListener"] = [](WeakReference& aSelf, sol::this_environment aThisEnv) {
+    luaVm["RegisterGlobalInputListener"] = [](WeakReference& aSelf, sol::this_environment aThisEnv) {
         const sol::protected_function unregisterInputListener = aSelf.Index("UnregisterInputListener", aThisEnv);
         const sol::protected_function registerInputListener = aSelf.Index("RegisterInputListener", aThisEnv);
 
@@ -626,7 +625,7 @@ void Scripting::RegisterOverrides()
         registerInputListener(aSelf, aSelf);
     };
 
-    m_override.Override("PlayerPuppet", "GracePeriodAfterSpawn", globals["RegisterGlobalInputListener"], sol::nil, false, false, true);
+    m_override.Override("PlayerPuppet", "GracePeriodAfterSpawn", luaVm["RegisterGlobalInputListener"], sol::nil, false, false, true);
     m_override.Override("PlayerPuppet", "OnDetach", sol::nil, sol::nil, false, false, true);
     m_override.Override("QuestTrackerGameController", "OnUninitialize", sol::nil, sol::nil, false, false, true);
 }

--- a/src/scripting/Scripting.cpp
+++ b/src/scripting/Scripting.cpp
@@ -462,6 +462,23 @@ void Scripting::PostInitializeScripting()
         "Dump", &GameOptions::Dump,
         "List", &GameOptions::List);
 
+    globals["Override"] = [this](const std::string& acTypeName, const std::string& acFullName,
+                                 sol::protected_function aFunction, sol::this_environment aThisEnv) -> void {
+        m_override.Override(acTypeName, acFullName, aFunction, aThisEnv, true);
+    };
+
+    globals["ObserveBefore"] = [this](const std::string& acTypeName, const std::string& acFullName,
+                                      sol::protected_function aFunction, sol::this_environment aThisEnv) -> void {
+        m_override.Override(acTypeName, acFullName, aFunction, aThisEnv, false, false);
+    };
+
+    globals["ObserveAfter"] = [this](const std::string& acTypeName, const std::string& acFullName,
+                                     sol::protected_function aFunction, sol::this_environment aThisEnv) -> void {
+        m_override.Override(acTypeName, acFullName, aFunction, aThisEnv, false, true);
+    };
+
+    globals["Observe"] = globals["ObserveBefore"];
+
     m_sandbox.PostInitializeScripting();
 
     TriggerOnHook();
@@ -523,23 +540,6 @@ void Scripting::PostInitializeMods()
     {
         return this->GetSingletonHandle(acName, aThisEnv);
     };
-
-    globals["Override"] = [this](const std::string& acTypeName, const std::string& acFullName,
-                                   sol::protected_function aFunction, sol::this_environment aThisEnv) -> void {
-        m_override.Override(acTypeName, acFullName, aFunction, aThisEnv, true);
-    };
-
-    globals["ObserveBefore"] = [this](const std::string& acTypeName, const std::string& acFullName,
-                                        sol::protected_function aFunction, sol::this_environment aThisEnv) -> void {
-        m_override.Override(acTypeName, acFullName, aFunction, aThisEnv, false, false);
-    };
-
-    globals["ObserveAfter"] = [this](const std::string& acTypeName, const std::string& acFullName,
-                                       sol::protected_function aFunction, sol::this_environment aThisEnv) -> void {
-        m_override.Override(acTypeName, acFullName, aFunction, aThisEnv, false, true);
-    };
-
-    globals["Observe"] = globals["ObserveBefore"];
 
     globals["GetMod"] = [this](const std::string& acName) -> sol::object
     {


### PR DESCRIPTION
- Returned `Vector3` type to previous behavior
- Enabled overrides for new `onHook` event
- Disabled warning "Member not found" which was more annoying than helpful and could in rare cases result in c++ exceptions
- Adjusted the global fallback table for sandboxes to not be confused with environments (the global table must only be used as a lookup fallback table and never as an environment)
- Removed unused `LuaSandbox::ExecuteFile` and `LuaSandbox::ExecuteString`