### PR TITLE
Fix possible deadlock on startup

### DIFF
--- a/ida/patterns.py
+++ b/ida/patterns.py
@@ -45,8 +45,6 @@ def get_groups() -> List[Group]:
             Item(name='ToStringDEBUG', pattern='48 89 5C 24 08 57 48 83  EC 20 FE 42 62 4C 8D 15 ? ? ? ? 33 C9 33 C0', expected=4, index=2),
             Item(name='LogChannel', pattern='4C 8B DC 49 89 5B 08 49  89 73 18 57 48 83 EC 70 48 8B 02 ? ? ? ? ? ? ? FE 42 62 4D 8D 43 10 33 FF 45 33 C9 49 89  7B 10 48 8B DA 48 89 7A', expected=1),
             Item(name='TDBIDConstructorDerive', pattern='40 53 48 83 EC 30 33 C0 4C 89 44 24 20 48 8B DA', expected=1),
-            Item(name='ProcessRunningState', pattern='40 53 48 83 EC 20 48 8B 0D ? ? ? ? 48 8B DA E8 ? ? ? ? 84 C0', expected=1),
-            Item(name='ProcessShutdownState', pattern='48 89 6C 24 18 56 48 83 EC 30 48 8B 0D ? ? ? ?', expected=1),
             Item(name='TranslateBytecode', pattern='4C 8B DC 55 53 57 41 55 49 8D 6B A1 48 81 EC 98 00 00 00 48 8B 1A 4C 8B E9 8B 42 0C 48 8D 3C C3'),
             Item(name='TweakDBLoad', pattern='48 89 5C 24 18 55 57 41 56 48 8B EC 48 83 EC 70 48 8B D9 45 33 F6 48 8D', expected=1),
             Item(name='RegisterMemberFunction', pattern='48 89 5C 24 08 57 48 83 EC 20 49 8B C1 4D 8B D0 44 8B 4C 24 58 48 8B DA 41 83 C9 03', expected=1)
@@ -77,6 +75,21 @@ def get_groups() -> List[Group]:
         ]),
         Group(name='CGame', functions=[
             Item(name='Main', pattern='40 57 48 83 EC 70 48 8B F9 0F 29 7C 24 50 48 8D 4C 24 38', expected=1)
+        ]),
+        Group(name='CGameApplication', functions=[
+            Item(name='Run', pattern='48 89 5C 24 08 57 48 83 EC 20 48 8B D9 33 FF 90 E8 ? ? ? ? 84 C0', expected=1)
+        ]),
+        Group(name='CBaseInitializationState', functions=[
+            Item(name='OnTick', pattern='48 83 EC 28 48 8B 05 ? ? ? ? 4C 8B C2 48 85 C0 75 12 8D 50 03 49 8B C8 E8 ? ? ? ?', expected=1)
+        ]),
+        Group(name='CInitializationState', functions=[
+            Item(name='OnTick', pattern='48 83 EC 28 48 8B 05 ? ? ? ? 4C 8B C2 8B 88 F8 00 00 00 85 C9 74 3D 83 E9 02 74 25 83 E9 01', expected=1)
+        ]),
+        Group(name='CRunningState', functions=[
+            Item(name='OnTick', pattern='40 53 48 83 EC 20 48 8B 0D ? ? ? ? 48 8B DA E8 ? ? ? ? 84 C0', expected=1)
+        ]),
+        Group(name='CShutdownState', functions=[
+            Item(name='OnTick', pattern='48 89 6C 24 18 56 48 83 EC 30 48 8B 0D ? ? ? ?', expected=1)
         ]),
         Group(name='PlayerSystem', functions=[
             Item(name='OnPlayerSpawned', pattern='48 8B C4 4C 89 48 20 55 56 57 48 8B EC 48 81 EC 80 00 00 00', expected=1)

--- a/src/d3d12/D3D12.cpp
+++ b/src/d3d12/D3D12.cpp
@@ -63,7 +63,7 @@ D3D12::D3D12(Window& aWindow, Paths& aPaths, Options& aOptions)
     HookGame();
 
     // add repeated task which prepares next ImGui frame for update
-    GameMainThread::Get().AddRepeatedTask([this]{ PrepareUpdate(); });
+    GameMainThread::Get().AddGenericTask([this]{ PrepareUpdate(); return false; });
 }
 
 D3D12::~D3D12()

--- a/src/d3d12/D3D12.cpp
+++ b/src/d3d12/D3D12.cpp
@@ -62,7 +62,7 @@ D3D12::D3D12(Window& aWindow, Paths& aPaths, Options& aOptions)
 {
     HookGame();
 
-    //
+    // add repeated task which prepares next ImGui frame for update
     GameMainThread::Get().AddRepeatedTask([this]{ PrepareUpdate(); });
 }
 

--- a/src/d3d12/D3D12.cpp
+++ b/src/d3d12/D3D12.cpp
@@ -29,11 +29,8 @@ LRESULT D3D12::OnWndProc(HWND ahWnd, UINT auMsg, WPARAM awParam, LPARAM alParam)
 
     if (d3d12.IsInitialized())
     {
-        {
-            std::lock_guard _(d3d12.m_imguiLock);
-            if (const auto res = ImGui_ImplWin32_WndProcHandler(ahWnd, auMsg, awParam, alParam))
-                return res;
-        }
+        if (const auto res = ImGui_ImplWin32_WndProcHandler(ahWnd, auMsg, awParam, alParam))
+            return res;
 
         if (d3d12.m_delayedTrapInput)
         {

--- a/src/d3d12/D3D12.cpp
+++ b/src/d3d12/D3D12.cpp
@@ -5,6 +5,7 @@
 
 #include <imgui_impl/dx12.h>
 #include <imgui_impl/win32.h>
+#include <scripting/GameHooks.h>
 
 void D3D12::SetTrapInputInImGui(const bool acEnabled)
 {
@@ -60,6 +61,9 @@ D3D12::D3D12(Window& aWindow, Paths& aPaths, Options& aOptions)
     , m_options(aOptions)
 {
     HookGame();
+
+    //
+    GameMainThread::Get().AddRepeatedTask([this]{ PrepareUpdate(); });
 }
 
 D3D12::~D3D12()

--- a/src/d3d12/D3D12.h
+++ b/src/d3d12/D3D12.h
@@ -27,8 +27,6 @@ struct D3D12
 
     LRESULT OnWndProc(HWND ahWnd, UINT auMsg, WPARAM awParam, LPARAM alParam) const;
 
-    void PrepareUpdate();
-
     TiltedPhoques::Signal<void()> OnInitialized;
 
     ID3D12Device* GetDevice() const;
@@ -51,6 +49,7 @@ protected:
     bool InitializeDownlevel(ID3D12CommandQueue* apCommandQueue, ID3D12Resource* apSourceTex2D, HWND ahWindow);
     bool InitializeImGui(size_t aBuffersCounts);
 
+    void PrepareUpdate();
     void Update();
 
     static HRESULT PresentDownlevel(ID3D12CommandQueueDownlevel* apCommandQueueDownlevel, ID3D12GraphicsCommandList* apOpenCommandList, ID3D12Resource* apSourceTex2D, HWND ahWindow, D3D12_DOWNLEVEL_PRESENT_FLAGS aFlags);

--- a/src/d3d12/D3D12.h
+++ b/src/d3d12/D3D12.h
@@ -27,8 +27,7 @@ struct D3D12
 
     LRESULT OnWndProc(HWND ahWnd, UINT auMsg, WPARAM awParam, LPARAM alParam) const;
 
-    bool IsImGuiPresentDraw() const;
-    void PrepareUpdate(bool aPrepareMods = true);
+    void PrepareUpdate();
 
     TiltedPhoques::Signal<void()> OnInitialized;
 
@@ -97,7 +96,6 @@ private:
 
     std::recursive_mutex m_imguiLock;
     std::array<ImDrawData, 3> m_imguiDrawDataBuffers;
-    std::atomic_bool m_imguiPresentDraw{ true };
     std::atomic_bool m_delayedTrapInput{ false };
     std::atomic_bool m_delayedTrapInputState{ false };
 };

--- a/src/d3d12/D3D12_Functions.cpp
+++ b/src/d3d12/D3D12_Functions.cpp
@@ -464,10 +464,10 @@ bool D3D12::InitializeImGui(size_t aBuffersCounts)
 
 void D3D12::PrepareUpdate()
 {
-    std::lock_guard _(m_imguiLock);
-
     if (!m_initialized)
         return;
+
+    std::lock_guard _(m_imguiLock);
 
     ImGui_ImplWin32_NewFrame(m_outSize);
     ImGui::NewFrame();

--- a/src/d3d12/D3D12_Functions.cpp
+++ b/src/d3d12/D3D12_Functions.cpp
@@ -466,6 +466,9 @@ void D3D12::PrepareUpdate()
 {
     std::lock_guard _(m_imguiLock);
 
+    if (!m_initialized)
+        return;
+
     ImGui_ImplWin32_NewFrame(m_outSize);
     ImGui::NewFrame();
 

--- a/src/d3d12/D3D12_Functions.cpp
+++ b/src/d3d12/D3D12_Functions.cpp
@@ -462,12 +462,7 @@ bool D3D12::InitializeImGui(size_t aBuffersCounts)
     return true;
 }
 
-bool D3D12::IsImGuiPresentDraw() const
-{
-    return m_imguiPresentDraw;
-}
-
-void D3D12::PrepareUpdate(bool aPrepareMods)
+void D3D12::PrepareUpdate()
 {
     std::lock_guard _(m_imguiLock);
 
@@ -476,8 +471,7 @@ void D3D12::PrepareUpdate(bool aPrepareMods)
 
     CET::Get().GetOverlay().Update();
 
-    if (aPrepareMods)
-        CET::Get().GetVM().Draw();
+    CET::Get().GetVM().Draw();
 
     ImGui::Render();
 
@@ -501,12 +495,6 @@ void D3D12::PrepareUpdate(bool aPrepareMods)
 
 void D3D12::Update()
 {
-    if (m_imguiPresentDraw)
-    {
-        PrepareUpdate(false);
-        m_imguiPresentDraw = !CET::Get().GetVM().IsInitialized();
-    }
-
     // swap staging ImGui buffer with render ImGui buffer
     {
         std::lock_guard _(m_imguiLock);
@@ -518,7 +506,8 @@ void D3D12::Update()
         }
     }
 
-    assert(m_imguiDrawDataBuffers[0].Valid);
+    if (!m_imguiDrawDataBuffers[0].Valid)
+        return;
 
     const auto bufferIndex = m_pdxgiSwapChain != nullptr ? m_pdxgiSwapChain->GetCurrentBackBufferIndex() : m_downlevelBufferIndex;
     auto& frameContext = m_frameContexts[bufferIndex];

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -4,9 +4,7 @@
 
 #include "Options.h"
 
-#ifdef CET_DEBUG
 #include "scripting/GameHooks.h"
-#endif
 
 void EnableDebugPatch();
 void StartScreenPatch();
@@ -63,13 +61,6 @@ static void Initialize()
             MinimapFlickerPatch();
 
         OptionsInitHook();
-
-
-#ifdef CET_DEBUG
-        // We only need to hook the game thread right now to do RTTI Dump, which is Debug-only
-        // if we need to queue tasks to the mainthread remove the debug check
-        GameMainThread::Initialize();
-#endif
 
         MH_EnableHook(nullptr);
     }

--- a/src/reverse/Addresses.h
+++ b/src/reverse/Addresses.h
@@ -13,8 +13,20 @@ namespace CyberEngineTweaks::Addresses
 {
 constexpr uintptr_t ImageBase = 0x140000000;
 
+#pragma region CBaseInitializationState
+constexpr uintptr_t CBaseInitializationState_OnTick = 0x140A72BA0 - ImageBase; // 48 83 EC 28 48 8B 05 ? ? ? ? 4C 8B C2 48 85 C0 75 12 8D 50 03 49 8B C8 E8 ? ? ? ?, expected: 1, index: 0
+#pragma endregion
+
 #pragma region CGame
 constexpr uintptr_t CGame_Main = 0x140A750D0 - ImageBase; // 40 57 48 83 EC 70 48 8B F9 0F 29 7C 24 50 48 8D 4C 24 38, expected: 1, index: 0
+#pragma endregion
+
+#pragma region CGameApplication
+constexpr uintptr_t CGameApplication_Run = 0x140A712D0 - ImageBase; // 48 89 5C 24 08 57 48 83 EC 20 48 8B D9 33 FF 90 E8 ? ? ? ? 84 C0, expected: 1, index: 0
+#pragma endregion
+
+#pragma region CInitializationState
+constexpr uintptr_t CInitializationState_OnTick = 0x140A72EA0 - ImageBase; // 48 83 EC 28 48 8B 05 ? ? ? ? 4C 8B C2 8B 88 F8 00 00 00 85 C9 74 3D 83 E9 02 74 25 83 E9 01, expected: 1, index: 0
 #pragma endregion
 
 #pragma region CPatches
@@ -42,6 +54,10 @@ constexpr uintptr_t CRenderGlobal_Shutdown = 0x142CCC550 - ImageBase; // 48 89 6
 constexpr uintptr_t CRenderNode_Present_DoInternal = 0x142CE4450 - ImageBase; // 48 89 5C 24 08 48 89 6C 24 18 48 89 74 24 20 57 41 56 41 57 48 83 EC 30 8B 01 41 8B F8 4C 8B 35, expected: 1, index: 0
 #pragma endregion
 
+#pragma region CRunningState
+constexpr uintptr_t CRunningState_OnTick = 0x140A72FE0 - ImageBase; // 40 53 48 83 EC 20 48 8B 0D ? ? ? ? 48 8B DA E8 ? ? ? ? 84 C0, expected: 1, index: 0
+#pragma endregion
+
 #pragma region CScript
 constexpr uintptr_t CScript_RunPureScript = 0x14020B9C0 - ImageBase; // 40 55 48 81 EC D0 00 00 00 48 8D 6C 24 40 8B, expected: 1, index: 0
 constexpr uintptr_t CScript_AllocateFunction = 0x1401AC0F0 - ImageBase; // BA B8 00 00 00 48 8D 4D D7 E8, expected: 3, index: 0
@@ -49,11 +65,13 @@ constexpr uintptr_t CScript_Log = 0x1401EDC40 - ImageBase; // 40 53 48 83 EC ? 4
 constexpr uintptr_t CScript_ToStringDEBUG = 0x140BD5400 - ImageBase; // 48 89 5C 24 08 57 48 83  EC 20 FE 42 62 4C 8D 15 ? ? ? ? 33 C9 33 C0, expected: 4, index: 2
 constexpr uintptr_t CScript_LogChannel = 0x1401EDCE0 - ImageBase; // 4C 8B DC 49 89 5B 08 49  89 73 18 57 48 83 EC 70 48 8B 02 ? ? ? ? ? ? ? FE 42 62 4D 8D 43 10 33 FF 45 33 C9 49 89  7B 10 48 8B DA 48 89 7A, expected: 1, index: 0
 constexpr uintptr_t CScript_TDBIDConstructorDerive = 0x142BEB670 - ImageBase; // 40 53 48 83 EC 30 33 C0 4C 89 44 24 20 48 8B DA, expected: 1, index: 0
-constexpr uintptr_t CScript_ProcessRunningState = 0x140A72FE0 - ImageBase; // 40 53 48 83 EC 20 48 8B 0D ? ? ? ? 48 8B DA E8 ? ? ? ? 84 C0, expected: 1, index: 0
-constexpr uintptr_t CScript_ProcessShutdownState = 0x140A730F0 - ImageBase; // 48 89 6C 24 18 56 48 83 EC 30 48 8B 0D ? ? ? ?, expected: 1, index: 0
 constexpr uintptr_t CScript_TranslateBytecode = 0x14027B0D0 - ImageBase; // 4C 8B DC 55 53 57 41 55 49 8D 6B A1 48 81 EC 98 00 00 00 48 8B 1A 4C 8B E9 8B 42 0C 48 8D 3C C3, expected: 1, index: 0
 constexpr uintptr_t CScript_TweakDBLoad = 0x140BD3730 - ImageBase; // 48 89 5C 24 18 55 57 41 56 48 8B EC 48 83 EC 70 48 8B D9 45 33 F6 48 8D, expected: 1, index: 0
 constexpr uintptr_t CScript_RegisterMemberFunction = 0x14020ACB0 - ImageBase; // 48 89 5C 24 08 57 48 83 EC 20 49 8B C1 4D 8B D0 44 8B 4C 24 58 48 8B DA 41 83 C9 03, expected: 1, index: 0
+#pragma endregion
+
+#pragma region CShutdownState
+constexpr uintptr_t CShutdownState_OnTick = 0x140A730F0 - ImageBase; // 48 89 6C 24 18 56 48 83 EC 30 48 8B 0D ? ? ? ?, expected: 1, index: 0
 #pragma endregion
 
 #pragma region CWinapi

--- a/src/scripting/GameDump.cpp
+++ b/src/scripting/GameDump.cpp
@@ -4,7 +4,7 @@
 
 namespace GameDump
 {
-void DumpVTablesTask::Run()
+bool DumpVTablesTask::Run()
 {
     TiltedPhoques::Map<uintptr_t, std::string> vtableMap;
 
@@ -82,5 +82,7 @@ void DumpVTablesTask::Run()
     {
         Log::Info("{:016X},{}", key, value);
     }
+
+    return true;
 }
 } // namespace GameDump

--- a/src/scripting/GameDump.h
+++ b/src/scripting/GameDump.h
@@ -11,6 +11,6 @@ namespace GameDump
 {
 struct DumpVTablesTask
 {
-    static void Run();
+    static bool Run();
 };
 } // namespace GameDump

--- a/src/scripting/GameHooks.cpp
+++ b/src/scripting/GameHooks.cpp
@@ -6,13 +6,13 @@
 
 static std::unique_ptr<GameMainThread> s_pGameMainThread;
 
-void GameMainThread::TaskQueue::AddTask(const std::function<bool()>& aFunction)
+void GameMainThread::RepeatedTaskQueue::AddTask(const std::function<bool()>& aFunction)
 {
     std::lock_guard lock(m_mutex);
     m_tasks.emplace_back(aFunction);
 }
 
-void GameMainThread::TaskQueue::Drain()
+void GameMainThread::RepeatedTaskQueue::Drain()
 {
     std::lock_guard lock(m_mutex);
     for (auto taskIt = m_tasks.begin(); taskIt != m_tasks.end();)
@@ -23,31 +23,48 @@ void GameMainThread::TaskQueue::Drain()
             ++taskIt;
     }
 }
+GameMainThread::StateTickOverride::StateTickOverride(const uintptr_t acOffset, const char* acpRealFunctionName)
+    : Offset(acOffset)
+    , RealFunctionName(acpRealFunctionName)
+{
+}
+
+bool GameMainThread::StateTickOverride::OnTick(RED4ext::IGameState* apThisState, RED4ext::CGameApplication* apGameApplication)
+{
+    Tasks.Drain();
+
+    return RealFunction(apThisState, apGameApplication);
+}
 
 GameMainThread& GameMainThread::Get()
 {
     static GameMainThread s_gameMainThread;
+
     return s_gameMainThread;
 }
 
 void GameMainThread::AddBaseInitializationTask(const std::function<bool()>& aFunction)
 {
-    m_baseInitializationQueue.AddTask(aFunction);
+    constexpr auto cStateIndex = static_cast<size_t>(RED4ext::EGameStateType::BaseInitialization);
+    return m_stateTickOverrides[cStateIndex].Tasks.AddTask(aFunction);
 }
 
 void GameMainThread::AddInitializationTask(const std::function<bool()>& aFunction)
 {
-    m_initializationQueue.AddTask(aFunction);
+    constexpr auto cStateIndex = static_cast<size_t>(RED4ext::EGameStateType::Initialization);
+    return m_stateTickOverrides[cStateIndex].Tasks.AddTask(aFunction);
 }
 
 void GameMainThread::AddRunningTask(const std::function<bool()>& aFunction)
 {
-    m_runningQueue.AddTask(aFunction);
+    constexpr auto cStateIndex = static_cast<size_t>(RED4ext::EGameStateType::Running);
+    return m_stateTickOverrides[cStateIndex].Tasks.AddTask(aFunction);
 }
 
 void GameMainThread::AddShutdownTask(const std::function<bool()>& aFunction)
 {
-    m_shutdownQueue.AddTask(aFunction);
+    constexpr auto cStateIndex = static_cast<size_t>(RED4ext::EGameStateType::Shutdown);
+    return m_stateTickOverrides[cStateIndex].Tasks.AddTask(aFunction);
 }
 
 void GameMainThread::AddGenericTask(const std::function<bool()>& aFunction)
@@ -65,96 +82,47 @@ GameMainThread::~GameMainThread()
     Unhook();
 }
 
-bool GameMainThread::HookMainThreadStateTick(RED4ext::IGameState* apThisState, RED4ext::CGameApplication* apGameApplication)
+bool GameMainThread::HookStateTick(RED4ext::IGameState* apThisState, RED4ext::CGameApplication* apGameApplication)
 {
     auto& gmt = Get();
 
+    // drain generic tasks
     gmt.m_genericQueue.Drain();
 
-    switch (apThisState->GetType())
-    {
-    case RED4ext::EGameStateType::BaseInitialization:
-        gmt.m_baseInitializationQueue.Drain();
-        return gmt.m_ppMainThreadStateTickLocations[0].second(apThisState, apGameApplication);
-    case RED4ext::EGameStateType::Initialization:
-        gmt.m_initializationQueue.Drain();
-        return gmt.m_ppMainThreadStateTickLocations[1].second(apThisState, apGameApplication);
-    case RED4ext::EGameStateType::Running:
-        gmt.m_runningQueue.Drain();
-        return gmt.m_ppMainThreadStateTickLocations[2].second(apThisState, apGameApplication);
-    case RED4ext::EGameStateType::Shutdown:
-        gmt.m_shutdownQueue.Drain();
-        return gmt.m_ppMainThreadStateTickLocations[3].second(apThisState, apGameApplication);
-    }
-
-    // this function should never get here!
-    assert(false);
-    return false;
+    // execute specific state tasks, including original function
+    const auto cStateIndex = static_cast<size_t>(apThisState->GetType());
+    return gmt.m_stateTickOverrides[cStateIndex].OnTick(apThisState, apGameApplication);
 }
 
 void GameMainThread::Hook()
 {
-    if (!m_ppMainThreadStateTickLocations[0].first)
+    for (auto& stateTickOverride : m_stateTickOverrides)
     {
-        const RED4ext::RelocPtr<uint8_t> func(CyberEngineTweaks::Addresses::CBaseInitializationState_OnTick);
-        m_ppMainThreadStateTickLocations[0].first = func.GetAddr();
-    }
-    if (m_ppMainThreadStateTickLocations[0].first)
-    {
-        if (MH_CreateHook(m_ppMainThreadStateTickLocations[0].first, reinterpret_cast<void*>(&GameMainThread::HookMainThreadStateTick), reinterpret_cast<void**>(&m_ppMainThreadStateTickLocations[0].second)) != MH_OK ||
-            MH_EnableHook(m_ppMainThreadStateTickLocations[0].first) != MH_OK)
-            Log::Error("Could not hook main thread function CBaseInitializationState::OnTick()!");
-    }
-    else
-        Log::Error("Could not locate CBaseInitializationState::OnTick()!");
-
-    if (!m_ppMainThreadStateTickLocations[1].first)
-    {
-        const RED4ext::RelocPtr<uint8_t> func(CyberEngineTweaks::Addresses::CInitializationState_OnTick);
-        m_ppMainThreadStateTickLocations[1].first = func.GetAddr();
-    }
-    if (m_ppMainThreadStateTickLocations[1].first)
-    {
-        if (MH_CreateHook(m_ppMainThreadStateTickLocations[1].first, reinterpret_cast<void*>(&GameMainThread::HookMainThreadStateTick), reinterpret_cast<void**>(&m_ppMainThreadStateTickLocations[1].second)) != MH_OK ||
-            MH_EnableHook(m_ppMainThreadStateTickLocations[1].first) != MH_OK)
-            Log::Error("Could not hook main thread function CInitializationState::OnTick()!");
-    }
-    else
-        Log::Error("Could not locate CInitializationState::OnTick()!");
-
-    if (!m_ppMainThreadStateTickLocations[2].first)
-    {
-        const RED4ext::RelocPtr<uint8_t> func(CyberEngineTweaks::Addresses::CRunningState_OnTick);
-        m_ppMainThreadStateTickLocations[2].first = func.GetAddr();
-    }
-    if (m_ppMainThreadStateTickLocations[2].first)
-    {
-        if (MH_CreateHook(m_ppMainThreadStateTickLocations[2].first, reinterpret_cast<void*>(&GameMainThread::HookMainThreadStateTick), reinterpret_cast<void**>(&m_ppMainThreadStateTickLocations[2].second)) != MH_OK ||
-            MH_EnableHook(m_ppMainThreadStateTickLocations[2].first) != MH_OK)
-            Log::Error("Could not hook main thread function CRunningState::OnTick()!");
-    }
-    else
-        Log::Error("Could not locate CRunningState::OnTick()!");
-
-    if (!m_ppMainThreadStateTickLocations[3].first)
-    {
-        const RED4ext::RelocPtr<uint8_t> func(CyberEngineTweaks::Addresses::CShutdownState_OnTick);
-        m_ppMainThreadStateTickLocations[3].first = func.GetAddr();
-    }
-    if (m_ppMainThreadStateTickLocations[3].first)
-    {
-        if (MH_CreateHook(m_ppMainThreadStateTickLocations[3].first, reinterpret_cast<void*>(&GameMainThread::HookMainThreadStateTick), reinterpret_cast<void**>(&m_ppMainThreadStateTickLocations[3].second)) != MH_OK ||
-            MH_EnableHook(m_ppMainThreadStateTickLocations[3].first) != MH_OK)
-            Log::Error("Could not hook main thread function CShutdownState::OnTick()!");
+        if (!stateTickOverride.Location)
+        {
+            const RED4ext::RelocPtr<uint8_t> func(stateTickOverride.Offset);
+            stateTickOverride.Location = func.GetAddr();
+        }
+        if (stateTickOverride.Location)
+        {
+            if (MH_CreateHook(stateTickOverride.Location, reinterpret_cast<void*>(&GameMainThread::HookStateTick), reinterpret_cast<void**>(&stateTickOverride.RealFunction)) != MH_OK ||
+                MH_EnableHook(stateTickOverride.Location) != MH_OK)
+                Log::Error("Could not hook main thread function {}! Main thread is not completely hooked!", stateTickOverride.RealFunctionName);
+            else
+                Log::Info("Main thread function {} hook complete!", stateTickOverride.RealFunctionName);
+        }
         else
-            Log::Info("Main thread function hook complete!");
+            Log::Error("Could not locate {}! Main thread is not completely hooked!", stateTickOverride.RealFunctionName);
     }
-    else
-        Log::Error("Could not locate CShutdownState::OnTick()!");
 }
 
-void GameMainThread::Unhook() const
+void GameMainThread::Unhook()
 {
-    for (auto location : m_ppMainThreadStateTickLocations | std::views::keys)
-        MH_DisableHook(location);
+    for (auto& stateTickOverride : m_stateTickOverrides)
+    {
+        MH_DisableHook(stateTickOverride.Location);
+
+        stateTickOverride.Location = nullptr;
+        stateTickOverride.RealFunction = nullptr;
+    }
 }

--- a/src/scripting/GameHooks.cpp
+++ b/src/scripting/GameHooks.cpp
@@ -2,6 +2,8 @@
 
 #include "GameHooks.h"
 
+#include "RED4ext/GameStates.hpp"
+
 static std::unique_ptr<GameMainThread> s_pGameMainThread;
 
 void GameMainThread::Initialize()
@@ -23,14 +25,29 @@ GameMainThread& GameMainThread::Get()
     return *s_pGameMainThread;
 }
 
-void GameMainThread::AddTask(const std::function<void()>& aFunction)
+void GameMainThread::AddBaseInitializationTask(const std::function<bool()>& aFunction)
 {
-    m_taskQueue.Add(aFunction);
+    m_baseInitializationTasks.emplace_back(aFunction);
 }
 
-void GameMainThread::AddRepeatedTask(std::function<void()> aFunction)
+void GameMainThread::AddInitializationTask(const std::function<bool()>& aFunction)
 {
-    m_repeatedTasks.emplace_back(std::move(aFunction));
+    m_initializationTasks.emplace_back(aFunction);
+}
+
+void GameMainThread::AddRunningTask(const std::function<bool()>& aFunction)
+{
+    m_runningTasks.emplace_back(aFunction);
+}
+
+void GameMainThread::AddShutdownTask(const std::function<bool()>& aFunction)
+{
+    m_shutdownTasks.emplace_back(aFunction);
+}
+
+void GameMainThread::AddGenericTask(const std::function<bool()>& aFunction)
+{
+    m_genericTasks.emplace_back(aFunction);
 }
 
 GameMainThread::GameMainThread()
@@ -43,39 +60,123 @@ GameMainThread::~GameMainThread()
     Unhook();
 }
 
-bool GameMainThread::HookMainThread(void* a1, void* a2)
+bool GameMainThread::HookMainThreadStateTick(RED4ext::IGameState* apThisState, RED4ext::CGameApplication* apGameApplication)
 {
     auto& gmt = Get();
 
-    // do all repeated tasks
-    for (auto& task : gmt.m_repeatedTasks)
-        task();
+    for (auto taskIt = gmt.m_genericTasks.begin(); taskIt != gmt.m_genericTasks.end(); ++taskIt)
+    {
+        if ((*taskIt)())
+            taskIt = gmt.m_genericTasks.erase(taskIt);
+    }
 
-    // do single tasks
-    gmt.m_taskQueue.Drain();
+    switch (apThisState->GetType())
+    {
+    case RED4ext::EGameStateType::BaseInitialization:
+        for (auto taskIt = gmt.m_baseInitializationTasks.begin(); taskIt != gmt.m_baseInitializationTasks.end();)
+        {
+            if ((*taskIt)())
+                taskIt = gmt.m_baseInitializationTasks.erase(taskIt);
+            else
+                ++taskIt;
+        }
+        return gmt.m_ppMainThreadStateTickLocations[0].second(apThisState, apGameApplication);
+    case RED4ext::EGameStateType::Initialization:
+        for (auto taskIt = gmt.m_initializationTasks.begin(); taskIt != gmt.m_initializationTasks.end();)
+        {
+            if ((*taskIt)())
+                taskIt = gmt.m_initializationTasks.erase(taskIt);
+            else
+                ++taskIt;
+        }
+        return gmt.m_ppMainThreadStateTickLocations[1].second(apThisState, apGameApplication);
+    case RED4ext::EGameStateType::Running:
+        for (auto taskIt = gmt.m_runningTasks.begin(); taskIt != gmt.m_runningTasks.end();)
+        {
+            if ((*taskIt)())
+                taskIt = gmt.m_runningTasks.erase(taskIt);
+            else
+                ++taskIt;
+        }
+        return gmt.m_ppMainThreadStateTickLocations[2].second(apThisState, apGameApplication);
+    case RED4ext::EGameStateType::Shutdown:
+        for (auto taskIt = gmt.m_shutdownTasks.begin(); taskIt != gmt.m_shutdownTasks.end();)
+        {
+            if ((*taskIt)())
+                taskIt = gmt.m_shutdownTasks.erase(taskIt);
+            else
+                ++taskIt;
+        }
+        return gmt.m_ppMainThreadStateTickLocations[3].second(apThisState, apGameApplication);
+    }
 
-    return gmt.m_pMainThreadOriginal(a1, a2);
+    assert(false);
+    return false;
 }
 
 void GameMainThread::Hook()
 {
-    if (!m_pMainThreadLocation)
+    if (!m_ppMainThreadStateTickLocations[0].first)
     {
-        const RED4ext::RelocPtr<uint8_t> func(CyberEngineTweaks::Addresses::CGame_Main);
-        m_pMainThreadLocation = func.GetAddr();
+        const RED4ext::RelocPtr<uint8_t> func(CyberEngineTweaks::Addresses::CBaseInitializationState_OnTick);
+        m_ppMainThreadStateTickLocations[0].first = func.GetAddr();
     }
-
-    if (m_pMainThreadLocation)
+    if (m_ppMainThreadStateTickLocations[0].first)
     {
-        if (MH_CreateHook(m_pMainThreadLocation, reinterpret_cast<void*>(&GameMainThread::HookMainThread), reinterpret_cast<void**>(&m_pMainThreadOriginal)) != MH_OK ||
-            MH_EnableHook(m_pMainThreadLocation) != MH_OK)
-            Log::Error("Could not hook main thread function!");
+        if (MH_CreateHook(m_ppMainThreadStateTickLocations[0].first, reinterpret_cast<void*>(&GameMainThread::HookMainThreadStateTick), reinterpret_cast<void**>(&m_ppMainThreadStateTickLocations[0].second)) != MH_OK ||
+            MH_EnableHook(m_ppMainThreadStateTickLocations[0].first) != MH_OK)
+            Log::Error("Could not hook main thread function CBaseInitializationState::OnTick()!");
+    }
+    else
+        Log::Error("Could not locate CBaseInitializationState::OnTick()!");
+
+    if (!m_ppMainThreadStateTickLocations[1].first)
+    {
+        const RED4ext::RelocPtr<uint8_t> func(CyberEngineTweaks::Addresses::CInitializationState_OnTick);
+        m_ppMainThreadStateTickLocations[1].first = func.GetAddr();
+    }
+    if (m_ppMainThreadStateTickLocations[1].first)
+    {
+        if (MH_CreateHook(m_ppMainThreadStateTickLocations[1].first, reinterpret_cast<void*>(&GameMainThread::HookMainThreadStateTick), reinterpret_cast<void**>(&m_ppMainThreadStateTickLocations[1].second)) != MH_OK ||
+            MH_EnableHook(m_ppMainThreadStateTickLocations[1].first) != MH_OK)
+            Log::Error("Could not hook main thread function CInitializationState::OnTick()!");
+    }
+    else
+        Log::Error("Could not locate CInitializationState::OnTick()!");
+
+    if (!m_ppMainThreadStateTickLocations[2].first)
+    {
+        const RED4ext::RelocPtr<uint8_t> func(CyberEngineTweaks::Addresses::CRunningState_OnTick);
+        m_ppMainThreadStateTickLocations[2].first = func.GetAddr();
+    }
+    if (m_ppMainThreadStateTickLocations[2].first)
+    {
+        if (MH_CreateHook(m_ppMainThreadStateTickLocations[2].first, reinterpret_cast<void*>(&GameMainThread::HookMainThreadStateTick), reinterpret_cast<void**>(&m_ppMainThreadStateTickLocations[2].second)) != MH_OK ||
+            MH_EnableHook(m_ppMainThreadStateTickLocations[2].first) != MH_OK)
+            Log::Error("Could not hook main thread function CRunningState::OnTick()!");
+    }
+    else
+        Log::Error("Could not locate CRunningState::OnTick()!");
+
+    if (!m_ppMainThreadStateTickLocations[3].first)
+    {
+        const RED4ext::RelocPtr<uint8_t> func(CyberEngineTweaks::Addresses::CShutdownState_OnTick);
+        m_ppMainThreadStateTickLocations[3].first = func.GetAddr();
+    }
+    if (m_ppMainThreadStateTickLocations[3].first)
+    {
+        if (MH_CreateHook(m_ppMainThreadStateTickLocations[3].first, reinterpret_cast<void*>(&GameMainThread::HookMainThreadStateTick), reinterpret_cast<void**>(&m_ppMainThreadStateTickLocations[3].second)) != MH_OK ||
+            MH_EnableHook(m_ppMainThreadStateTickLocations[3].first) != MH_OK)
+            Log::Error("Could not hook main thread function CShutdownState::OnTick()!");
         else
             Log::Info("Main thread function hook complete!");
     }
+    else
+        Log::Error("Could not locate CShutdownState::OnTick()!");
 }
 
 void GameMainThread::Unhook() const
 {
-    MH_DisableHook(m_pMainThreadLocation);
+    for (auto location : m_ppMainThreadStateTickLocations | std::views::keys)
+        MH_DisableHook(location);
 }

--- a/src/scripting/GameHooks.cpp
+++ b/src/scripting/GameHooks.cpp
@@ -19,12 +19,18 @@ void GameMainThread::Shutdown()
 
 GameMainThread& GameMainThread::Get()
 {
+    Initialize();
     return *s_pGameMainThread;
 }
 
-void GameMainThread::AddTask(std::function<void()> aFunction)
+void GameMainThread::AddTask(const std::function<void()>& aFunction)
 {
-    m_taskQueue.Add(std::move(aFunction));
+    m_taskQueue.Add(aFunction);
+}
+
+void GameMainThread::AddRepeatedTask(std::function<void()> aFunction)
+{
+    m_repeatedTasks.emplace_back(std::move(aFunction));
 }
 
 GameMainThread::GameMainThread()
@@ -40,6 +46,11 @@ GameMainThread::~GameMainThread()
 bool GameMainThread::HookMainThread(void* a1, void* a2)
 {
     auto& gmt = Get();
+
+    // add all repeated tasks
+    for (auto& task : gmt.m_repeatedTasks)
+        gmt.m_taskQueue.Add(task);
+
 
     gmt.m_taskQueue.Drain();
 

--- a/src/scripting/GameHooks.cpp
+++ b/src/scripting/GameHooks.cpp
@@ -24,9 +24,28 @@ void GameMainThread::RepeatedTaskQueue::Drain()
     }
 }
 GameMainThread::StateTickOverride::StateTickOverride(const uintptr_t acOffset, const char* acpRealFunctionName)
-    : Offset(acOffset)
-    , RealFunctionName(acpRealFunctionName)
 {
+    const RED4ext::RelocPtr<uint8_t> func(acOffset);
+    Location = func.GetAddr();
+
+    if (Location)
+    {
+        if (MH_CreateHook(Location, reinterpret_cast<void*>(&GameMainThread::HookStateTick), reinterpret_cast<void**>(&RealFunction)) != MH_OK ||
+            MH_EnableHook(Location) != MH_OK)
+            Log::Error("Could not hook main thread function {}! Main thread is not completely hooked!", acpRealFunctionName);
+        else
+            Log::Info("Main thread function {} hook complete!", acpRealFunctionName);
+    }
+    else
+        Log::Error("Could not locate {}! Main thread is not completely hooked!", acpRealFunctionName);
+}
+
+GameMainThread::StateTickOverride::~StateTickOverride()
+{
+    MH_DisableHook(Location);
+
+    Location = nullptr;
+    RealFunction = nullptr;
 }
 
 bool GameMainThread::StateTickOverride::OnTick(RED4ext::IGameState* apThisState, RED4ext::CGameApplication* apGameApplication)
@@ -72,16 +91,6 @@ void GameMainThread::AddGenericTask(const std::function<bool()>& aFunction)
     m_genericQueue.AddTask(aFunction);
 }
 
-GameMainThread::GameMainThread()
-{
-    Hook();
-}
-
-GameMainThread::~GameMainThread()
-{
-    Unhook();
-}
-
 bool GameMainThread::HookStateTick(RED4ext::IGameState* apThisState, RED4ext::CGameApplication* apGameApplication)
 {
     auto& gmt = Get();
@@ -92,37 +101,4 @@ bool GameMainThread::HookStateTick(RED4ext::IGameState* apThisState, RED4ext::CG
     // execute specific state tasks, including original function
     const auto cStateIndex = static_cast<size_t>(apThisState->GetType());
     return gmt.m_stateTickOverrides[cStateIndex].OnTick(apThisState, apGameApplication);
-}
-
-void GameMainThread::Hook()
-{
-    for (auto& stateTickOverride : m_stateTickOverrides)
-    {
-        if (!stateTickOverride.Location)
-        {
-            const RED4ext::RelocPtr<uint8_t> func(stateTickOverride.Offset);
-            stateTickOverride.Location = func.GetAddr();
-        }
-        if (stateTickOverride.Location)
-        {
-            if (MH_CreateHook(stateTickOverride.Location, reinterpret_cast<void*>(&GameMainThread::HookStateTick), reinterpret_cast<void**>(&stateTickOverride.RealFunction)) != MH_OK ||
-                MH_EnableHook(stateTickOverride.Location) != MH_OK)
-                Log::Error("Could not hook main thread function {}! Main thread is not completely hooked!", stateTickOverride.RealFunctionName);
-            else
-                Log::Info("Main thread function {} hook complete!", stateTickOverride.RealFunctionName);
-        }
-        else
-            Log::Error("Could not locate {}! Main thread is not completely hooked!", stateTickOverride.RealFunctionName);
-    }
-}
-
-void GameMainThread::Unhook()
-{
-    for (auto& stateTickOverride : m_stateTickOverrides)
-    {
-        MH_DisableHook(stateTickOverride.Location);
-
-        stateTickOverride.Location = nullptr;
-        stateTickOverride.RealFunction = nullptr;
-    }
 }

--- a/src/scripting/GameHooks.cpp
+++ b/src/scripting/GameHooks.cpp
@@ -47,11 +47,11 @@ bool GameMainThread::HookMainThread(void* a1, void* a2)
 {
     auto& gmt = Get();
 
-    // add all repeated tasks
+    // do all repeated tasks
     for (auto& task : gmt.m_repeatedTasks)
-        gmt.m_taskQueue.Add(task);
+        task();
 
-
+    // do single tasks
     gmt.m_taskQueue.Drain();
 
     return gmt.m_pMainThreadOriginal(a1, a2);

--- a/src/scripting/GameHooks.h
+++ b/src/scripting/GameHooks.h
@@ -2,9 +2,6 @@
 
 struct GameMainThread
 {
-    static void Initialize();
-    static void Shutdown();
-
     static GameMainThread& Get();
 
     void AddBaseInitializationTask(const std::function<bool()>& aFunction);
@@ -27,9 +24,20 @@ private:
 
     std::array<std::pair<uint8_t*, TMainThreadStateTick*>, 4> m_ppMainThreadStateTickLocations;
 
-    TiltedPhoques::Vector<std::function<bool()>> m_baseInitializationTasks;
-    TiltedPhoques::Vector<std::function<bool()>> m_initializationTasks;
-    TiltedPhoques::Vector<std::function<bool()>> m_runningTasks;
-    TiltedPhoques::Vector<std::function<bool()>> m_shutdownTasks;
-    TiltedPhoques::Vector<std::function<bool()>> m_genericTasks;
+    // helper task queue which executes added tasks each drain until they are finished
+    struct TaskQueue
+    {
+        void AddTask(const std::function<bool()>& aFunction);
+        void Drain();
+
+    private:
+        std::recursive_mutex m_mutex;
+        TiltedPhoques::Vector<std::function<bool()>> m_tasks;
+    };
+
+    TaskQueue m_baseInitializationQueue;
+    TaskQueue m_initializationQueue;
+    TaskQueue m_runningQueue;
+    TaskQueue m_shutdownQueue;
+    TaskQueue m_genericQueue;
 };

--- a/src/scripting/GameHooks.h
+++ b/src/scripting/GameHooks.h
@@ -10,13 +10,8 @@ struct GameMainThread
     void AddShutdownTask(const std::function<bool()>& aFunction);
     void AddGenericTask(const std::function<bool()>& aFunction);
 
-    ~GameMainThread();
-
 private:
-    GameMainThread();
-
-    void Hook();
-    void Unhook();
+    GameMainThread() = default;
 
     using TStateTick = bool(RED4ext::IGameState*, RED4ext::CGameApplication*);
 
@@ -36,11 +31,9 @@ private:
     struct StateTickOverride
     {
         StateTickOverride(const uintptr_t acOffset, const char* acpRealFunctionName);
+        ~StateTickOverride();
 
         bool OnTick(RED4ext::IGameState*, RED4ext::CGameApplication*);
-
-        const uintptr_t Offset;
-        const char* RealFunctionName;
 
         uint8_t* Location = nullptr;
         TStateTick* RealFunction = nullptr;

--- a/src/scripting/GameHooks.h
+++ b/src/scripting/GameHooks.h
@@ -7,8 +7,11 @@ struct GameMainThread
 
     static GameMainThread& Get();
 
-    void AddTask(const std::function<void()>& aFunction);
-    void AddRepeatedTask(std::function<void()> aFunction);
+    void AddBaseInitializationTask(const std::function<bool()>& aFunction);
+    void AddInitializationTask(const std::function<bool()>& aFunction);
+    void AddRunningTask(const std::function<bool()>& aFunction);
+    void AddShutdownTask(const std::function<bool()>& aFunction);
+    void AddGenericTask(const std::function<bool()>& aFunction);
 
     ~GameMainThread();
 
@@ -18,13 +21,15 @@ private:
     void Hook();
     void Unhook() const;
 
-    using TMainThreadLoop = bool(void*, void*);
+    using TMainThreadStateTick = bool(RED4ext::IGameState*, RED4ext::CGameApplication*);
 
-    static bool HookMainThread(void* a1, void* a2);
+    static bool HookMainThreadStateTick(RED4ext::IGameState* apThisState, RED4ext::CGameApplication* apGameApplication);
 
-    uint8_t* m_pMainThreadLocation = nullptr;
-    TMainThreadLoop* m_pMainThreadOriginal = nullptr;
+    std::array<std::pair<uint8_t*, TMainThreadStateTick*>, 4> m_ppMainThreadStateTickLocations;
 
-    TiltedPhoques::Vector<std::function<void()>> m_repeatedTasks;
-    TiltedPhoques::TaskQueue m_taskQueue;
+    TiltedPhoques::Vector<std::function<bool()>> m_baseInitializationTasks;
+    TiltedPhoques::Vector<std::function<bool()>> m_initializationTasks;
+    TiltedPhoques::Vector<std::function<bool()>> m_runningTasks;
+    TiltedPhoques::Vector<std::function<bool()>> m_shutdownTasks;
+    TiltedPhoques::Vector<std::function<bool()>> m_genericTasks;
 };

--- a/src/scripting/GameHooks.h
+++ b/src/scripting/GameHooks.h
@@ -7,13 +7,14 @@ struct GameMainThread
 
     static GameMainThread& Get();
 
-    void AddTask(std::function<void()> aFunction);
+    void AddTask(const std::function<void()>& aFunction);
+    void AddRepeatedTask(std::function<void()> aFunction);
 
     ~GameMainThread();
 
 private:
     GameMainThread();
-    
+
     void Hook();
     void Unhook() const;
 
@@ -24,5 +25,6 @@ private:
     uint8_t* m_pMainThreadLocation = nullptr;
     TMainThreadLoop* m_pMainThreadOriginal = nullptr;
 
+    TiltedPhoques::Vector<std::function<void()>> m_repeatedTasks;
     TiltedPhoques::TaskQueue m_taskQueue;
 };

--- a/src/scripting/LuaVM.cpp
+++ b/src/scripting/LuaVM.cpp
@@ -32,22 +32,21 @@ bool LuaVM::ExecuteLua(const std::string& acCommand) const
 
 void LuaVM::Update(float aDeltaTime)
 {
-    if (!m_initialized)
-        return;
-
-    CET::Get().GetBindings().Update();
-
-    if (m_reload)
+    if (m_initialized)
     {
-        m_scripting.ReloadAllMods();
+        CET::Get().GetBindings().Update();
 
-        m_reload = false;
+        if (m_reload)
+        {
+            m_scripting.ReloadAllMods();
+
+            m_reload = false;
+        }
+
+        m_scripting.TriggerOnUpdate(aDeltaTime);
     }
 
-    m_scripting.TriggerOnUpdate(aDeltaTime);
-
-    if (!m_d3d12.IsImGuiPresentDraw())
-        m_d3d12.PrepareUpdate();
+    m_d3d12.PrepareUpdate();
 }
 
 void LuaVM::Draw() const

--- a/src/scripting/LuaVM.cpp
+++ b/src/scripting/LuaVM.cpp
@@ -32,21 +32,19 @@ bool LuaVM::ExecuteLua(const std::string& acCommand) const
 
 void LuaVM::Update(float aDeltaTime)
 {
-    if (m_initialized)
+    if (!m_initialized)
+        return;
+
+    CET::Get().GetBindings().Update();
+
+    if (m_reload)
     {
-        CET::Get().GetBindings().Update();
+        m_scripting.ReloadAllMods();
 
-        if (m_reload)
-        {
-            m_scripting.ReloadAllMods();
-
-            m_reload = false;
-        }
-
-        m_scripting.TriggerOnUpdate(aDeltaTime);
+        m_reload = false;
     }
 
-    m_d3d12.PrepareUpdate();
+    m_scripting.TriggerOnUpdate(aDeltaTime);
 }
 
 void LuaVM::Draw() const

--- a/src/scripting/LuaVM.h
+++ b/src/scripting/LuaVM.h
@@ -69,8 +69,6 @@ protected:
     static void HookLogChannel(RED4ext::IScriptable*, RED4ext::CStackFrame* apStack, void*, void*);
     static void HookTDBIDToStringDEBUG(RED4ext::IScriptable*, RED4ext::CStackFrame* apStack, void* apResult, void*);
     static TDBID* HookTDBIDCtorDerive(TDBID* apBase, TDBID* apThis, const char* acpName);
-    static bool HookRunningStateRun(uintptr_t aThis, uintptr_t aApp);
-    static bool HookShutdownStateRun(uintptr_t aThis, uintptr_t aApp);
     static uintptr_t HookSetLoadingState(uintptr_t aThis, int aState);
     static uint64_t HookTweakDBLoad(uintptr_t aThis, uintptr_t aParam);
     static bool HookTranslateBytecode(uintptr_t aBinder, uintptr_t aData);
@@ -87,8 +85,6 @@ private:
     RED4ext::OpcodeHandlers::Handler_t m_realLogChannel{nullptr};
     RED4ext::OpcodeHandlers::Handler_t m_realTDBIDToStringDEBUG{nullptr};
     TTDBIDCtorDerive* m_realTDBIDCtorDerive{ nullptr };
-    TRunningStateRun* m_realRunningStateRun{ nullptr };
-    TShutdownStateRun* m_realShutdownStateRun{ nullptr };
     TSetLoadingState* m_realSetLoadingState{ nullptr };
     TTweakDBLoad* m_realTweakDBLoad{ nullptr };
     TTranslateBytecode* m_realTranslateBytecode{ nullptr };

--- a/src/scripting/Scripting.cpp
+++ b/src/scripting/Scripting.cpp
@@ -592,7 +592,7 @@ void Scripting::PostInitializeMods()
         // some hierarchies may also not be accurately reflected due to hash ordering
         // technically this table is flattened and contains all hierarchy, but traversing the hierarchy first reduces
         // error when there are classes that instantiate a parent class but don't actually have a subclass instance
-        GameMainThread::Get().AddTask(&GameDump::DumpVTablesTask::Run);
+        GameMainThread::Get().AddRunningTask(&GameDump::DumpVTablesTask::Run);
     };
     globals["DumpReflection"] = [this](bool aVerbose, bool aExtendedPath, bool aPropertyHolders)
     {

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -11,6 +11,7 @@
 #include <RED4ext/CName.hpp>
 #include <RED4ext/CString.hpp>
 #include <RED4ext/DynArray.hpp>
+#include "RED4ext/GameApplication.hpp"
 #include <RED4ext/GameEngine.hpp>
 #include <RED4ext/Hashing/CRC.hpp>
 #include <RED4ext/ISerializable.hpp>
@@ -66,6 +67,7 @@
 #include "Options.h"
 #include "Paths.h"
 #include "reverse/Addresses.h"
+#include "scripting/GameHooks.h"
 #include "VKBindings.h"
 
 template<>


### PR DESCRIPTION
If user toggles overlay during early startup, focuses on console input and presses overlay toggle hotkey, deadlock happens.

ImGui got locked in main thread and render thread due to some ImGui things...

We do not access platform things from present now, modified a bit log there.
Removed lock of ImGui in OnWndProc.

Reworked GameMainThread class as part of this, used it for managing tasks for each state type tick function.
Currently used in LuaVM and D3D12, along with dump job.

Dependency for https://github.com/yamashi/CyberEngineTweaks/pull/754