### PR TITLE
Persistent state for Overlay widget toggles

### DIFF
--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -3,106 +3,161 @@
 #include "Paths.h"
 #include "Utils.h"
 
+
+void PatchesSettings::Load(const nlohmann::json& aConfig)
+{
+    RemovePedestrians = aConfig.value("remove_pedestrians", RemovePedestrians);
+    SkipStartMenu = aConfig.value("skip_start_menu", SkipStartMenu);
+    AmdSmt = aConfig.value("amd_smt", AmdSmt);
+    AsyncCompute = aConfig.value("disable_async_compute", AsyncCompute);
+    Antialiasing = aConfig.value("disable_antialiasing", Antialiasing);
+    DisableIntroMovies = aConfig.value("disable_intro_movies", DisableIntroMovies);
+    DisableVignette = aConfig.value("disable_vignette", DisableVignette);
+    DisableBoundaryTeleport = aConfig.value("disable_boundary_teleport", DisableBoundaryTeleport);
+    DisableWin7Vsync = aConfig.value("disable_win7_vsync", DisableWin7Vsync);
+    MinimapFlicker = aConfig.value("minimap_flicker", MinimapFlicker);
+}
+
+nlohmann::json PatchesSettings::Save() const
+{
+    return {
+      {"remove_pedestrians", RemovePedestrians},
+      {"disable_async_compute", AsyncCompute},
+      {"disable_antialiasing", Antialiasing},
+      {"skip_start_menu", SkipStartMenu},
+      {"amd_smt", AmdSmt},
+      {"disable_intro_movies", DisableIntroMovies},
+      {"disable_vignette", DisableVignette},
+      {"disable_boundary_teleport", DisableBoundaryTeleport},
+      {"disable_win7_vsync", DisableWin7Vsync},
+      {"minimap_flicker", MinimapFlicker},
+    };
+}
+
+void PatchesSettings::ResetToDefaults()
+{
+    RemovePedestrians = false;
+    AsyncCompute = false;
+    Antialiasing = false;
+    SkipStartMenu = false;
+    AmdSmt = false;
+    DisableIntroMovies = false;
+    DisableVignette = false;
+    DisableBoundaryTeleport = false;
+    DisableWin7Vsync = false;
+    MinimapFlicker = false;
+}
+
+void FontSettings::Load(const nlohmann::json& aConfig)
+{
+    Path = aConfig.value("path", Path);
+    GlyphRanges = aConfig.value("glyph_ranges", GlyphRanges);
+    SizeBase = aConfig.value("size_base", SizeBase);
+    OversampleHorizontal = aConfig.value("oversample_horizontal", OversampleHorizontal);
+    OversampleVertical = aConfig.value("oversample_vertical", OversampleVertical);
+}
+
+nlohmann::json FontSettings::Save() const
+{
+    return {
+      {"font_path", Path},
+      {"font_glyph_ranges", GlyphRanges},
+      {"font_size_base", SizeBase},
+      {"oversample_horizontal", OversampleHorizontal},
+      {"oversample_vertical", OversampleVertical}
+    };
+}
+
+void FontSettings::ResetToDefaults()
+{
+    Path = "";
+    GlyphRanges = "Default";
+    SizeBase = 18.0f;
+    OversampleHorizontal = 3;
+    OversampleVertical = 1;
+}
+
+void DeveloperSettings::Load(const nlohmann::json& aConfig)
+{
+    RemoveDeadBindings = aConfig.value("remove_dead_bindings", RemoveDeadBindings);
+    EnableImGuiAssertions = aConfig.value("enable_imgui_assertions", EnableImGuiAssertions);
+    DumpGameOptions = aConfig.value("dump_game_options", DumpGameOptions);
+    EnableDebug = aConfig.value("enable_debug", EnableDebug);
+
+    // set global "Enable ImGui Assertions"
+    g_ImGuiAssertionsEnabled = EnableImGuiAssertions;
+}
+
+nlohmann::json DeveloperSettings::Save() const
+{
+    // set global "Enable ImGui Assertions"
+    g_ImGuiAssertionsEnabled = EnableImGuiAssertions;
+
+    return {
+      {"remove_dead_bindings", RemoveDeadBindings},
+      {"enable_imgui_assertions", EnableImGuiAssertions},
+      {"enable_debug", EnableDebug},
+      {"dump_game_options", DumpGameOptions},
+    };
+}
+
+void DeveloperSettings::ResetToDefaults()
+{
+    RemoveDeadBindings = true;
+    EnableImGuiAssertions = false;
+    EnableDebug = false;
+    DumpGameOptions = false;
+
+    // set global "Enable ImGui Assertions"
+    g_ImGuiAssertionsEnabled = EnableImGuiAssertions;
+}
+
 void Options::Load()
 {
     const auto path = GetAbsolutePath(m_paths.Config(), "", false);
-    if (!path.empty())
-    {
-        std::ifstream configFile(path);
-        if(configFile)
-        {
-            const auto config = nlohmann::json::parse(configFile);
-            PatchRemovePedestrians = config.value("remove_pedestrians", PatchRemovePedestrians);
-            PatchSkipStartMenu = config.value("skip_start_menu", PatchSkipStartMenu);
-            PatchAmdSmt = config.value("amd_smt", PatchAmdSmt);
-            PatchAsyncCompute = config.value("disable_async_compute", PatchAsyncCompute);
-            PatchAntialiasing = config.value("disable_antialiasing", PatchAntialiasing);
-            PatchDisableIntroMovies = config.value("disable_intro_movies", PatchDisableIntroMovies);
-            PatchDisableVignette = config.value("disable_vignette", PatchDisableVignette);
-            PatchDisableBoundaryTeleport = config.value("disable_boundary_teleport", PatchDisableBoundaryTeleport);
-            PatchDisableWin7Vsync = config.value("disable_win7_vsync", PatchDisableWin7Vsync);
-            PatchMinimapFlicker = config.value("minimap_flicker", PatchMinimapFlicker);
+    if (path.empty())
+        return;
 
-            RemoveDeadBindings = config.value("cetdev_remove_dead_bindings", RemoveDeadBindings);
-            EnableImGuiAssertionsLogging = config.value("cetdev_enable_imgui_assertions_logging", EnableImGuiAssertionsLogging);
-            DumpGameOptions = config.value("dump_game_options", DumpGameOptions);
-            PatchEnableDebug = config.value("enable_debug", PatchEnableDebug);
+    std::ifstream configFile(path);
+    if(!configFile)
+        return;
 
-            // font config
-            FontPath = config.value("font_path", FontPath);
-            FontGlyphRanges = config.value("font_glyph_ranges", FontGlyphRanges);
-            FontSizeBase = config.value("font_size_base", FontSizeBase);
-            FontOversampleHorizontal = config.value("font_oversample_horizontal", FontOversampleHorizontal);
-            FontOversampleVertical = config.value("font_oversample_vertical", FontOversampleVertical);
+    auto config = nlohmann::json::parse(configFile);
 
-            // check old config names
-            if (config.value("unlock_menu", false))
-                PatchEnableDebug = true;
-        }
-        configFile.close();
-    }
+    // patches config
+    const auto& patchesConfig = config["patches"];
+    if (!patchesConfig.empty())
+        Patches.Load(patchesConfig);
 
-    // set global "Enable ImGui Assertions"
-    g_ImGuiAssertionsEnabled = EnableImGuiAssertionsLogging;
+    // font config
+    const auto& fontConfig = config["font"];
+    if (!fontConfig.empty())
+        Font.Load(fontConfig);
+
+    // developer config
+    const auto& developerConfig = config["developer"];
+    if (!developerConfig.empty())
+        Developer.Load(developerConfig);
 }
 
-void Options::Save()
+void Options::Save() const
 {
-    nlohmann::json config;
-
-    config["remove_pedestrians"] = PatchRemovePedestrians;
-    config["disable_async_compute"] = PatchAsyncCompute;
-    config["disable_antialiasing"] = PatchAntialiasing;
-    config["skip_start_menu"] = PatchSkipStartMenu;
-    config["amd_smt"] = PatchAmdSmt;
-    config["disable_intro_movies"] = PatchDisableIntroMovies;
-    config["disable_vignette"] = PatchDisableVignette;
-    config["disable_boundary_teleport"] = PatchDisableBoundaryTeleport;
-    config["disable_win7_vsync"] = PatchDisableWin7Vsync;
-    config["minimap_flicker"] = PatchMinimapFlicker;
-
-    config["cetdev_remove_dead_bindings"] = RemoveDeadBindings;
-    config["cetdev_enable_imgui_assertions_logging"] = EnableImGuiAssertionsLogging;
-    config["enable_debug"] = PatchEnableDebug;
-    config["dump_game_options"] = DumpGameOptions;
-
-    config["font_path"] = FontPath;
-    config["font_glyph_ranges"] = FontGlyphRanges;
-    config["font_size_base"] = FontSizeBase;
-    config["font_oversample_horizontal"] = FontOversampleHorizontal;
-    config["font_oversample_vertical"] = FontOversampleVertical;
+    nlohmann::json config = {
+      {"patches", Patches.Save()},
+      {"font", Font.Save()},
+      {"developer", Developer.Save()}
+    };
 
     const auto path = GetAbsolutePath(m_paths.Config(), "", true);
     std::ofstream o(path);
     o << config.dump(4) << std::endl;
-
-    // set global "Enable ImGui Assertions"
-    g_ImGuiAssertionsEnabled = EnableImGuiAssertionsLogging;
 }
 
 void Options::ResetToDefaults()
 {
-    PatchRemovePedestrians = false;
-    PatchAsyncCompute = false;
-    PatchAntialiasing = false;
-    PatchSkipStartMenu = false;
-    PatchAmdSmt = false;
-    PatchDisableIntroMovies = false;
-    PatchDisableVignette = false;
-    PatchDisableBoundaryTeleport = false;
-    PatchDisableWin7Vsync = false;
-    PatchMinimapFlicker = false;
-
-    RemoveDeadBindings = true;
-    EnableImGuiAssertionsLogging = false;
-    PatchEnableDebug = false;
-    DumpGameOptions = false;
-
-    FontPath = "";
-    FontGlyphRanges = "Default";
-    FontSizeBase = 18.0f;
-    FontOversampleHorizontal = 3;
-    FontOversampleVertical = 1;
+    Patches.ResetToDefaults();
+    Font.ResetToDefaults();
+    Developer.ResetToDefaults();
 
     Save();
 }
@@ -178,5 +233,11 @@ Options::Options(Paths& aPaths)
     }
 
     Load();
+    Save();
+}
+
+Options::~Options()
+{
+    // save on exit to make sure persistent state is preserved
     Save();
 }

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -51,8 +51,8 @@ void PatchesSettings::ResetToDefaults()
 void FontSettings::Load(const nlohmann::json& aConfig)
 {
     Path = aConfig.value("path", Path);
-    GlyphRanges = aConfig.value("glyph_ranges", GlyphRanges);
-    SizeBase = aConfig.value("size_base", SizeBase);
+    Language = aConfig.value("language", Language);
+    BaseSize = aConfig.value("base_size", BaseSize);
     OversampleHorizontal = aConfig.value("oversample_horizontal", OversampleHorizontal);
     OversampleVertical = aConfig.value("oversample_vertical", OversampleVertical);
 }
@@ -60,9 +60,9 @@ void FontSettings::Load(const nlohmann::json& aConfig)
 nlohmann::json FontSettings::Save() const
 {
     return {
-      {"font_path", Path},
-      {"font_glyph_ranges", GlyphRanges},
-      {"font_size_base", SizeBase},
+      {"path", Path},
+      {"language", Language},
+      {"base_size", BaseSize},
       {"oversample_horizontal", OversampleHorizontal},
       {"oversample_vertical", OversampleVertical}
     };
@@ -71,8 +71,8 @@ nlohmann::json FontSettings::Save() const
 void FontSettings::ResetToDefaults()
 {
     Path = "";
-    GlyphRanges = "Default";
-    SizeBase = 18.0f;
+    Language = "Default";
+    BaseSize = 18.0f;
     OversampleHorizontal = 3;
     OversampleVertical = 1;
 }
@@ -81,8 +81,8 @@ void DeveloperSettings::Load(const nlohmann::json& aConfig)
 {
     RemoveDeadBindings = aConfig.value("remove_dead_bindings", RemoveDeadBindings);
     EnableImGuiAssertions = aConfig.value("enable_imgui_assertions", EnableImGuiAssertions);
-    DumpGameOptions = aConfig.value("dump_game_options", DumpGameOptions);
     EnableDebug = aConfig.value("enable_debug", EnableDebug);
+    DumpGameOptions = aConfig.value("dump_game_options", DumpGameOptions);
 
     // set global "Enable ImGui Assertions"
     g_ImGuiAssertionsEnabled = EnableImGuiAssertions;
@@ -134,16 +134,6 @@ nlohmann::json OverlayPersistentState::Save() const
     };
 }
 
-void OverlayPersistentState::ResetToDefaults()
-{
-    ConsoleToggled = false;
-    BindingsToggled = false;
-    SettingsToggled = false;
-    TweakDBEditorToggled = false;
-    GameLogToggled = false;
-    ImGuiDebugToggled = false;
-}
-
 void PersistentState::Load(const nlohmann::json& aConfig)
 {
     const auto& overlayJson = aConfig["overlay"];
@@ -156,11 +146,6 @@ nlohmann::json PersistentState::Save() const
     return {
         {"overlay", Overlay.Save()}
     };
-}
-
-void PersistentState::ResetToDefaults()
-{
-    Overlay.ResetToDefaults();
 }
 
 void Options::Load(const bool acPersistentStateReload)
@@ -218,7 +203,6 @@ void Options::ResetToDefaults()
     Patches.ResetToDefaults();
     Font.ResetToDefaults();
     Developer.ResetToDefaults();
-    PersistentState.ResetToDefaults();
 
     Save();
 }

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -36,16 +36,7 @@ nlohmann::json PatchesSettings::Save() const
 
 void PatchesSettings::ResetToDefaults()
 {
-    RemovePedestrians = false;
-    AsyncCompute = false;
-    Antialiasing = false;
-    SkipStartMenu = false;
-    AmdSmt = false;
-    DisableIntroMovies = false;
-    DisableVignette = false;
-    DisableBoundaryTeleport = false;
-    DisableWin7Vsync = false;
-    MinimapFlicker = false;
+    *this = {};
 }
 
 void FontSettings::Load(const nlohmann::json& aConfig)
@@ -70,11 +61,7 @@ nlohmann::json FontSettings::Save() const
 
 void FontSettings::ResetToDefaults()
 {
-    Path = "";
-    Language = "Default";
-    BaseSize = 18.0f;
-    OversampleHorizontal = 3;
-    OversampleVertical = 1;
+    *this = {};
 }
 
 void DeveloperSettings::Load(const nlohmann::json& aConfig)
@@ -103,10 +90,7 @@ nlohmann::json DeveloperSettings::Save() const
 
 void DeveloperSettings::ResetToDefaults()
 {
-    RemoveDeadBindings = true;
-    EnableImGuiAssertions = false;
-    EnableDebug = false;
-    DumpGameOptions = false;
+    *this = {};
 
     // set global "Enable ImGui Assertions"
     g_ImGuiAssertionsEnabled = EnableImGuiAssertions;

--- a/src/Options.h
+++ b/src/Options.h
@@ -4,37 +4,64 @@
 
 struct Paths;
 
+struct PatchesSettings
+{
+    void Load(const nlohmann::json& aConfig);
+    nlohmann::json Save() const;
+    void ResetToDefaults();
+
+    bool RemovePedestrians{ false };
+    bool AsyncCompute{ false };
+    bool Antialiasing{ false };
+    bool SkipStartMenu{ false };
+    bool AmdSmt{ false };
+    bool DisableIntroMovies{ false };
+    bool DisableVignette{ false };
+    bool DisableBoundaryTeleport{ false };
+    bool DisableWin7Vsync{ false };
+    bool MinimapFlicker{ false };
+};
+
+struct FontSettings
+{
+    void Load(const nlohmann::json& aConfig);
+    nlohmann::json Save() const;
+    void ResetToDefaults();
+
+    std::string Path{ };
+    std::string GlyphRanges{"Default"};
+    float SizeBase{ 18.0f };
+    int32_t OversampleHorizontal{ 3 };
+    int32_t OversampleVertical{ 1 };
+};
+
+struct DeveloperSettings
+{
+    void Load(const nlohmann::json& aConfig);
+    nlohmann::json Save() const;
+    void ResetToDefaults();
+
+    bool RemoveDeadBindings{ true };
+    bool EnableImGuiAssertions{ false };
+    bool EnableDebug{ false };
+    bool DumpGameOptions{ false };
+};
+
 struct Options
 {
     Options(Paths& aPaths);
-    ~Options() = default;
+    ~Options();
 
     void Load();
-    void Save();
+    void Save() const;
     void ResetToDefaults();
 
     Image GameImage;
-    bool PatchEnableDebug{ false };
-    bool PatchRemovePedestrians{ false };
-    bool PatchAsyncCompute{ false };
-    bool PatchAntialiasing{ false };
-    bool PatchSkipStartMenu{ false };
-    bool PatchAmdSmt{ false };
-    bool PatchDisableIntroMovies{ false };
-    bool PatchDisableVignette{ false };
-    bool PatchDisableBoundaryTeleport{ false };
-    bool PatchDisableWin7Vsync{ false };
-    bool PatchMinimapFlicker{ false };
-    bool DumpGameOptions{ false };
-    std::string FontPath{ };
-    std::string FontGlyphRanges{"Default"};
-    float FontSizeBase{ 18.0f };
-    int32_t FontOversampleHorizontal{ 3 };
-    int32_t FontOversampleVertical{ 1 };
     bool ExeValid{ false };
-    bool RemoveDeadBindings{ true };
-    bool DrawImGuiDiagnosticWindow{ false };
-    bool EnableImGuiAssertionsLogging{ false };
+
+    PatchesSettings Patches{ };
+    FontSettings Font{ };
+    DeveloperSettings Developer{ };
 
 private:
 

--- a/src/Options.h
+++ b/src/Options.h
@@ -29,8 +29,8 @@ struct FontSettings
     void ResetToDefaults();
 
     std::string Path{ };
-    std::string GlyphRanges{"Default"};
-    float SizeBase{ 18.0f };
+    std::string Language{"Default"};
+    float BaseSize{ 18.0f };
     int32_t OversampleHorizontal{ 3 };
     int32_t OversampleVertical{ 1 };
 };
@@ -51,7 +51,6 @@ struct OverlayPersistentState
 {
     void Load(const nlohmann::json& aConfig);
     nlohmann::json Save() const;
-    void ResetToDefaults();
 
     bool ConsoleToggled = false;
     bool BindingsToggled = false;
@@ -65,7 +64,6 @@ struct PersistentState
 {
     void Load(const nlohmann::json& aConfig);
     nlohmann::json Save() const;
-    void ResetToDefaults();
 
     OverlayPersistentState Overlay{ };
 };

--- a/src/Options.h
+++ b/src/Options.h
@@ -47,12 +47,35 @@ struct DeveloperSettings
     bool DumpGameOptions{ false };
 };
 
+struct OverlayPersistentState
+{
+    void Load(const nlohmann::json& aConfig);
+    nlohmann::json Save() const;
+    void ResetToDefaults();
+
+    bool ConsoleToggled = false;
+    bool BindingsToggled = false;
+    bool SettingsToggled = false;
+    bool TweakDBEditorToggled = false;
+    bool GameLogToggled = false;
+    bool ImGuiDebugToggled = false;
+};
+
+struct PersistentState
+{
+    void Load(const nlohmann::json& aConfig);
+    nlohmann::json Save() const;
+    void ResetToDefaults();
+
+    OverlayPersistentState Overlay{ };
+};
+
 struct Options
 {
     Options(Paths& aPaths);
     ~Options();
 
-    void Load();
+    void Load(const bool acPersistentStateReload = false);
     void Save() const;
     void ResetToDefaults();
 
@@ -62,6 +85,7 @@ struct Options
     PatchesSettings Patches{ };
     FontSettings Font{ };
     DeveloperSettings Developer{ };
+    PersistentState PersistentState{ };
 
 private:
 

--- a/src/VKBindings.cpp
+++ b/src/VKBindings.cpp
@@ -98,7 +98,7 @@ void VKBindings::InitializeMods(const TiltedPhoques::Map<std::string, std::refer
         if (currentModBindingsIt == acVKBinds.cend())
         {
             // when we want to filter dead bindings, mark mod for removal (default)
-            if (m_cOptions.RemoveDeadBindings)
+            if (m_cOptions.Developer.RemoveDeadBindings)
             {
                 deadMods.emplace_back(modName);
                 continue;
@@ -134,7 +134,7 @@ void VKBindings::InitializeMods(const TiltedPhoques::Map<std::string, std::refer
         // register them otherwise to prevent rebinds
         for (const auto& deadId : deadIDs)
         {
-            if (m_cOptions.RemoveDeadBindings)
+            if (m_cOptions.Developer.RemoveDeadBindings)
                 m_modIdToBinds[modName].erase(deadId);
             else
                 Bind(m_modIdToBinds[modName][deadId], {modName, deadId});

--- a/src/d3d12/D3D12_Functions.cpp
+++ b/src/d3d12/D3D12_Functions.cpp
@@ -281,7 +281,7 @@ void D3D12::ReloadFonts()
 
     ImFontConfig config;
     const auto& fontSettings = m_options.Font;
-    config.SizePixels = std::floorf(fontSettings.SizeBase * scaleFromReference);
+    config.SizePixels = std::floorf(fontSettings.BaseSize * scaleFromReference);
     config.OversampleH = fontSettings.OversampleHorizontal;
     config.OversampleV = fontSettings.OversampleVertical;
     if (config.OversampleH == 1 && config.OversampleV == 1)
@@ -308,37 +308,37 @@ void D3D12::ReloadFonts()
     else
         io.Fonts->AddFontFromFileTTF(UTF16ToUTF8(customFontPath.native()).c_str(), config.SizePixels, &config, cpGlyphRanges);
 
-    if (fontSettings.GlyphRanges == "ChineseFull")
+    if (fontSettings.Language == "ChineseFull")
     {
         cetFontPath = GetAbsolutePath(m_paths.Fonts() / L"NotoSansTC-Regular.otf", m_paths.Fonts(), false);
         cpGlyphRanges = io.Fonts->GetGlyphRangesChineseFull();
     }
-    else if (fontSettings.GlyphRanges == "ChineseSimplifiedCommon")
+    else if (fontSettings.Language == "ChineseSimplifiedCommon")
     {
         cetFontPath = GetAbsolutePath(m_paths.Fonts() / L"NotoSansSC-Regular.otf", m_paths.Fonts(), false);
         cpGlyphRanges = io.Fonts->GetGlyphRangesChineseSimplifiedCommon();
     }
-    else if (fontSettings.GlyphRanges == "Japanese")
+    else if (fontSettings.Language == "Japanese")
     {
         cetFontPath = GetAbsolutePath(m_paths.Fonts() / L"NotoSansJP-Regular.otf", m_paths.Fonts(), false);
         cpGlyphRanges = io.Fonts->GetGlyphRangesJapanese();
     }
-    else if (fontSettings.GlyphRanges == "Korean")
+    else if (fontSettings.Language == "Korean")
     {
         cetFontPath = GetAbsolutePath(m_paths.Fonts() / L"NotoSansKR-Regular.otf", m_paths.Fonts(), false);
         cpGlyphRanges = io.Fonts->GetGlyphRangesKorean();
     }
-    else if (fontSettings.GlyphRanges == "Cyrillic")
+    else if (fontSettings.Language == "Cyrillic")
     {
         cetFontPath = GetAbsolutePath(m_paths.Fonts() / L"NotoSans-Regular.ttf", m_paths.Fonts(), false);
         cpGlyphRanges = io.Fonts->GetGlyphRangesCyrillic();
     }
-    else if (fontSettings.GlyphRanges == "Thai")
+    else if (fontSettings.Language == "Thai")
     {
         cetFontPath = GetAbsolutePath(m_paths.Fonts() / L"NotoSansThai-Regular.ttf", m_paths.Fonts(), false);
         cpGlyphRanges = io.Fonts->GetGlyphRangesThai();
     }
-    else if (fontSettings.GlyphRanges == "Vietnamese")
+    else if (fontSettings.Language == "Vietnamese")
     {
         cetFontPath = GetAbsolutePath(m_paths.Fonts() / L"NotoSans-Regular.ttf", m_paths.Fonts(), false);
         cpGlyphRanges = io.Fonts->GetGlyphRangesVietnamese();

--- a/src/d3d12/D3D12_Functions.cpp
+++ b/src/d3d12/D3D12_Functions.cpp
@@ -280,20 +280,21 @@ void D3D12::ReloadFonts()
     io.Fonts->Clear();
 
     ImFontConfig config;
-    config.SizePixels = std::floorf(m_options.FontSizeBase * scaleFromReference);
-    config.OversampleH = m_options.FontOversampleHorizontal;
-    config.OversampleV = m_options.FontOversampleVertical;
+    const auto& fontSettings = m_options.Font;
+    config.SizePixels = std::floorf(fontSettings.SizeBase * scaleFromReference);
+    config.OversampleH = fontSettings.OversampleHorizontal;
+    config.OversampleV = fontSettings.OversampleVertical;
     if (config.OversampleH == 1 && config.OversampleV == 1)
         config.PixelSnapH = true;
     config.MergeMode = false;
 
     // add default font
-    const auto customFontPath = m_options.FontPath.empty() ? std::filesystem::path{} : GetAbsolutePath(UTF8ToUTF16(m_options.FontPath), m_paths.Fonts(), false);
+    const auto customFontPath = fontSettings.Path.empty() ? std::filesystem::path{} : GetAbsolutePath(UTF8ToUTF16(fontSettings.Path), m_paths.Fonts(), false);
     auto cetFontPath = GetAbsolutePath(L"NotoSans-Regular.ttf", m_paths.Fonts(), false);
     const auto* cpGlyphRanges = io.Fonts->GetGlyphRangesDefault();
     if (customFontPath.empty())
     {
-        if (!m_options.FontPath.empty())
+        if (!fontSettings.Path.empty())
             Log::Warn("D3D12::ReloadFonts() - Custom font path is invalid! Using default CET font.");
 
         if (cetFontPath.empty())
@@ -307,37 +308,37 @@ void D3D12::ReloadFonts()
     else
         io.Fonts->AddFontFromFileTTF(UTF16ToUTF8(customFontPath.native()).c_str(), config.SizePixels, &config, cpGlyphRanges);
 
-    if (m_options.FontGlyphRanges == "ChineseFull")
+    if (fontSettings.GlyphRanges == "ChineseFull")
     {
         cetFontPath = GetAbsolutePath(m_paths.Fonts() / L"NotoSansTC-Regular.otf", m_paths.Fonts(), false);
         cpGlyphRanges = io.Fonts->GetGlyphRangesChineseFull();
     }
-    else if (m_options.FontGlyphRanges == "ChineseSimplifiedCommon")
+    else if (fontSettings.GlyphRanges == "ChineseSimplifiedCommon")
     {
         cetFontPath = GetAbsolutePath(m_paths.Fonts() / L"NotoSansSC-Regular.otf", m_paths.Fonts(), false);
         cpGlyphRanges = io.Fonts->GetGlyphRangesChineseSimplifiedCommon();
     }
-    else if (m_options.FontGlyphRanges == "Japanese")
+    else if (fontSettings.GlyphRanges == "Japanese")
     {
         cetFontPath = GetAbsolutePath(m_paths.Fonts() / L"NotoSansJP-Regular.otf", m_paths.Fonts(), false);
         cpGlyphRanges = io.Fonts->GetGlyphRangesJapanese();
     }
-    else if (m_options.FontGlyphRanges == "Korean")
+    else if (fontSettings.GlyphRanges == "Korean")
     {
         cetFontPath = GetAbsolutePath(m_paths.Fonts() / L"NotoSansKR-Regular.otf", m_paths.Fonts(), false);
         cpGlyphRanges = io.Fonts->GetGlyphRangesKorean();
     }
-    else if (m_options.FontGlyphRanges == "Cyrillic")
+    else if (fontSettings.GlyphRanges == "Cyrillic")
     {
         cetFontPath = GetAbsolutePath(m_paths.Fonts() / L"NotoSans-Regular.ttf", m_paths.Fonts(), false);
         cpGlyphRanges = io.Fonts->GetGlyphRangesCyrillic();
     }
-    else if (m_options.FontGlyphRanges == "Thai")
+    else if (fontSettings.GlyphRanges == "Thai")
     {
         cetFontPath = GetAbsolutePath(m_paths.Fonts() / L"NotoSansThai-Regular.ttf", m_paths.Fonts(), false);
         cpGlyphRanges = io.Fonts->GetGlyphRangesThai();
     }
-    else if (m_options.FontGlyphRanges == "Vietnamese")
+    else if (fontSettings.GlyphRanges == "Vietnamese")
     {
         cetFontPath = GetAbsolutePath(m_paths.Fonts() / L"NotoSans-Regular.ttf", m_paths.Fonts(), false);
         cpGlyphRanges = io.Fonts->GetGlyphRangesVietnamese();
@@ -388,7 +389,7 @@ void D3D12::ReloadFonts()
     config.MergeMode = true;
     if (customFontPath.empty())
     {
-        if (!m_options.FontPath.empty())
+        if (!fontSettings.Path.empty())
             Log::Warn("D3D12::ReloadFonts() - Custom font path is invalid! Using default CET font.");
 
         if (cetFontPath.empty())

--- a/src/d3d12/D3D12_Hooks.cpp
+++ b/src/d3d12/D3D12_Hooks.cpp
@@ -12,7 +12,7 @@
 
 HRESULT D3D12::PresentDownlevel(ID3D12CommandQueueDownlevel* apCommandQueueDownlevel, ID3D12GraphicsCommandList* apOpenCommandList, ID3D12Resource* apSourceTex2D, HWND ahWindow, D3D12_DOWNLEVEL_PRESENT_FLAGS aFlags)
 {
-    if (CET::Get().GetOptions().PatchDisableWin7Vsync)
+    if (CET::Get().GetOptions().Patches.DisableWin7Vsync)
         aFlags &= ~D3D12_DOWNLEVEL_PRESENT_FLAG_WAIT_FOR_VBLANK;
 
     auto& d3d12 = CET::Get().GetD3D12();

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -38,28 +38,28 @@ static void Initialize()
             return;
 
         // initialize patches
-        if (options.PatchEnableDebug)
+        if (options.Developer.EnableDebug)
             EnableDebugPatch();
 
-        if (options.PatchSkipStartMenu)
+        if (options.Patches.SkipStartMenu)
             StartScreenPatch();
 
-        if (options.PatchRemovePedestrians)
+        if (options.Patches.RemovePedestrians)
             RemovePedsPatch();
 
-        if (options.PatchDisableIntroMovies)
+        if (options.Patches.DisableIntroMovies)
             DisableIntroMoviesPatch();
 
-        if (options.PatchDisableVignette)
+        if (options.Patches.DisableVignette)
             DisableVignettePatch();
 
-        if (options.PatchDisableBoundaryTeleport)
+        if (options.Patches.DisableBoundaryTeleport)
             DisableBoundaryTeleportPatch();
 
-        if (options.PatchAmdSmt)
+        if (options.Patches.AmdSmt)
             SmtAmdPatch();
 
-        if (options.PatchMinimapFlicker)
+        if (options.Patches.MinimapFlicker)
             MinimapFlickerPatch();
 
         OptionsInitHook();

--- a/src/overlay/Overlay.cpp
+++ b/src/overlay/Overlay.cpp
@@ -62,11 +62,13 @@ void Overlay::Update()
         if (m_bindings.FirstTimeSetup())
             return;
 
+        const auto& persistentState = m_options.PersistentState.Overlay;
+
         auto drawPopup = false;
         WidgetResult disableResult;
         if (m_enabled)
         {
-            if (m_toggled && !drawPopup && m_consoleEnabled)
+            if (m_toggled && !drawPopup && persistentState.ConsoleToggled)
             {
                 disableResult = m_console.OnDisable();
                 if (disableResult == WidgetResult::CANCEL)
@@ -75,7 +77,7 @@ void Overlay::Update()
                     drawPopup = true;
             }
 
-            if (m_toggled && !drawPopup && m_bindingsEnabled)
+            if (m_toggled && !drawPopup && persistentState.BindingsToggled)
             {
                 disableResult = m_bindings.OnDisable();
                 if (disableResult == WidgetResult::CANCEL)
@@ -84,7 +86,7 @@ void Overlay::Update()
                     drawPopup = true;
             }
 
-            if (m_toggled && !drawPopup && m_settingsEnabled)
+            if (m_toggled && !drawPopup && persistentState.SettingsToggled)
             {
                 disableResult = m_settings.OnDisable();
                 if (disableResult == WidgetResult::CANCEL)
@@ -93,7 +95,7 @@ void Overlay::Update()
                     drawPopup = true;
             }
 
-            if (m_toggled && !drawPopup && m_tweakDBEditorEnabled)
+            if (m_toggled && !drawPopup && persistentState.TweakDBEditorToggled)
             {
                 disableResult = m_tweakDBEditor.OnDisable();
                 if (disableResult == WidgetResult::CANCEL)
@@ -102,7 +104,7 @@ void Overlay::Update()
                     drawPopup = true;
             }
 
-            if (m_toggled && !drawPopup && m_gameLogEnabled)
+            if (m_toggled && !drawPopup && persistentState.GameLogToggled)
             {
                 disableResult = m_gameLog.OnDisable();
                 if (disableResult == WidgetResult::CANCEL)
@@ -111,7 +113,7 @@ void Overlay::Update()
                     drawPopup = true;
             }
 
-            if (m_toggled && !drawPopup && m_imguiDebugEnabled)
+            if (m_toggled && !drawPopup && persistentState.ImGuiDebugToggled)
             {
                 disableResult = m_imguiDebug.OnDisable();
                 if (disableResult == WidgetResult::CANCEL)
@@ -122,7 +124,7 @@ void Overlay::Update()
         }
         else
         {
-            if (m_toggled && !drawPopup && m_consoleEnabled)
+            if (m_toggled && !drawPopup && persistentState.ConsoleToggled)
             {
                 disableResult = m_console.OnEnable();
                 if (disableResult == WidgetResult::CANCEL)
@@ -131,7 +133,7 @@ void Overlay::Update()
                     drawPopup = true;
             }
 
-            if (m_toggled && !drawPopup && m_bindingsEnabled)
+            if (m_toggled && !drawPopup && persistentState.BindingsToggled)
             {
                 disableResult = m_bindings.OnEnable();
                 if (disableResult == WidgetResult::CANCEL)
@@ -140,7 +142,7 @@ void Overlay::Update()
                     drawPopup = true;
             }
 
-            if (m_toggled && !drawPopup && m_settingsEnabled)
+            if (m_toggled && !drawPopup && persistentState.SettingsToggled)
             {
                 disableResult = m_settings.OnEnable();
                 if (disableResult == WidgetResult::CANCEL)
@@ -149,7 +151,7 @@ void Overlay::Update()
                     drawPopup = true;
             }
 
-            if (m_toggled && !drawPopup && m_tweakDBEditorEnabled)
+            if (m_toggled && !drawPopup && persistentState.TweakDBEditorToggled)
             {
                 disableResult = m_tweakDBEditor.OnEnable();
                 if (disableResult == WidgetResult::CANCEL)
@@ -158,7 +160,7 @@ void Overlay::Update()
                     drawPopup = true;
             }
 
-            if (m_toggled && !drawPopup && m_gameLogEnabled)
+            if (m_toggled && !drawPopup && persistentState.GameLogToggled)
             {
                 disableResult = m_gameLog.OnEnable();
                 if (disableResult == WidgetResult::CANCEL)
@@ -167,7 +169,7 @@ void Overlay::Update()
                     drawPopup = true;
             }
 
-            if (m_toggled && !drawPopup && m_imguiDebugEnabled)
+            if (m_toggled && !drawPopup && persistentState.ImGuiDebugToggled)
             {
                 disableResult = m_imguiDebug.OnEnable();
                 if (disableResult == WidgetResult::CANCEL)
@@ -281,57 +283,58 @@ Overlay::~Overlay()
 void Overlay::DrawToolbar()
 {
     const auto itemWidth = GetAlignedItemWidth(7);
+    auto& persistentState = m_options.PersistentState.Overlay;
 
-    ImGui::PushStyleColor(ImGuiCol_Button, m_consoleEnabled ? ImGui::GetStyleColorVec4(ImGuiCol_ButtonActive) : ImGui::GetStyleColorVec4(ImGuiCol_Button));
+    ImGui::PushStyleColor(ImGuiCol_Button, persistentState.ConsoleToggled ? ImGui::GetStyleColorVec4(ImGuiCol_ButtonActive) : ImGui::GetStyleColorVec4(ImGuiCol_Button));
     if (ImGui::Button("Console", ImVec2(itemWidth, 0)))
         m_console.Toggle();
     if (!m_toggled)
-        m_consoleEnabled = m_console.IsEnabled();
+        persistentState.ConsoleToggled = m_console.IsEnabled();
     ImGui::PopStyleColor();
 
     ImGui::SameLine();
 
-    ImGui::PushStyleColor(ImGuiCol_Button, m_bindingsEnabled ? ImGui::GetStyleColorVec4(ImGuiCol_ButtonActive) : ImGui::GetStyleColorVec4(ImGuiCol_Button));
+    ImGui::PushStyleColor(ImGuiCol_Button, persistentState.BindingsToggled ? ImGui::GetStyleColorVec4(ImGuiCol_ButtonActive) : ImGui::GetStyleColorVec4(ImGuiCol_Button));
     if (ImGui::Button("Bindings", ImVec2(itemWidth, 0)))
         m_bindings.Toggle();
     if (!m_toggled)
-        m_bindingsEnabled = m_bindings.IsEnabled();
+        persistentState.BindingsToggled = m_bindings.IsEnabled();
     ImGui::PopStyleColor();
 
     ImGui::SameLine();
 
-    ImGui::PushStyleColor(ImGuiCol_Button, m_settingsEnabled ? ImGui::GetStyleColorVec4(ImGuiCol_ButtonActive) : ImGui::GetStyleColorVec4(ImGuiCol_Button));
+    ImGui::PushStyleColor(ImGuiCol_Button, persistentState.SettingsToggled ? ImGui::GetStyleColorVec4(ImGuiCol_ButtonActive) : ImGui::GetStyleColorVec4(ImGuiCol_Button));
     if (ImGui::Button("Settings", ImVec2(itemWidth, 0)))
         m_settings.Toggle();
     if (!m_toggled)
-        m_settingsEnabled = m_settings.IsEnabled();
+        persistentState.SettingsToggled = m_settings.IsEnabled();
     ImGui::PopStyleColor();
 
     ImGui::SameLine();
 
-    ImGui::PushStyleColor(ImGuiCol_Button, m_tweakDBEditorEnabled ? ImGui::GetStyleColorVec4(ImGuiCol_ButtonActive) : ImGui::GetStyleColorVec4(ImGuiCol_Button));
+    ImGui::PushStyleColor(ImGuiCol_Button, persistentState.TweakDBEditorToggled ? ImGui::GetStyleColorVec4(ImGuiCol_ButtonActive) : ImGui::GetStyleColorVec4(ImGuiCol_Button));
     if (ImGui::Button("TweakDB Editor", ImVec2(itemWidth, 0)))
         m_tweakDBEditor.Toggle();
     if (!m_toggled)
-        m_tweakDBEditorEnabled = m_tweakDBEditor.IsEnabled();
+        persistentState.TweakDBEditorToggled = m_tweakDBEditor.IsEnabled();
     ImGui::PopStyleColor();
 
     ImGui::SameLine();
 
-    ImGui::PushStyleColor(ImGuiCol_Button, m_gameLogEnabled ? ImGui::GetStyleColorVec4(ImGuiCol_ButtonActive) : ImGui::GetStyleColorVec4(ImGuiCol_Button));
+    ImGui::PushStyleColor(ImGuiCol_Button, persistentState.GameLogToggled ? ImGui::GetStyleColorVec4(ImGuiCol_ButtonActive) : ImGui::GetStyleColorVec4(ImGuiCol_Button));
     if (ImGui::Button("Game Log", ImVec2(itemWidth, 0)))
         m_gameLog.Toggle();
     if (!m_toggled)
-        m_gameLogEnabled = m_gameLog.IsEnabled();
+        persistentState.GameLogToggled = m_gameLog.IsEnabled();
     ImGui::PopStyleColor();
 
     ImGui::SameLine();
 
-    ImGui::PushStyleColor(ImGuiCol_Button, m_imguiDebugEnabled ? ImGui::GetStyleColorVec4(ImGuiCol_ButtonActive) : ImGui::GetStyleColorVec4(ImGuiCol_Button));
+    ImGui::PushStyleColor(ImGuiCol_Button, persistentState.ImGuiDebugToggled ? ImGui::GetStyleColorVec4(ImGuiCol_ButtonActive) : ImGui::GetStyleColorVec4(ImGuiCol_Button));
     if (ImGui::Button("ImGui Debug", ImVec2(itemWidth, 0)))
         m_imguiDebug.Toggle();
     if (!m_toggled)
-        m_imguiDebugEnabled = m_imguiDebug.IsEnabled();
+        persistentState.ImGuiDebugToggled = m_imguiDebug.IsEnabled();
     ImGui::PopStyleColor();
 
     ImGui::SameLine();

--- a/src/overlay/Overlay.h
+++ b/src/overlay/Overlay.h
@@ -38,17 +38,11 @@ private:
     void DrawToolbar();
 
     Console m_console;
-    bool m_consoleEnabled = false;
     Bindings m_bindings;
-    bool m_bindingsEnabled = false;
     Settings m_settings;
-    bool m_settingsEnabled = false;
     TweakDBEditor m_tweakDBEditor;
-    bool m_tweakDBEditorEnabled = false;
     GameLog m_gameLog;
-    bool m_gameLogEnabled = false;
     ImGuiDebug m_imguiDebug;
-    bool m_imguiDebugEnabled = false;
 
     TClipToCenter* m_realClipToCenter{ nullptr };
 

--- a/src/overlay/widgets/Bindings.cpp
+++ b/src/overlay/widgets/Bindings.cpp
@@ -164,6 +164,8 @@ bool Bindings::FirstTimeSetup()
     if (m_vkBindInfos.empty())
         Initialize();
 
+    m_vm.BlockDraw(true);
+
     ImGui::OpenPopup("CET First Time Setup");
 
     if (ImGui::BeginPopupModal("CET First Time Setup", nullptr, ImGuiWindowFlags_AlwaysAutoResize))

--- a/src/overlay/widgets/Settings.cpp
+++ b/src/overlay/widgets/Settings.cpp
@@ -70,16 +70,17 @@ void Settings::OnUpdate()
             ImGui::TreePush();
             if (ImGui::BeginTable("##SETTINGS_PATCHES", 2, ImGuiTableFlags_Sortable | ImGuiTableFlags_SizingStretchSame, ImVec2(-ImGui::GetStyle().IndentSpacing, 0)))
             {
-                UpdateAndDrawSetting("AMD SMT Patch", "For AMD CPUs that did not get a performance boost after CDPR's patch (requires restart to take effect).", m_patchAmdSmt, m_options.PatchAmdSmt);
-                UpdateAndDrawSetting("Remove Pedestrians", "Removes most of the pedestrians and traffic (requires restart to take effect).", m_patchRemovePedestrians, m_options.PatchRemovePedestrians);
-                UpdateAndDrawSetting("Disable Async Compute", "Disables async compute, this can give a boost on older GPUs like Nvidia 10xx series for example (requires restart to take effect).", m_patchAsyncCompute, m_options.PatchAsyncCompute);
-                UpdateAndDrawSetting("Disable Anti-aliasing", "Completely disables anti-aliasing (requires restart to take effect).", m_patchAntialiasing, m_options.PatchAntialiasing);
-                UpdateAndDrawSetting("Skip Start Menu", "Skips the 'Breaching...' menu asking you to press space bar to continue (requires restart to take effect).", m_patchSkipStartMenu, m_options.PatchSkipStartMenu);
-                UpdateAndDrawSetting("Suppress Intro Movies", "Disables logos played at the beginning (requires restart to take effect).", m_patchDisableIntroMovies, m_options.PatchDisableIntroMovies);
-                UpdateAndDrawSetting("Disable Vignette", "Disables vignetting along screen borders (requires restart to take effect).", m_patchDisableVignette, m_options.PatchDisableVignette);
-                UpdateAndDrawSetting("Disable Boundary Teleport", "Allows players to access out-of-bounds locations (requires restart to take effect).", m_patchDisableBoundaryTeleport, m_options.PatchDisableBoundaryTeleport);
-                UpdateAndDrawSetting("Disable V-Sync (Windows 7 only)", " (requires restart to take effect).", m_patchDisableWin7Vsync, m_options.PatchDisableWin7Vsync);
-                UpdateAndDrawSetting("Fix Minimap Flicker", "Disables VSync on Windows 7 to bypass the 60 FPS limit (requires restart to take effect).", m_patchMinimapFlicker, m_options.PatchMinimapFlicker);
+                const auto& patchesSettings = m_options.Patches;
+                UpdateAndDrawSetting("AMD SMT Patch", "For AMD CPUs that did not get a performance boost after CDPR's patch (requires restart to take effect).", m_patches.AmdSmt, patchesSettings.AmdSmt);
+                UpdateAndDrawSetting("Remove Pedestrians", "Removes most of the pedestrians and traffic (requires restart to take effect).", m_patches.RemovePedestrians, patchesSettings.RemovePedestrians);
+                UpdateAndDrawSetting("Disable Async Compute", "Disables async compute, this can give a boost on older GPUs like Nvidia 10xx series for example (requires restart to take effect).", m_patches.AsyncCompute, patchesSettings.AsyncCompute);
+                UpdateAndDrawSetting("Disable Anti-aliasing", "Completely disables anti-aliasing (requires restart to take effect).", m_patches.Antialiasing, patchesSettings.Antialiasing);
+                UpdateAndDrawSetting("Skip Start Menu", "Skips the 'Breaching...' menu asking you to press space bar to continue (requires restart to take effect).", m_patches.SkipStartMenu, patchesSettings.SkipStartMenu);
+                UpdateAndDrawSetting("Suppress Intro Movies", "Disables logos played at the beginning (requires restart to take effect).", m_patches.DisableIntroMovies, patchesSettings.DisableIntroMovies);
+                UpdateAndDrawSetting("Disable Vignette", "Disables vignetting along screen borders (requires restart to take effect).", m_patches.DisableVignette, patchesSettings.DisableVignette);
+                UpdateAndDrawSetting("Disable Boundary Teleport", "Allows players to access out-of-bounds locations (requires restart to take effect).", m_patches.DisableBoundaryTeleport, patchesSettings.DisableBoundaryTeleport);
+                UpdateAndDrawSetting("Disable V-Sync (Windows 7 only)", " (requires restart to take effect).", m_patches.DisableWin7Vsync, patchesSettings.DisableWin7Vsync);
+                UpdateAndDrawSetting("Fix Minimap Flicker", "Disables VSync on Windows 7 to bypass the 60 FPS limit (requires restart to take effect).", m_patches.MinimapFlicker, patchesSettings.MinimapFlicker);
 
                 ImGui::EndTable();
             }
@@ -90,10 +91,11 @@ void Settings::OnUpdate()
             ImGui::TreePush();
             if (ImGui::BeginTable("##SETTINGS_DEV", 2, ImGuiTableFlags_Sortable | ImGuiTableFlags_SizingStretchSame, ImVec2(-ImGui::GetStyle().IndentSpacing, 0)))
             {
-                UpdateAndDrawSetting("Remove Dead Bindings", "Removes all bindings which are no longer valid (disabling this could be useful when debugging mod issues).", m_removeDeadBindings, m_options.RemoveDeadBindings);
-                UpdateAndDrawSetting("Enable ImGui Assertions Logging", "Enables all ImGui assertions, assertions will get logged into log file of whoever triggered the assertion (useful when debugging ImGui issues, should also be used to check mods before shipping!).", m_enableImGuiAssertionsLogging, m_options.EnableImGuiAssertionsLogging);
-                UpdateAndDrawSetting("Enable Debug Build", "Sets internal flags to disguise as debug build (requires restart to take effect).", m_patchEnableDebug, m_options.PatchEnableDebug);
-                UpdateAndDrawSetting("Dump Game Options", "Dumps all game options into main log file (requires restart to take effect).", m_dumpGameOptions, m_options.DumpGameOptions);
+                const auto& developerSettings = m_options.Developer;
+                UpdateAndDrawSetting("Remove Dead Bindings", "Removes all bindings which are no longer valid (disabling this could be useful when debugging mod issues).", m_developer.RemoveDeadBindings, developerSettings.RemoveDeadBindings);
+                UpdateAndDrawSetting("Enable ImGui Assertions", "Enables all ImGui assertions, assertions will get logged into log file of whoever triggered the assertion (useful when debugging ImGui issues, should also be used to check mods before shipping!).", m_developer.EnableImGuiAssertions, developerSettings.EnableImGuiAssertions);
+                UpdateAndDrawSetting("Enable Debug Build", "Sets internal flags to disguise as debug build (requires restart to take effect).", m_developer.EnableDebug, developerSettings.EnableDebug);
+                UpdateAndDrawSetting("Dump Game Options", "Dumps all game options into main log file (requires restart to take effect).", m_developer.DumpGameOptions, developerSettings.DumpGameOptions);
 
                 ImGui::EndTable();
             }
@@ -119,40 +121,14 @@ void Settings::Load()
 {
     m_options.Load();
 
-    m_patchRemovePedestrians = m_options.PatchRemovePedestrians;
-    m_patchAsyncCompute = m_options.PatchAsyncCompute;
-    m_patchAntialiasing = m_options.PatchAntialiasing;
-    m_patchSkipStartMenu = m_options.PatchSkipStartMenu;
-    m_patchAmdSmt = m_options.PatchAmdSmt;
-    m_patchDisableIntroMovies = m_options.PatchDisableIntroMovies;
-    m_patchDisableVignette = m_options.PatchDisableVignette;
-    m_patchDisableBoundaryTeleport = m_options.PatchDisableBoundaryTeleport;
-    m_patchDisableWin7Vsync = m_options.PatchDisableWin7Vsync;
-    m_patchMinimapFlicker = m_options.PatchMinimapFlicker;
-
-    m_removeDeadBindings = m_options.RemoveDeadBindings;
-    m_enableImGuiAssertionsLogging = m_options.EnableImGuiAssertionsLogging;
-    m_patchEnableDebug = m_options.PatchEnableDebug;
-    m_dumpGameOptions = m_options.DumpGameOptions;
+    m_patches = m_options.Patches;
+    m_developer = m_options.Developer;
 }
 
 void Settings::Save() const
 {
-    m_options.PatchRemovePedestrians = m_patchRemovePedestrians;
-    m_options.PatchAsyncCompute = m_patchAsyncCompute;
-    m_options.PatchAntialiasing = m_patchAntialiasing;
-    m_options.PatchSkipStartMenu = m_patchSkipStartMenu;
-    m_options.PatchAmdSmt = m_patchAmdSmt;
-    m_options.PatchDisableIntroMovies = m_patchDisableIntroMovies;
-    m_options.PatchDisableVignette = m_patchDisableVignette;
-    m_options.PatchDisableBoundaryTeleport = m_patchDisableBoundaryTeleport;
-    m_options.PatchDisableWin7Vsync = m_patchDisableWin7Vsync;
-    m_options.PatchMinimapFlicker = m_patchMinimapFlicker;
-
-    m_options.RemoveDeadBindings = m_removeDeadBindings;
-    m_options.EnableImGuiAssertionsLogging = m_enableImGuiAssertionsLogging;
-    m_options.PatchEnableDebug = m_patchEnableDebug;
-    m_options.DumpGameOptions = m_dumpGameOptions;
+    m_options.Patches = m_patches;
+    m_options.Developer = m_developer;
 
     m_options.Save();
 }
@@ -160,7 +136,9 @@ void Settings::Save() const
 void Settings::ResetToDefaults()
 {
     m_options.ResetToDefaults();
-    Load();
+
+    m_patches = m_options.Patches;
+    m_developer = m_options.Developer;
 }
 
 void Settings::UpdateAndDrawSetting(const std::string& acLabel, const std::string& acTooltip, bool& aCurrent, const bool& acSaved)

--- a/src/overlay/widgets/Settings.cpp
+++ b/src/overlay/widgets/Settings.cpp
@@ -11,16 +11,7 @@ Settings::Settings(Options& aOptions, LuaVM& aVm)
     , m_options(aOptions)
     , m_vm(aVm)
 {
-}
-
-WidgetResult Settings::OnEnable()
-{
-    if (!m_enabled)
-    {
-        Load();
-        m_enabled = true;
-    }
-    return m_enabled ? WidgetResult::ENABLED : WidgetResult::DISABLED;
+    Load();
 }
 
 WidgetResult Settings::OnPopup()

--- a/src/overlay/widgets/Settings.h
+++ b/src/overlay/widgets/Settings.h
@@ -10,7 +10,6 @@ struct Settings : Widget
     Settings(Options& aOptions, LuaVM& aVm);
     ~Settings() override = default;
 
-    WidgetResult OnEnable() override;
     WidgetResult OnDisable() override;
 
     void Load();

--- a/src/overlay/widgets/Settings.h
+++ b/src/overlay/widgets/Settings.h
@@ -2,7 +2,8 @@
 
 #include "Widget.h"
 
-struct Options;
+#include <Options.h>
+
 struct LuaVM;
 struct Settings : Widget
 {
@@ -23,20 +24,8 @@ protected:
 private:
     void UpdateAndDrawSetting(const std::string& acLabel, const std::string& acTooltip, bool& aCurrent, const bool& acSaved);
 
-    bool m_patchEnableDebug{ false };
-    bool m_patchRemovePedestrians{ false };
-    bool m_patchAsyncCompute{ false };
-    bool m_patchAntialiasing{ false };
-    bool m_patchSkipStartMenu{ false };
-    bool m_patchAmdSmt{ false };
-    bool m_patchDisableIntroMovies{ false };
-    bool m_patchDisableVignette{ false };
-    bool m_patchDisableBoundaryTeleport{ false };
-    bool m_patchDisableWin7Vsync{ false };
-    bool m_patchMinimapFlicker{ false };
-    bool m_dumpGameOptions{ false };
-    bool m_removeDeadBindings{ true };
-    bool m_enableImGuiAssertionsLogging{ false };
+    PatchesSettings m_patches;
+    DeveloperSettings m_developer;
 
     Options& m_options;
     LuaVM& m_vm;

--- a/src/patches/OptionsPatch.cpp
+++ b/src/patches/OptionsPatch.cpp
@@ -16,17 +16,17 @@ void* HookGameOptionInit(GameOption* apThis)
         gameOptions.emplace_back(apThis);
     }
 
-    if (options.DumpGameOptions)
+    if (options.Developer.DumpGameOptions)
         Log::Info(apThis->GetInfo());
 
-    if (options.PatchAsyncCompute && strcmp(apThis->pCategory, "Rendering/AsyncCompute") == 0)
+    if (options.Patches.AsyncCompute && strcmp(apThis->pCategory, "Rendering/AsyncCompute") == 0)
     {
         if (apThis->SetBool(false))
             Log::Info("Disabled hidden setting \"{}/{}\"", apThis->pCategory, apThis->pName);
         else
             Log::Warn("Failed to disable hidden setting \"{}/{}\"", apThis->pCategory, apThis->pName);
     }
-    else if (options.PatchAntialiasing && (strcmp(apThis->pName, "Antialiasing") == 0 || strcmp(apThis->pName, "ScreenSpaceReflection") == 0))
+    else if (options.Patches.Antialiasing && (strcmp(apThis->pName, "Antialiasing") == 0 || strcmp(apThis->pName, "ScreenSpaceReflection") == 0))
     {
         if (apThis->SetBool(false))
             Log::Info("Disabled hidden setting \"{}/{}\"", apThis->pCategory, apThis->pName);


### PR DESCRIPTION
Keeps previously opened widgets opened after game shuts down when it next launches.

Also organize options a bit better and fix mod being able to draw during first time setup.

Dependency for https://github.com/yamashi/CyberEngineTweaks/pull/754
Continued in #754 (gave it separate file there and some other tweaks)
