### PR TITLE
Better mod logging

### DIFF
--- a/src/overlay/Overlay.cpp
+++ b/src/overlay/Overlay.cpp
@@ -259,11 +259,10 @@ void Overlay::Hook()
 }
 
 Overlay::Overlay(D3D12& aD3D12, VKBindings& aBindings, Options& aOptions, LuaVM& aVm)
-    : m_console(aD3D12, aVm)
+    : m_console(aVm)
     , m_bindings(aBindings, aVm)
     , m_settings(aOptions, aVm)
     , m_tweakDBEditor(aVm)
-    , m_gameLog(aD3D12)
     , m_d3d12(aD3D12)
     , m_options(aOptions)
     , m_vm(aVm)

--- a/src/overlay/widgets/Console.cpp
+++ b/src/overlay/widgets/Console.cpp
@@ -5,10 +5,9 @@
 #include <scripting/LuaVM.h>
 #include <Utils.h>
 
-Console::Console(D3D12& aD3D12, LuaVM& aVm)
-    : Widget("Console")
+Console::Console(LuaVM& aVm)
+    : LogWindow("Console", "scripting")
     , m_vm(aVm)
-    , m_logWindow(aD3D12, "scripting")
 {
     m_command.resize(255);
 }
@@ -81,7 +80,7 @@ void Console::OnUpdate()
 {
     const auto& style = ImGui::GetStyle();
     const auto inputLineHeight = ImGui::GetTextLineHeight() + style.ItemInnerSpacing.y * 2;
-    m_logWindow.Draw({-FLT_MIN, -(inputLineHeight + style.ItemSpacing.y)});
+    DrawLog({-FLT_MIN, -(inputLineHeight + style.ItemSpacing.y)});
 
     ImGui::SetNextItemWidth(-FLT_MIN);
     constexpr auto flags = ImGuiInputTextFlags_EnterReturnsTrue | ImGuiInputTextFlags_AllowTabInput | ImGuiInputTextFlags_CallbackHistory | ImGuiInputTextFlags_CallbackResize;

--- a/src/overlay/widgets/Console.h
+++ b/src/overlay/widgets/Console.h
@@ -1,13 +1,11 @@
 #pragma once
 
-#include "Widget.h"
 #include "LogWindow.h"
 
-struct D3D12;
 struct LuaVM;
-struct Console : Widget
+struct Console : LogWindow
 {
-    Console(D3D12& aD3D12, LuaVM& aVm);
+    Console(LuaVM& aVm);
     ~Console() override = default;
 
     WidgetResult OnDisable() override;
@@ -21,7 +19,6 @@ private:
     static int HandleConsole(ImGuiInputTextCallbackData* apData);
 
     LuaVM& m_vm;
-    LogWindow m_logWindow;
 
     TiltedPhoques::Vector<std::string> m_history;
     size_t m_historyIndex{ 0 };

--- a/src/overlay/widgets/GameLog.cpp
+++ b/src/overlay/widgets/GameLog.cpp
@@ -2,13 +2,7 @@
 
 #include "GameLog.h"
 
-GameLog::GameLog(D3D12& aD3D12)
-    : Widget("Game Log")
-    , m_logWindow(aD3D12, "gamelog")
+GameLog::GameLog()
+    : LogWindow("Game Log", "gamelog")
 {
-}
-
-void GameLog::OnUpdate()
-{
-    m_logWindow.Draw({-FLT_MIN, -FLT_MIN});
 }

--- a/src/overlay/widgets/GameLog.h
+++ b/src/overlay/widgets/GameLog.h
@@ -1,17 +1,9 @@
 #pragma once
 
-#include "Widget.h"
 #include "LogWindow.h"
 
-struct D3D12;
-struct GameLog : Widget
+struct GameLog : LogWindow
 {
-    GameLog(D3D12& aD3D12);
+    GameLog();
     ~GameLog() override = default;
-
-protected:
-    void OnUpdate() override;
-
-private:
-    LogWindow m_logWindow;
 };

--- a/src/overlay/widgets/LogWindow.cpp
+++ b/src/overlay/widgets/LogWindow.cpp
@@ -2,11 +2,10 @@
 
 #include "LogWindow.h"
 
-#include <d3d12/D3D12.h>
 #include <Utils.h>
 
-LogWindow::LogWindow(D3D12& aD3D12, const std::string& acpLoggerName)
-    : m_d3d12(aD3D12)
+LogWindow::LogWindow(const std::string& acpWindowTitle, const std::string& acpLoggerName)
+    : Widget(acpWindowTitle)
     , m_loggerName(acpLoggerName)
 {
     auto logSink = CreateCustomSinkMT([this](const std::string& msg){ Log(msg); });
@@ -14,7 +13,12 @@ LogWindow::LogWindow(D3D12& aD3D12, const std::string& acpLoggerName)
     spdlog::get(m_loggerName)->sinks().emplace_back(std::move(logSink));
 }
 
-void LogWindow::Draw(const ImVec2& size)
+void LogWindow::OnUpdate()
+{
+    DrawLog({-FLT_MIN, -FLT_MIN});
+}
+
+void LogWindow::DrawLog(const ImVec2& size)
 {
     const auto itemWidth = GetAlignedItemWidth(2);
 

--- a/src/overlay/widgets/LogWindow.cpp
+++ b/src/overlay/widgets/LogWindow.cpp
@@ -57,7 +57,7 @@ void LogWindow::Draw(const ImVec2& size)
                 switch (level)
                 {
                 case spdlog::level::level_enum::trace:
-                    ImGui::PushStyleColor(ImGuiCol_Text, ImVec4{0.0f, 0.0f, 1.0f, 1.0f});
+                    ImGui::PushStyleColor(ImGuiCol_Text, ImVec4{0.0f, 1.0f, 1.0f, 1.0f});
                     break;
 
                 case spdlog::level::level_enum::debug:

--- a/src/overlay/widgets/LogWindow.h
+++ b/src/overlay/widgets/LogWindow.h
@@ -1,16 +1,18 @@
 #pragma once
 
-struct D3D12;
-struct LogWindow
-{
-    LogWindow(D3D12& aD3D12, const std::string& acpLoggerName);
+#include "Widget.h"
 
-    void Draw(const ImVec2& size);
+struct LogWindow : Widget
+{
+    LogWindow(const std::string& acpWindowTitle, const std::string& acpLoggerName);
+
+protected:
+    void OnUpdate() override;
+
+    void DrawLog(const ImVec2& size);
 
 private:
     void Log(const std::string& acpText);
-
-    D3D12& m_d3d12;
 
     std::string m_loggerName;
     float m_normalizedWidth{ -1.0f };

--- a/src/scripting/LuaSandbox.cpp
+++ b/src/scripting/LuaSandbox.cpp
@@ -187,7 +187,7 @@ void LuaSandbox::Initialize()
         m_globals["os"] = osCopy;
     }
 
-    CreateSandbox("", "", false, false, false, false);
+    CreateSandbox("", "", false, false, false, true);
 }
 
 void LuaSandbox::PostInitializeScripting()
@@ -258,9 +258,9 @@ uint64_t LuaSandbox::CreateSandbox(const std::filesystem::path& acPath, const st
             InitializeDBForSandbox(res, luaState);
         if (aEnableIO)
             InitializeIOForSandbox(res, luaState, acName);
-        if (aEnableLogger)
-            InitializeLoggerForSandbox(res, luaState, acName);
     }
+    if (aEnableLogger)
+        InitializeLoggerForSandbox(res, luaState, acName);
     return cResID;
 }
 
@@ -653,20 +653,48 @@ void LuaSandbox::InitializeLoggerForSandbox(Sandbox& aSandbox, const sol::state&
     const auto& cSBRootPath = aSandbox.GetRootPath();
 
     // initialize logger for this mod
-    auto logger = CreateLogger(GetAbsolutePath(acName + ".log", cSBRootPath, true), acName);
-
-    // assign logger to mod so it can be used from within it too
-    sol::table spdlog(acpState, sol::create);
-    spdlog["trace"]    = [logger](const std::string& message) { logger->trace("{}", message);    };
-    spdlog["debug"]    = [logger](const std::string& message) { logger->debug("{}", message);    };
-    spdlog["info"]     = [logger](const std::string& message) { logger->info("{}", message);     };
-    spdlog["warning"]  = [logger](const std::string& message) { logger->warn("{}", message);     };
-    spdlog["error"]    = [logger](const std::string& message) { logger->error("{}", message);    };
-    spdlog["critical"] = [logger](const std::string& message) { logger->critical("{}", message); };
-    sbEnv["spdlog"] = spdlog;
+    auto logger = acName.empty() ? spdlog::get("scripting") : CreateLogger(GetAbsolutePath(acName + ".log", cSBRootPath, true), acName);
 
     // assign logger to special var so we can access it from our functions
     sbEnv["__logger"] = logger;
+
+    // assign logger to mod so it can be used from within it too
+    sol::table modLog(acpState, sol::create);
+
+    auto logMessage = [logger](spdlog::level::level_enum aLogLevel, sol::variadic_args aArgs, sol::this_state aState)
+    {
+        std::ostringstream oss;
+        sol::state_view s(aState);
+        for (auto it = aArgs.cbegin(); it != aArgs.cend(); ++it)
+        {
+            if (it != aArgs.cbegin())
+                oss << " ";
+            std::string str = s["tostring"]((*it).get<sol::object>());
+            oss << str;
+        }
+
+        logger->log(aLogLevel, "{}", oss.str().c_str());
+    };
+
+    modLog["trace"]    = [logMessage](sol::variadic_args aArgs, sol::this_state aState) { logMessage(spdlog::level::level_enum::trace,    aArgs, aState); };
+    modLog["debug"]    = [logMessage](sol::variadic_args aArgs, sol::this_state aState) { logMessage(spdlog::level::level_enum::debug,    aArgs, aState); };
+    modLog["info"]     = [logMessage](sol::variadic_args aArgs, sol::this_state aState) { logMessage(spdlog::level::level_enum::info,     aArgs, aState); };
+    modLog["warning"]  = [logMessage](sol::variadic_args aArgs, sol::this_state aState) { logMessage(spdlog::level::level_enum::warn,     aArgs, aState); };
+    modLog["error"]    = [logMessage](sol::variadic_args aArgs, sol::this_state aState) { logMessage(spdlog::level::level_enum::err,      aArgs, aState); };
+    modLog["critical"] = [logMessage](sol::variadic_args aArgs, sol::this_state aState) { logMessage(spdlog::level::level_enum::critical, aArgs, aState); };
+
+    if (acName.empty())
+    {
+        // in case of empty name, bind modLog to consoleLog
+        sbEnv["consoleLog"] = modLog;
+        return;
+    }
+
+    sbEnv["modLog"] = modLog;
+    sbEnv["consoleLog"] = m_sandboxes[0].GetEnvironment()["consoleLog"];
+
+    // keep old spdlog binding for compatibility
+    sbEnv["spdlog"] = sbEnv["modlog"];
 }
 
 void LuaSandbox::CloseDBForSandbox(const Sandbox& aSandbox) const

--- a/src/scripting/LuaSandbox.cpp
+++ b/src/scripting/LuaSandbox.cpp
@@ -694,7 +694,7 @@ void LuaSandbox::InitializeLoggerForSandbox(Sandbox& aSandbox, const sol::state&
     sbEnv["consoleLog"] = m_sandboxes[0].GetEnvironment()["consoleLog"];
 
     // keep old spdlog binding for compatibility
-    sbEnv["spdlog"] = sbEnv["modlog"];
+    sbEnv["spdlog"] = sbEnv["modLog"];
 
     // TODO - make this use real mod name when we have mod info
     auto logWindow = std::make_shared<LogWindow>(acName + " Log", acName);

--- a/src/scripting/LuaSandbox.cpp
+++ b/src/scripting/LuaSandbox.cpp
@@ -699,12 +699,10 @@ void LuaSandbox::InitializeLoggerForSandbox(Sandbox& aSandbox, const sol::state&
     // TODO - make this use real mod name when we have mod info
     auto logWindow = std::make_shared<LogWindow>(acName + " Log", acName);
     sbEnv["__loggerWindow"] = logWindow;
-    sbEnv["SetModLogDrawEnabled"] = [logWindow](const bool acEnabled){
-        if (logWindow->IsEnabled() != acEnabled)
-            logWindow->Toggle();
-        return logWindow->IsEnabled();
+    sbEnv["ToggleModLog"] = [logWindow]{
+        logWindow->Toggle();
     };
-    sbEnv["IsModLogDrawEnabled"] = [logWindow]{
+    sbEnv["IsModLogEnabled"] = [logWindow]{
         return logWindow->IsEnabled();
     };
 }

--- a/src/scripting/LuaSandbox.cpp
+++ b/src/scripting/LuaSandbox.cpp
@@ -695,6 +695,18 @@ void LuaSandbox::InitializeLoggerForSandbox(Sandbox& aSandbox, const sol::state&
 
     // keep old spdlog binding for compatibility
     sbEnv["spdlog"] = sbEnv["modlog"];
+
+    // TODO - make this use real mod name when we have mod info
+    auto logWindow = std::make_shared<LogWindow>(acName + " Log", acName);
+    sbEnv["__loggerWindow"] = logWindow;
+    sbEnv["SetModLogDrawEnabled"] = [logWindow](const bool acEnabled){
+        if (logWindow->IsEnabled() != acEnabled)
+            logWindow->Toggle();
+        return logWindow->IsEnabled();
+    };
+    sbEnv["IsModLogDrawEnabled"] = [logWindow]{
+        return logWindow->IsEnabled();
+    };
 }
 
 void LuaSandbox::CloseDBForSandbox(const Sandbox& aSandbox) const

--- a/src/scripting/LuaVM.cpp
+++ b/src/scripting/LuaVM.cpp
@@ -50,7 +50,7 @@ void LuaVM::Update(float aDeltaTime)
         m_d3d12.PrepareUpdate();
 }
 
-void LuaVM::Draw() const
+void LuaVM::Draw()
 {
     if (!m_initialized || m_drawBlocked)
         return;

--- a/src/scripting/LuaVM.h
+++ b/src/scripting/LuaVM.h
@@ -35,7 +35,7 @@ struct LuaVM
     bool ExecuteLua(const std::string& acCommand) const;
 
     void Update(float aDeltaTime);
-    void Draw() const;
+    void Draw();
     void ReloadAllMods();
 
     void OnOverlayOpen() const;

--- a/src/scripting/Sandbox.cpp
+++ b/src/scripting/Sandbox.cpp
@@ -31,6 +31,11 @@ sol::environment& Sandbox::GetEnvironment()
     return m_env;
 }
 
+const sol::environment& Sandbox::GetEnvironment() const
+{
+    return m_env;
+}
+
 const std::filesystem::path& Sandbox::GetRootPath() const
 {
     return m_path;

--- a/src/scripting/Sandbox.h
+++ b/src/scripting/Sandbox.h
@@ -12,6 +12,7 @@ struct Sandbox
 
     uint64_t GetId() const;
     sol::environment& GetEnvironment();
+    const sol::environment& GetEnvironment() const;
     const std::filesystem::path& GetRootPath() const;
 
 private:

--- a/src/scripting/ScriptContext.cpp
+++ b/src/scripting/ScriptContext.cpp
@@ -44,6 +44,7 @@ ScriptContext::ScriptContext(LuaSandbox& aLuaSandbox, const std::filesystem::pat
     auto& env = sb.GetEnvironment();
     m_logger = env["__logger"].get<std::shared_ptr<spdlog::logger>>();
 
+
     env["registerForEvent"] = [this](const std::string& acName, sol::function aCallback)
     {
         if(acName == "onHook")

--- a/src/scripting/ScriptContext.cpp
+++ b/src/scripting/ScriptContext.cpp
@@ -43,7 +43,7 @@ ScriptContext::ScriptContext(LuaSandbox& aLuaSandbox, const std::filesystem::pat
     auto& sb = m_sandbox[m_sandboxID];
     auto& env = sb.GetEnvironment();
     m_logger = env["__logger"].get<std::shared_ptr<spdlog::logger>>();
-
+    m_loggerWindow = env["__loggerWindow"].get<std::shared_ptr<LogWindow>>();
 
     env["registerForEvent"] = [this](const std::string& acName, sol::function aCallback)
     {
@@ -84,7 +84,7 @@ ScriptContext::ScriptContext(LuaSandbox& aLuaSandbox, const std::filesystem::pat
             };
     };
 
-    auto wrapDescription = [&aLuaSandbox, loggerRef = m_logger, sandboxId = m_sandboxID](const std::variant<std::string, sol::function>& acDescription) -> std::variant<std::string, std::function<void()>> {
+    auto wrapDescription = [&aLuaSandbox, loggerRef = m_logger](const std::variant<std::string, sol::function>& acDescription) -> std::variant<std::string, std::function<void()>> {
         if (std::holds_alternative<sol::function>(acDescription))
         {
             auto callback = std::get<sol::function>(acDescription);
@@ -266,13 +266,16 @@ void ScriptContext::TriggerOnUpdate(float aDeltaTime) const
     TryLuaFunction(m_logger, m_onUpdate, aDeltaTime);
 }
 
-void ScriptContext::TriggerOnDraw() const
+void ScriptContext::TriggerOnDraw()
 {
     auto lockedState = m_sandbox.GetLockedState();
 
     m_sandbox.SetImGuiAvailable(true);
 
     const auto previousStyle = ImGui::GetStyle();
+
+    if (m_loggerWindow)
+        m_loggerWindow->Draw();
 
     TryLuaFunction(m_logger, m_onDraw);
 

--- a/src/scripting/ScriptContext.h
+++ b/src/scripting/ScriptContext.h
@@ -2,6 +2,7 @@
 
 #include "LuaSandbox.h"
 
+struct LogWindow;
 struct ScriptContext
 {
     ScriptContext(LuaSandbox& aLuaSandbox, const std::filesystem::path& acPath, const std::string& acName);
@@ -17,7 +18,7 @@ struct ScriptContext
     void TriggerOnTweak() const;
     void TriggerOnInit() const;
     void TriggerOnUpdate(float aDeltaTime) const;
-    void TriggerOnDraw() const;
+    void TriggerOnDraw();
 
     void TriggerOnOverlayOpen() const;
     void TriggerOnOverlayClose() const;
@@ -44,5 +45,6 @@ private:
     TiltedPhoques::Vector<VKBind> m_vkBinds{ };
     std::string m_name{ };
     std::shared_ptr<spdlog::logger> m_logger{ nullptr };
+    std::shared_ptr<LogWindow> m_loggerWindow{ nullptr };
     bool m_initialized{ false };
 };

--- a/src/scripting/ScriptStore.cpp
+++ b/src/scripting/ScriptStore.cpp
@@ -130,10 +130,11 @@ void ScriptStore::TriggerOnUpdate(float aDeltaTime) const
         mod.TriggerOnUpdate(aDeltaTime);
 }
 
-void ScriptStore::TriggerOnDraw() const
+void ScriptStore::TriggerOnDraw()
 {
-    for (const auto& mod : m_contexts | std::views::values)
-        mod.TriggerOnDraw();
+    // TODO - needs to be like this, cant use auto& like above as it is always const
+    for (auto it = m_contexts.begin(); it != m_contexts.end(); ++it)
+        it.value().TriggerOnDraw();
 }
 
 void ScriptStore::TriggerOnOverlayOpen() const

--- a/src/scripting/ScriptStore.h
+++ b/src/scripting/ScriptStore.h
@@ -18,7 +18,7 @@ struct ScriptStore
     void TriggerOnTweak() const;
     void TriggerOnInit() const;
     void TriggerOnUpdate(float aDeltaTime) const;
-    void TriggerOnDraw() const;
+    void TriggerOnDraw();
 
     void TriggerOnOverlayOpen() const;
     void TriggerOnOverlayClose() const;

--- a/src/scripting/Scripting.cpp
+++ b/src/scripting/Scripting.cpp
@@ -651,7 +651,7 @@ void Scripting::TriggerOnUpdate(float aDeltaTime) const
     m_store.TriggerOnUpdate(aDeltaTime);
 }
 
-void Scripting::TriggerOnDraw() const
+void Scripting::TriggerOnDraw()
 {
     m_store.TriggerOnDraw();
 }

--- a/src/scripting/Scripting.cpp
+++ b/src/scripting/Scripting.cpp
@@ -89,27 +89,14 @@ void Scripting::Initialize()
         });
     }
 
-    // setup logger for console sandbox
     auto& consoleSB = m_sandbox[0];
     auto& consoleSBEnv = consoleSB.GetEnvironment();
-    consoleSBEnv["__logger"] = spdlog::get("scripting");
 
-    // load in game bindings
-    globals["print"] = [](sol::variadic_args aArgs, sol::this_state aState)
+    // load in basic game bindings
+    globals["print"] = [consoleSBEnv](sol::variadic_args aArgs, sol::this_state aState)
     {
-        std::ostringstream oss;
-        sol::state_view s(aState);
-        for (auto it = aArgs.cbegin(); it != aArgs.cend(); ++it)
-        {
-            if (it != aArgs.cbegin())
-            {
-                oss << " ";
-            }
-            std::string str = s["tostring"]((*it).get<sol::object>());
-            oss << str;
-        }
-
-        spdlog::get("scripting")->info(oss.str());
+        // for backwards compatibility
+        consoleSBEnv["spdlog"]["info"](aArgs, aState);
     };
 
     globals["GetVersion"] = []() -> std::string

--- a/src/scripting/Scripting.cpp
+++ b/src/scripting/Scripting.cpp
@@ -89,15 +89,11 @@ void Scripting::Initialize()
         });
     }
 
-    auto& consoleSB = m_sandbox[0];
-    auto& consoleSBEnv = consoleSB.GetEnvironment();
 
     // load in basic game bindings
-    globals["print"] = [consoleSBEnv](sol::variadic_args aArgs, sol::this_state aState)
-    {
-        // for backwards compatibility
-        consoleSBEnv["spdlog"]["info"](aArgs, aState);
-    };
+    auto& consoleSB = m_sandbox[0];
+    auto& consoleSBEnv = consoleSB.GetEnvironment();
+    globals["print"] = consoleSBEnv["consoleLog"]["info"]; // alias for backwards compat
 
     globals["GetVersion"] = []() -> std::string
     {

--- a/src/scripting/Scripting.h
+++ b/src/scripting/Scripting.h
@@ -27,7 +27,7 @@ struct Scripting
     void TriggerOnTweak() const;
     void TriggerOnInit() const;
     void TriggerOnUpdate(float aDeltaTime) const;
-    void TriggerOnDraw() const;
+    void TriggerOnDraw();
     void TriggerOnOverlayOpen() const;
     void TriggerOnOverlayClose() const;
 


### PR DESCRIPTION
Idea is to give mods better logging facilities to both, console and their own logs (which they now only have in form of a file).

This should enable colored console output and allow mods to enable their own logging window at will, which would contain only their log. Logging into these sinks is provided via new consoleLog and modLog functions.

consoleLog works also in console, is meant as a replacement for print (print is still supported and behaves as consoleLog.info)
modLog is mod-specific, points to mod-specific logger and log window (aliases spdlog for backwards compatibility)

Both of these new interfaces support printing of multiple arguments (converts them to strings and concats them like print did previously).
This is upgrade over previous spdlog implementation, which it inherits thanks to shared interface.