### PR TITLE
Increase memory for RTTI helpers

### DIFF
--- a/src/reverse/RTTIHelper.cpp
+++ b/src/reverse/RTTIHelper.cpp
@@ -971,7 +971,7 @@ void RTTIHelper::SetProperty(RED4ext::CClass* apClass, RED4ext::ScriptInstance a
     if (!pProp)
         return;
 
-    static thread_local TiltedPhoques::ScratchAllocator s_scratchMemory(1 << 13);
+    static thread_local TiltedPhoques::ScratchAllocator s_scratchMemory(1 << 14);
     struct ResetAllocator
     {
         ~ResetAllocator() { s_scratchMemory.Reset(); }

--- a/src/scripting/Scripting.cpp
+++ b/src/scripting/Scripting.cpp
@@ -949,13 +949,13 @@ RED4ext::CStackType Scripting::ToRED(sol::object aObject, RED4ext::CBaseRTTIType
 
 void Scripting::ToRED(sol::object aObject, RED4ext::CStackType& aRet)
 {
-    static thread_local TiltedPhoques::ScratchAllocator s_scratchMemory(1 << 13);
+    static thread_local TiltedPhoques::ScratchAllocator s_scratchMemory(1 << 14);
 
     const auto result = ToRED(aObject, aRet.type, &s_scratchMemory);
 
     aRet.type->Assign(aRet.value, result.value);
 
-    if (aRet.type->GetType() != RED4ext::ERTTIType::Class)
+    if (aRet.type->GetType() != RED4ext::ERTTIType::Class && result.value)
         aRet.type->Destruct(result.value);
 
     s_scratchMemory.Reset();


### PR DESCRIPTION
- Added more memory for RTTI calls and overrides as one upcoming mod hits the limit
- Fixed possible crash when lua value cannot be converted or there's not enough memory