### PR TITLE
Better logging

### DIFF
--- a/src/CET.cpp
+++ b/src/CET.cpp
@@ -71,7 +71,7 @@ CET::CET()
     , m_bindings(m_paths, m_options)
     , m_window(&m_bindings, &m_d3d12)
     , m_d3d12(m_window, m_paths, m_options)
-    , m_vm(m_paths, m_bindings, m_d3d12)
+    , m_vm(m_paths, m_options, m_bindings, m_d3d12)
     , m_overlay(m_bindings, m_options, m_persistentState, m_vm)
 {
     m_vm.Initialize();

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -69,6 +69,7 @@ void DeveloperSettings::Load(const nlohmann::json& aConfig)
     EnableImGuiAssertions = aConfig.value("enable_imgui_assertions", EnableImGuiAssertions);
     EnableDebug = aConfig.value("enable_debug", EnableDebug);
     DumpGameOptions = aConfig.value("dump_game_options", DumpGameOptions);
+    MaxLinesLogOutput = aConfig.value("max_lines_log_output", MaxLinesLogOutput);
     MaxLinesConsoleHistory = aConfig.value("max_lines_console_history", MaxLinesConsoleHistory);
     PersistentConsole = aConfig.value("persistent_console", PersistentConsole);
 
@@ -86,6 +87,7 @@ nlohmann::json DeveloperSettings::Save() const
       {"enable_imgui_assertions", EnableImGuiAssertions},
       {"enable_debug", EnableDebug},
       {"dump_game_options", DumpGameOptions},
+      {"max_lines_log_output", MaxLinesLogOutput},
       {"max_lines_console_history", MaxLinesConsoleHistory},
       {"persistent_console", PersistentConsole}
     };

--- a/src/Options.h
+++ b/src/Options.h
@@ -51,6 +51,7 @@ struct DeveloperSettings
     bool EnableImGuiAssertions{ false };
     bool EnableDebug{ false };
     bool DumpGameOptions{ false };
+    uint64_t MaxLinesLogOutput{ 1000 };
     uint64_t MaxLinesConsoleHistory{ 1000 };
     bool PersistentConsole{ true };
 };

--- a/src/overlay/Overlay.cpp
+++ b/src/overlay/Overlay.cpp
@@ -265,6 +265,7 @@ Overlay::Overlay(VKBindings& aBindings, Options& aOptions, PersistentState& aPer
     , m_bindings(aBindings, aVm)
     , m_settings(aOptions, aVm)
     , m_tweakDBEditor(aVm)
+    , m_gameLog(aOptions, "Game Log", "gamelog")
     , m_options(aOptions)
     , m_persistentState(aPersistentState)
     , m_vm(aVm)

--- a/src/overlay/Overlay.h
+++ b/src/overlay/Overlay.h
@@ -4,7 +4,7 @@
 #include "widgets/Bindings.h"
 #include "widgets/Settings.h"
 #include "widgets/TweakDBEditor.h"
-#include "widgets/GameLog.h"
+#include "widgets/LogWindow.h"
 #include "widgets/ImGuiDebug.h"
 
 using TClipToCenter = HWND(RED4ext::CGameEngine::UnkC0*);
@@ -39,7 +39,7 @@ private:
     Bindings m_bindings;
     Settings m_settings;
     TweakDBEditor m_tweakDBEditor;
-    GameLog m_gameLog;
+    LogWindow m_gameLog;
     ImGuiDebug m_imguiDebug;
 
     TClipToCenter* m_realClipToCenter{ nullptr };

--- a/src/overlay/widgets/Console.cpp
+++ b/src/overlay/widgets/Console.cpp
@@ -6,7 +6,7 @@
 #include <Utils.h>
 
 Console::Console(Options& aOptions, PersistentState& aPersistentState, LuaVM& aVm)
-    : LogWidget("Console", "scripting")
+    : LogWindow(aOptions, "Console", "scripting")
     , m_persistentState(aPersistentState)
     , m_vm(aVm)
 {

--- a/src/overlay/widgets/Console.cpp
+++ b/src/overlay/widgets/Console.cpp
@@ -6,11 +6,9 @@
 #include <Utils.h>
 
 Console::Console(Options& aOptions, PersistentState& aPersistentState, LuaVM& aVm)
-    : Widget("Console", "scripting")
-    , m_options(aOptions)
+    : LogWidget("Console", "scripting")
     , m_persistentState(aPersistentState)
     , m_vm(aVm)
-    , m_logWindow("scripting")
 {
     m_command.resize(255);
     m_historyIndex = m_persistentState.Console.History.empty() ? 0 : m_persistentState.Console.History.size() - 1;
@@ -86,7 +84,7 @@ void Console::OnUpdate()
 {
     const auto& style = ImGui::GetStyle();
     const auto inputLineHeight = ImGui::GetTextLineHeight() + style.ItemInnerSpacing.y * 2;
-    m_logWindow.Draw({-FLT_MIN, -(inputLineHeight + style.ItemSpacing.y)});
+    DrawLog({-FLT_MIN, -(inputLineHeight + style.ItemSpacing.y)});
 
     ImGui::SetNextItemWidth(-FLT_MIN);
     constexpr auto flags = ImGuiInputTextFlags_EnterReturnsTrue | ImGuiInputTextFlags_AllowTabInput | ImGuiInputTextFlags_CallbackHistory | ImGuiInputTextFlags_CallbackResize;

--- a/src/overlay/widgets/Console.h
+++ b/src/overlay/widgets/Console.h
@@ -1,10 +1,9 @@
 #pragma once
 
-#include "Widget.h"
 #include "LogWindow.h"
 
 struct LuaVM;
-struct Console : Widget
+struct Console : LogWindow
 {
     Console(Options& aOptions, PersistentState& aPersistentState, LuaVM& aVm);
     ~Console() override = default;
@@ -19,11 +18,8 @@ private:
     static int HandleConsoleResize(ImGuiInputTextCallbackData* apData);
     static int HandleConsole(ImGuiInputTextCallbackData* apData);
 
-    Options& m_options;
     PersistentState& m_persistentState;
     LuaVM& m_vm;
-
-    LogWindow m_logWindow;
 
     size_t m_historyIndex{ 0 };
     bool m_newHistory{ true };

--- a/src/overlay/widgets/GameLog.cpp
+++ b/src/overlay/widgets/GameLog.cpp
@@ -3,12 +3,6 @@
 #include "GameLog.h"
 
 GameLog::GameLog()
-    : Widget("Game Log")
-    , m_logWindow("gamelog")
+    : LogWindow("Game Log", "gamelog")
 {
-}
-
-void GameLog::OnUpdate()
-{
-    m_logWindow.Draw({-FLT_MIN, -FLT_MIN});
 }

--- a/src/overlay/widgets/GameLog.cpp
+++ b/src/overlay/widgets/GameLog.cpp
@@ -1,8 +1,0 @@
-#include <stdafx.h>
-
-#include "GameLog.h"
-
-GameLog::GameLog()
-    : LogWindow("Game Log", "gamelog")
-{
-}

--- a/src/overlay/widgets/GameLog.h
+++ b/src/overlay/widgets/GameLog.h
@@ -1,9 +1,0 @@
-#pragma once
-
-#include "LogWindow.h"
-
-struct GameLog : LogWindow
-{
-    GameLog();
-    ~GameLog() override = default;
-};

--- a/src/overlay/widgets/GameLog.h
+++ b/src/overlay/widgets/GameLog.h
@@ -1,16 +1,9 @@
 #pragma once
 
-#include "Widget.h"
 #include "LogWindow.h"
 
-struct GameLog : Widget
+struct GameLog : LogWindow
 {
     GameLog();
     ~GameLog() override = default;
-
-protected:
-    void OnUpdate() override;
-
-private:
-    LogWindow m_logWindow;
 };

--- a/src/overlay/widgets/LogWindow.cpp
+++ b/src/overlay/widgets/LogWindow.cpp
@@ -55,7 +55,7 @@ void LogWindow::Draw(const ImVec2& size)
                 switch (level)
                 {
                 case spdlog::level::level_enum::trace:
-                    ImGui::PushStyleColor(ImGuiCol_Text, ImVec4{0.0f, 0.0f, 1.0f, 1.0f});
+                    ImGui::PushStyleColor(ImGuiCol_Text, ImVec4{0.0f, 1.0f, 1.0f, 1.0f});
                     break;
 
                 case spdlog::level::level_enum::debug:

--- a/src/overlay/widgets/LogWindow.cpp
+++ b/src/overlay/widgets/LogWindow.cpp
@@ -4,15 +4,21 @@
 
 #include <Utils.h>
 
-LogWindow::LogWindow(const std::string& acpLoggerName)
-    : m_loggerName(acpLoggerName)
+LogWindow::LogWindow(const std::string& acpWindowTitle, const std::string& acpLoggerName)
+    : Widget(acpWindowTitle)
+    , m_loggerName(acpLoggerName)
 {
     auto logSink = CreateCustomSinkMT([this](const std::string& msg){ Log(msg); });
     logSink->set_pattern("%L;%v");
     spdlog::get(m_loggerName)->sinks().emplace_back(std::move(logSink));
 }
 
-void LogWindow::Draw(const ImVec2& size)
+void LogWindow::OnUpdate()
+{
+    DrawLog({-FLT_MIN, -FLT_MIN});
+}
+
+void LogWindow::DrawLog(const ImVec2& size)
 {
     const auto itemWidth = GetAlignedItemWidth(2);
 

--- a/src/overlay/widgets/LogWindow.cpp
+++ b/src/overlay/widgets/LogWindow.cpp
@@ -2,8 +2,7 @@
 
 #include "LogWindow.h"
 
-#include "CET.h"
-
+#include <CET.h>
 #include <Utils.h>
 
 LogWindow::LogWindow(const Options& acOptions, const std::string& acpWindowTitle, const std::string& acpLoggerName)

--- a/src/overlay/widgets/LogWindow.h
+++ b/src/overlay/widgets/LogWindow.h
@@ -1,10 +1,15 @@
 #pragma once
 
-struct LogWindow
-{
-    LogWindow(const std::string& acpLoggerName);
+#include "Widget.h"
 
-    void Draw(const ImVec2& size);
+struct LogWindow : Widget
+{
+    LogWindow(const std::string& acpWindowTitle, const std::string& acpLoggerName);
+
+protected:
+    void OnUpdate() override;
+
+    void DrawLog(const ImVec2& size);
 
 private:
     void Log(const std::string& acpText);

--- a/src/overlay/widgets/LogWindow.h
+++ b/src/overlay/widgets/LogWindow.h
@@ -2,14 +2,17 @@
 
 #include "Widget.h"
 
+struct Options;
 struct LogWindow : Widget
 {
-    LogWindow(const std::string& acpWindowTitle, const std::string& acpLoggerName);
+    LogWindow(const Options& acOptions, const std::string& acpWindowTitle, const std::string& acpLoggerName);
 
 protected:
     void OnUpdate() override;
 
     void DrawLog(const ImVec2& size);
+
+    const Options& m_options;
 
 private:
     void Log(const std::string& acpText);

--- a/src/overlay/widgets/LogWindow.h
+++ b/src/overlay/widgets/LogWindow.h
@@ -2,7 +2,6 @@
 
 #include "Widget.h"
 
-struct Options;
 struct LogWindow : Widget
 {
     LogWindow(const Options& acOptions, const std::string& acpWindowTitle, const std::string& acpLoggerName);

--- a/src/scripting/LuaSandbox.cpp
+++ b/src/scripting/LuaSandbox.cpp
@@ -694,15 +694,13 @@ void LuaSandbox::InitializeLoggerForSandbox(Sandbox& aSandbox, const sol::state&
     sbEnv["consoleLog"] = m_sandboxes[0].GetEnvironment()["consoleLog"];
 
     // keep old spdlog binding for compatibility
-    sbEnv["spdlog"] = sbEnv["modlog"];
+    sbEnv["spdlog"] = sbEnv["modLog"];
 
     // TODO - make this use real mod name when we have mod info
     auto logWindow = std::make_shared<LogWindow>(acName + " Log", acName);
     sbEnv["__loggerWindow"] = logWindow;
-    sbEnv["SetModLogDrawEnabled"] = [logWindow](const bool acEnabled){
-        if (logWindow->IsEnabled() != acEnabled)
-            logWindow->Toggle();
-        return logWindow->IsEnabled();
+    sbEnv["ToggleModLogDraw"] = [logWindow]{
+        logWindow->Toggle();
     };
     sbEnv["IsModLogDrawEnabled"] = [logWindow]{
         return logWindow->IsEnabled();

--- a/src/scripting/LuaSandbox.cpp
+++ b/src/scripting/LuaSandbox.cpp
@@ -187,7 +187,7 @@ void LuaSandbox::Initialize()
         m_globals["os"] = osCopy;
     }
 
-    CreateSandbox("", "", false, false, false, false);
+    CreateSandbox("", "", false, false, false, true);
 }
 
 void LuaSandbox::PostInitializeScripting()
@@ -258,9 +258,9 @@ uint64_t LuaSandbox::CreateSandbox(const std::filesystem::path& acPath, const st
             InitializeDBForSandbox(res, luaState);
         if (aEnableIO)
             InitializeIOForSandbox(res, luaState, acName);
-        if (aEnableLogger)
-            InitializeLoggerForSandbox(res, luaState, acName);
     }
+    if (aEnableLogger)
+        InitializeLoggerForSandbox(res, luaState, acName);
     return cResID;
 }
 
@@ -653,20 +653,48 @@ void LuaSandbox::InitializeLoggerForSandbox(Sandbox& aSandbox, const sol::state&
     const auto& cSBRootPath = aSandbox.GetRootPath();
 
     // initialize logger for this mod
-    auto logger = CreateLogger(GetAbsolutePath(acName + ".log", cSBRootPath, true), acName);
-
-    // assign logger to mod so it can be used from within it too
-    sol::table spdlog(acpState, sol::create);
-    spdlog["trace"]    = [logger](const std::string& message) { logger->trace("{}", message);    };
-    spdlog["debug"]    = [logger](const std::string& message) { logger->debug("{}", message);    };
-    spdlog["info"]     = [logger](const std::string& message) { logger->info("{}", message);     };
-    spdlog["warning"]  = [logger](const std::string& message) { logger->warn("{}", message);     };
-    spdlog["error"]    = [logger](const std::string& message) { logger->error("{}", message);    };
-    spdlog["critical"] = [logger](const std::string& message) { logger->critical("{}", message); };
-    sbEnv["spdlog"] = spdlog;
+    auto logger = acName.empty() ? spdlog::get("scripting") : CreateLogger(GetAbsolutePath(acName + ".log", cSBRootPath, true), acName);
 
     // assign logger to special var so we can access it from our functions
     sbEnv["__logger"] = logger;
+
+    // assign logger to mod so it can be used from within it too
+    sol::table modLog(acpState, sol::create);
+
+    auto logMessage = [logger](spdlog::level::level_enum aLogLevel, sol::variadic_args aArgs, sol::this_state aState)
+    {
+        std::ostringstream oss;
+        sol::state_view s(aState);
+        for (auto it = aArgs.cbegin(); it != aArgs.cend(); ++it)
+        {
+            if (it != aArgs.cbegin())
+                oss << " ";
+            std::string str = s["tostring"]((*it).get<sol::object>());
+            oss << str;
+        }
+
+        logger->log(aLogLevel, "{}", oss.str().c_str());
+    };
+
+    modLog["trace"]    = [logMessage](sol::variadic_args aArgs, sol::this_state aState) { logMessage(spdlog::level::level_enum::trace,    aArgs, aState); };
+    modLog["debug"]    = [logMessage](sol::variadic_args aArgs, sol::this_state aState) { logMessage(spdlog::level::level_enum::debug,    aArgs, aState); };
+    modLog["info"]     = [logMessage](sol::variadic_args aArgs, sol::this_state aState) { logMessage(spdlog::level::level_enum::info,     aArgs, aState); };
+    modLog["warning"]  = [logMessage](sol::variadic_args aArgs, sol::this_state aState) { logMessage(spdlog::level::level_enum::warn,     aArgs, aState); };
+    modLog["error"]    = [logMessage](sol::variadic_args aArgs, sol::this_state aState) { logMessage(spdlog::level::level_enum::err,      aArgs, aState); };
+    modLog["critical"] = [logMessage](sol::variadic_args aArgs, sol::this_state aState) { logMessage(spdlog::level::level_enum::critical, aArgs, aState); };
+
+    if (acName.empty())
+    {
+        // in case of empty name, bind modLog to consoleLog
+        sbEnv["consoleLog"] = modLog;
+        return;
+    }
+
+    sbEnv["modLog"] = modLog;
+    sbEnv["consoleLog"] = m_sandboxes[0].GetEnvironment()["consoleLog"];
+
+    // keep old spdlog binding for compatibility
+    sbEnv["spdlog"] = sbEnv["modlog"];
 }
 
 void LuaSandbox::CloseDBForSandbox(const Sandbox& aSandbox) const

--- a/src/scripting/LuaSandbox.cpp
+++ b/src/scripting/LuaSandbox.cpp
@@ -695,6 +695,18 @@ void LuaSandbox::InitializeLoggerForSandbox(Sandbox& aSandbox, const sol::state&
 
     // keep old spdlog binding for compatibility
     sbEnv["spdlog"] = sbEnv["modlog"];
+
+    // TODO - make this use real mod name when we have mod info
+    auto logWindow = std::make_shared<LogWindow>(acName + " Log", acName);
+    sbEnv["__loggerWindow"] = logWindow;
+    sbEnv["SetModLogDrawEnabled"] = [logWindow](const bool acEnabled){
+        if (logWindow->IsEnabled() != acEnabled)
+            logWindow->Toggle();
+        return logWindow->IsEnabled();
+    };
+    sbEnv["IsModLogDrawEnabled"] = [logWindow]{
+        return logWindow->IsEnabled();
+    };
 }
 
 void LuaSandbox::CloseDBForSandbox(const Sandbox& aSandbox) const

--- a/src/scripting/LuaSandbox.h
+++ b/src/scripting/LuaSandbox.h
@@ -4,7 +4,7 @@
 
 struct LuaSandbox
 {
-    LuaSandbox(Scripting* apScripting, const VKBindings& acVKBindings);
+    LuaSandbox(const Options& acOptions, Scripting& aScripting, const VKBindings& acVKBindings);
     ~LuaSandbox() = default;
 
     void Initialize();
@@ -35,7 +35,8 @@ private:
 
     void CloseDBForSandbox(const Sandbox& aSandbox) const;
 
-    Scripting* m_pScripting;
+    const Options& m_options;
+    Scripting& m_scripting;
     const VKBindings& m_vkBindings;
     sol::table m_globals{};
     TiltedPhoques::Vector<Sandbox> m_sandboxes{};

--- a/src/scripting/LuaVM.cpp
+++ b/src/scripting/LuaVM.cpp
@@ -47,7 +47,7 @@ void LuaVM::Update(float aDeltaTime)
     m_scripting.TriggerOnUpdate(aDeltaTime);
 }
 
-void LuaVM::Draw() const
+void LuaVM::Draw()
 {
     if (!m_initialized || m_drawBlocked)
         return;

--- a/src/scripting/LuaVM.h
+++ b/src/scripting/LuaVM.h
@@ -25,7 +25,7 @@ struct TDBIDLookupEntry
 struct Image;
 struct LuaVM
 {
-    LuaVM(const Paths& aPaths, VKBindings& aBindings, D3D12& aD3D12);
+    LuaVM(const Paths& acPaths, const Options& acOptions, VKBindings& aBindings, D3D12& aD3D12);
     ~LuaVM() = default;
 
     [[nodiscard]] const VKBind* GetBind(const VKModBind& acModBind) const;

--- a/src/scripting/LuaVM.h
+++ b/src/scripting/LuaVM.h
@@ -35,7 +35,7 @@ struct LuaVM
     bool ExecuteLua(const std::string& acCommand) const;
 
     void Update(float aDeltaTime);
-    void Draw() const;
+    void Draw();
     void ReloadAllMods();
 
     void OnOverlayOpen() const;

--- a/src/scripting/LuaVM_Hooks.cpp
+++ b/src/scripting/LuaVM_Hooks.cpp
@@ -257,8 +257,8 @@ void LuaVM::HookLogChannel(RED4ext::IScriptable*, RED4ext::CStackFrame* apStack,
     }
 }
 
-LuaVM::LuaVM(const Paths& aPaths, VKBindings& aBindings, D3D12& aD3D12)
-    : m_scripting(aPaths, aBindings, aD3D12)
+LuaVM::LuaVM(const Paths& acPaths, const Options& acOptions, VKBindings& aBindings, D3D12& aD3D12)
+    : m_scripting(acPaths, acOptions, aBindings, aD3D12)
     , m_d3d12(aD3D12)
 {
     Hook();

--- a/src/scripting/Sandbox.cpp
+++ b/src/scripting/Sandbox.cpp
@@ -31,6 +31,11 @@ sol::environment& Sandbox::GetEnvironment()
     return m_env;
 }
 
+const sol::environment& Sandbox::GetEnvironment() const
+{
+    return m_env;
+}
+
 const std::filesystem::path& Sandbox::GetRootPath() const
 {
     return m_path;

--- a/src/scripting/Sandbox.h
+++ b/src/scripting/Sandbox.h
@@ -4,8 +4,11 @@ struct Scripting;
 
 struct Sandbox
 {
-    Sandbox(uint64_t aId, Scripting* apScripting, sol::table aBaseEnvironment, const std::filesystem::path& acRootPath);
+    Sandbox(Scripting& aScripting, uint64_t aId, sol::table aBaseEnvironment, const std::filesystem::path& acRootPath);
+    Sandbox(Sandbox&& aOther) noexcept;
     ~Sandbox() = default;
+
+    Sandbox& operator=(Sandbox&& aOther) noexcept;
 
     sol::protected_function_result ExecuteFile(const std::string& acPath) const;
     sol::protected_function_result ExecuteString(const std::string& acString) const;
@@ -16,8 +19,10 @@ struct Sandbox
     const std::filesystem::path& GetRootPath() const;
 
 private:
+
+    Scripting& m_scripting;
+
     uint64_t m_id{0};
-    Scripting* m_pScripting;
     sol::environment m_env;
     std::filesystem::path m_path{};
 };

--- a/src/scripting/Sandbox.h
+++ b/src/scripting/Sandbox.h
@@ -12,6 +12,7 @@ struct Sandbox
 
     uint64_t GetId() const;
     sol::environment& GetEnvironment();
+    const sol::environment& GetEnvironment() const;
     const std::filesystem::path& GetRootPath() const;
 
 private:

--- a/src/scripting/ScriptContext.cpp
+++ b/src/scripting/ScriptContext.cpp
@@ -44,6 +44,7 @@ ScriptContext::ScriptContext(LuaSandbox& aLuaSandbox, const std::filesystem::pat
     auto& env = sb.GetEnvironment();
     m_logger = env["__logger"].get<std::shared_ptr<spdlog::logger>>();
 
+
     env["registerForEvent"] = [this](const std::string& acName, sol::function aCallback)
     {
         if(acName == "onHook")

--- a/src/scripting/ScriptContext.cpp
+++ b/src/scripting/ScriptContext.cpp
@@ -43,7 +43,7 @@ ScriptContext::ScriptContext(LuaSandbox& aLuaSandbox, const std::filesystem::pat
     auto& sb = m_sandbox[m_sandboxID];
     auto& env = sb.GetEnvironment();
     m_logger = env["__logger"].get<std::shared_ptr<spdlog::logger>>();
-
+    m_loggerWindow = env["__loggerWindow"].get<std::shared_ptr<LogWindow>>();
 
     env["registerForEvent"] = [this](const std::string& acName, sol::function aCallback)
     {
@@ -84,7 +84,7 @@ ScriptContext::ScriptContext(LuaSandbox& aLuaSandbox, const std::filesystem::pat
             };
     };
 
-    auto wrapDescription = [&aLuaSandbox, loggerRef = m_logger, sandboxId = m_sandboxID](const std::variant<std::string, sol::function>& acDescription) -> std::variant<std::string, std::function<void()>> {
+    auto wrapDescription = [&aLuaSandbox, loggerRef = m_logger](const std::variant<std::string, sol::function>& acDescription) -> std::variant<std::string, std::function<void()>> {
         if (std::holds_alternative<sol::function>(acDescription))
         {
             auto callback = std::get<sol::function>(acDescription);
@@ -266,13 +266,16 @@ void ScriptContext::TriggerOnUpdate(float aDeltaTime) const
     TryLuaFunction(m_logger, m_onUpdate, aDeltaTime);
 }
 
-void ScriptContext::TriggerOnDraw() const
+void ScriptContext::TriggerOnDraw()
 {
     auto lockedState = m_sandbox.GetLockedState();
 
     m_sandbox.SetImGuiAvailable(true);
 
     const auto previousStyle = ImGui::GetStyle();
+
+    if (m_loggerWindow)
+        m_loggerWindow->Draw();
 
     TryLuaFunction(m_logger, m_onDraw);
 

--- a/src/scripting/ScriptContext.h
+++ b/src/scripting/ScriptContext.h
@@ -2,6 +2,7 @@
 
 #include "LuaSandbox.h"
 
+struct LogWindow;
 struct ScriptContext
 {
     ScriptContext(LuaSandbox& aLuaSandbox, const std::filesystem::path& acPath, const std::string& acName);
@@ -17,7 +18,7 @@ struct ScriptContext
     void TriggerOnTweak() const;
     void TriggerOnInit() const;
     void TriggerOnUpdate(float aDeltaTime) const;
-    void TriggerOnDraw() const;
+    void TriggerOnDraw();
 
     void TriggerOnOverlayOpen() const;
     void TriggerOnOverlayClose() const;
@@ -44,5 +45,6 @@ private:
     TiltedPhoques::Vector<VKBind> m_vkBinds{ };
     std::string m_name{ };
     std::shared_ptr<spdlog::logger> m_logger{ nullptr };
+    std::shared_ptr<LogWindow> m_loggerWindow{ nullptr };
     bool m_initialized{ false };
 };

--- a/src/scripting/ScriptStore.cpp
+++ b/src/scripting/ScriptStore.cpp
@@ -130,10 +130,11 @@ void ScriptStore::TriggerOnUpdate(float aDeltaTime) const
         mod.TriggerOnUpdate(aDeltaTime);
 }
 
-void ScriptStore::TriggerOnDraw() const
+void ScriptStore::TriggerOnDraw()
 {
-    for (const auto& mod : m_contexts | std::views::values)
-        mod.TriggerOnDraw();
+    // TODO - needs to be like this, cant use auto& like above as it is always const
+    for (auto it = m_contexts.begin(); it != m_contexts.end(); ++it)
+        it.value().TriggerOnDraw();
 }
 
 void ScriptStore::TriggerOnOverlayOpen() const

--- a/src/scripting/ScriptStore.h
+++ b/src/scripting/ScriptStore.h
@@ -18,7 +18,7 @@ struct ScriptStore
     void TriggerOnTweak() const;
     void TriggerOnInit() const;
     void TriggerOnUpdate(float aDeltaTime) const;
-    void TriggerOnDraw() const;
+    void TriggerOnDraw();
 
     void TriggerOnOverlayOpen() const;
     void TriggerOnOverlayClose() const;

--- a/src/scripting/Scripting.cpp
+++ b/src/scripting/Scripting.cpp
@@ -30,16 +30,16 @@ static constexpr bool s_cThrowLuaErrors = true;
 
 static RTTILocator s_stringType{RED4ext::FNV1a64("String")};
 
-Scripting::Scripting(const Paths& aPaths, VKBindings& aBindings, D3D12& aD3D12)
-    : m_sandbox(this, aBindings)
+Scripting::Scripting(const Paths& acPaths, const Options& acOptions, VKBindings& aBindings, D3D12& aD3D12)
+    : m_sandbox(acOptions, *this, aBindings)
     , m_mapper(m_lua.AsRef(), m_sandbox)
-    , m_store(m_sandbox, aPaths, aBindings)
+    , m_store(m_sandbox, acPaths, aBindings)
     , m_override(this)
-    , m_paths(aPaths)
+    , m_paths(acPaths)
     , m_d3d12(aD3D12)
 {
-    CreateLogger(aPaths.CETRoot() / "scripting.log", "scripting");
-    CreateLogger(aPaths.CETRoot() / "gamelog.log", "gamelog");
+    CreateLogger(acPaths.CETRoot() / "scripting.log", "scripting");
+    CreateLogger(acPaths.CETRoot() / "gamelog.log", "gamelog");
 }
 
 void Scripting::Initialize()

--- a/src/scripting/Scripting.cpp
+++ b/src/scripting/Scripting.cpp
@@ -651,7 +651,7 @@ void Scripting::TriggerOnUpdate(float aDeltaTime) const
     m_store.TriggerOnUpdate(aDeltaTime);
 }
 
-void Scripting::TriggerOnDraw() const
+void Scripting::TriggerOnDraw()
 {
     m_store.TriggerOnDraw();
 }

--- a/src/scripting/Scripting.cpp
+++ b/src/scripting/Scripting.cpp
@@ -89,28 +89,11 @@ void Scripting::Initialize()
         });
     }
 
-    // setup logger for console sandbox
+
+    // load in basic game bindings
     auto& consoleSB = m_sandbox[0];
     auto& consoleSBEnv = consoleSB.GetEnvironment();
-    consoleSBEnv["__logger"] = spdlog::get("scripting");
-
-    // load in game bindings
-    globals["print"] = [](sol::variadic_args aArgs, sol::this_state aState)
-    {
-        std::ostringstream oss;
-        sol::state_view s(aState);
-        for (auto it = aArgs.cbegin(); it != aArgs.cend(); ++it)
-        {
-            if (it != aArgs.cbegin())
-            {
-                oss << " ";
-            }
-            std::string str = s["tostring"]((*it).get<sol::object>());
-            oss << str;
-        }
-
-        spdlog::get("scripting")->info(oss.str());
-    };
+    globals["print"] = consoleSBEnv["consoleLog"]["info"]; // alias for backwards compat
 
     globals["GetVersion"] = []() -> std::string
     {

--- a/src/scripting/Scripting.h
+++ b/src/scripting/Scripting.h
@@ -27,7 +27,7 @@ struct Scripting
     void TriggerOnTweak() const;
     void TriggerOnInit() const;
     void TriggerOnUpdate(float aDeltaTime) const;
-    void TriggerOnDraw() const;
+    void TriggerOnDraw();
     void TriggerOnOverlayOpen() const;
     void TriggerOnOverlayClose() const;
 

--- a/src/scripting/Scripting.h
+++ b/src/scripting/Scripting.h
@@ -11,7 +11,7 @@ struct Scripting
 {
     using LockedState = TiltedPhoques::Locked<sol::state, std::recursive_mutex>;
 
-    Scripting(const Paths& aPaths, VKBindings& aBindings, D3D12& aD3D12);
+    Scripting(const Paths& acPaths, const Options& acOptions, VKBindings& aBindings, D3D12& aD3D12);
     ~Scripting() = default;
 
     void Initialize();


### PR DESCRIPTION
Idea is to give mods better logging facilities to both, console and their own logs (which they now only have in form of a file).

This should enable colored console output and allow mods to enable their own logging window at will, which would contain only their log. Logging into these sinks is provided via new consoleLog and modLog functions.

consoleLog works also in console, is meant as a replacement for print (print is still supported and behaves as consoleLog.info)
modLog is mod-specific, points to mod-specific logger and log window (aliases spdlog for backwards compatibility)

Both of these new interfaces support printing of multiple arguments (converts them to strings and concats them like print did previously).
This is upgrade over previous spdlog implementation, which it inherits thanks to shared interface.

Conflicts with PR #757 (Console.cpp)

![consoleLog](https://user-images.githubusercontent.com/41929176/201942913-aacb876c-5fd3-40e5-98d0-17fab94e059e.png)
![modLog](https://user-images.githubusercontent.com/41929176/201942939-d74c415d-b8ff-4838-b4b0-1e0cc3a87cdb.png)
