### PR TITLE
Fix nil assignments in lua

### DIFF
--- a/src/reverse/TweakDB/TweakDB.cpp
+++ b/src/reverse/TweakDB/TweakDB.cpp
@@ -115,6 +115,9 @@ bool TweakDB::SetFlatsByName(const std::string& acRecordName, sol::table aTable,
 
 bool TweakDB::SetFlats(TweakDBID aDBID, sol::table aTable, sol::this_environment aThisEnv)
 {
+    const sol::environment cEnv = aThisEnv;
+    const auto logger = cEnv["__logger"].get<std::shared_ptr<spdlog::logger>>();
+
     bool success = true;
     const TweakDBID prepDBID(aDBID, ".");
 
@@ -124,7 +127,7 @@ bool TweakDB::SetFlats(TweakDBID aDBID, sol::table aTable, sol::this_environment
             continue;
 
         const TweakDBID flatDBID(prepDBID, key.as<std::string>());
-        success &= SetFlat(flatDBID, value, aThisEnv);
+        success &= SetOrCreateFlat(flatDBID, value, "", "", logger);
     }
 
     UpdateRecordByID(aDBID);
@@ -132,29 +135,29 @@ bool TweakDB::SetFlats(TweakDBID aDBID, sol::table aTable, sol::this_environment
     return success;
 }
 
-bool TweakDB::SetFlatByName(const std::string& acFlatName, sol::object aObject, sol::this_environment aThisEnv) const
+bool TweakDB::SetFlatByName(const std::string& acFlatName, sol::optional<sol::object> aObject, sol::this_environment aThisEnv) const
 {
     const sol::environment cEnv = aThisEnv;
     const auto logger = cEnv["__logger"].get<std::shared_ptr<spdlog::logger>>();
 
-    return SetOrCreateFlat(TweakDBID(acFlatName), std::move(aObject), acFlatName, "", logger);
+    return SetOrCreateFlat(TweakDBID(acFlatName), aObject.value_or(sol::nil), acFlatName, "", logger);
 }
 
-bool TweakDB::SetFlat(TweakDBID aDBID, sol::object aObject, sol::this_environment aThisEnv) const
+bool TweakDB::SetFlat(TweakDBID aDBID, sol::optional<sol::object> aObject, sol::this_environment aThisEnv) const
 {
     const sol::environment cEnv = aThisEnv;
     const auto logger = cEnv["__logger"].get<std::shared_ptr<spdlog::logger>>();
 
-    return SetOrCreateFlat(aDBID, std::move(aObject), "", "", logger);
+    return SetOrCreateFlat(aDBID, aObject.value_or(sol::nil), "", "", logger);
 }
 
-bool TweakDB::SetFlatByNameAutoUpdate(const std::string& acFlatName, sol::object aObject, sol::this_environment aThisEnv)
+bool TweakDB::SetFlatByNameAutoUpdate(const std::string& acFlatName, sol::optional<sol::object> aObject, sol::this_environment aThisEnv)
 {
     const sol::environment cEnv = aThisEnv;
     const auto logger = cEnv["__logger"].get<std::shared_ptr<spdlog::logger>>();
 
     const TweakDBID dbid(acFlatName);
-    if (SetOrCreateFlat(dbid, std::move(aObject), acFlatName, "", logger))
+    if (SetOrCreateFlat(dbid, aObject.value_or(sol::nil), acFlatName, "", logger))
     {
         const uint64_t recordDBID = CET::Get().GetVM().GetTDBIDBase(dbid.value);
         if (recordDBID != 0)
@@ -166,12 +169,12 @@ bool TweakDB::SetFlatByNameAutoUpdate(const std::string& acFlatName, sol::object
     return false;
 }
 
-bool TweakDB::SetFlatAutoUpdate(TweakDBID aDBID, sol::object aObject, sol::this_environment aThisEnv)
+bool TweakDB::SetFlatAutoUpdate(TweakDBID aDBID, sol::optional<sol::object> aObject, sol::this_environment aThisEnv)
 {
     const sol::environment cEnv = aThisEnv;
     const auto logger = cEnv["__logger"].get<std::shared_ptr<spdlog::logger>>();
 
-    if (SetOrCreateFlat(aDBID, std::move(aObject), "", "", logger))
+    if (SetOrCreateFlat(aDBID, aObject.value_or(sol::nil), "", "", logger))
     {
         const uint64_t recordDBID = CET::Get().GetVM().GetTDBIDBase(aDBID.value);
         if (recordDBID != 0)
@@ -183,20 +186,20 @@ bool TweakDB::SetFlatAutoUpdate(TweakDBID aDBID, sol::object aObject, sol::this_
     return false;
 }
 
-bool TweakDB::SetTypedFlatByName(const std::string& acFlatName, sol::object aObject, const std::string& acTypeName, sol::this_environment aThisEnv) const
+bool TweakDB::SetTypedFlatByName(const std::string& acFlatName, sol::optional<sol::object> aObject, const std::string& acTypeName, sol::this_environment aThisEnv) const
 {
     const sol::environment cEnv = aThisEnv;
     const auto logger = cEnv["__logger"].get<std::shared_ptr<spdlog::logger>>();
 
-    return SetOrCreateFlat(TweakDBID(acFlatName), aObject, acFlatName, acTypeName, logger);
+    return SetOrCreateFlat(TweakDBID(acFlatName), aObject.value_or(sol::nil), acFlatName, acTypeName, logger);
 }
 
-bool TweakDB::SetTypedFlat(TweakDBID aDBID, sol::object aObject, const std::string& acTypeName, sol::this_environment aThisEnv) const
+bool TweakDB::SetTypedFlat(TweakDBID aDBID, sol::optional<sol::object> aObject, const std::string& acTypeName, sol::this_environment aThisEnv) const
 {
     const sol::environment cEnv = aThisEnv;
     const auto logger = cEnv["__logger"].get<std::shared_ptr<spdlog::logger>>();
 
-    return SetOrCreateFlat(aDBID, aObject, "", acTypeName, logger);
+    return SetOrCreateFlat(aDBID, aObject.value_or(sol::nil), "", acTypeName, logger);
 }
 
 bool TweakDB::SetOrCreateFlat(

--- a/src/reverse/TweakDB/TweakDB.h
+++ b/src/reverse/TweakDB/TweakDB.h
@@ -22,12 +22,12 @@ struct TweakDB
     sol::object GetFlat(TweakDBID aDBID) const;
     bool SetFlatsByName(const std::string& acRecordName, sol::table aTable, sol::this_environment aThisEnv);
     bool SetFlats(TweakDBID aDBID, sol::table aTable, sol::this_environment aThisEnv);
-    bool SetFlatByName(const std::string& acFlatName, sol::object aObject, sol::this_environment aThisEnv) const;
-    bool SetFlat(TweakDBID aDBID, sol::object aObject, sol::this_environment aThisEnv) const;
-    bool SetFlatByNameAutoUpdate(const std::string& acFlatName, sol::object aObject, sol::this_environment aThisEnv);
-    bool SetFlatAutoUpdate(TweakDBID aDBID, sol::object aObject, sol::this_environment aThisEnv);
-    bool SetTypedFlatByName(const std::string& acFlatName, sol::object aObject, const std::string& acTypeName, sol::this_environment aThisEnv) const;
-    bool SetTypedFlat(TweakDBID aDBID, sol::object aObject, const std::string& acTypeName, sol::this_environment aThisEnv) const;
+    bool SetFlatByName(const std::string& acFlatName, sol::optional<sol::object> aObject, sol::this_environment aThisEnv) const;
+    bool SetFlat(TweakDBID aDBID, sol::optional<sol::object> aObject, sol::this_environment aThisEnv) const;
+    bool SetFlatByNameAutoUpdate(const std::string& acFlatName, sol::optional<sol::object> aObject, sol::this_environment aThisEnv);
+    bool SetFlatAutoUpdate(TweakDBID aDBID, sol::optional<sol::object> aObject, sol::this_environment aThisEnv);
+    bool SetTypedFlatByName(const std::string& acFlatName, sol::optional<sol::object> aObject, const std::string& acTypeName, sol::this_environment aThisEnv) const;
+    bool SetTypedFlat(TweakDBID aDBID, sol::optional<sol::object> aObject, const std::string& acTypeName, sol::this_environment aThisEnv) const;
     bool UpdateRecordByName(const std::string& acRecordName);
     bool UpdateRecordByID(TweakDBID aDBID);
     bool UpdateRecord(sol::object aValue, sol::this_environment aThisEnv);

--- a/src/reverse/Type.cpp
+++ b/src/reverse/Type.cpp
@@ -40,9 +40,9 @@ sol::object Type::Index(const std::string& acName, sol::this_environment aThisEn
     return Index_Impl(acName, aThisEnv);
 }
 
-sol::object Type::NewIndex(const std::string& acName, sol::object aParam)
+sol::object Type::NewIndex(const std::string& acName, sol::optional<sol::object> aParam)
 {
-    return NewIndex_Impl(acName, aParam);
+    return NewIndex_Impl(acName, aParam.has_value() ? aParam.value() : sol::nil);
 }
 
 sol::object Type::Index_Impl(const std::string& acName, sol::this_environment aThisEnv)
@@ -254,7 +254,7 @@ sol::object ClassType::Index_Impl(const std::string& acName, sol::this_environme
     if (!func)
         return sol::nil;
 
-    return NewIndex(acName, func);
+    return Type::NewIndex_Impl(acName, func);
 }
 
 sol::object ClassType::NewIndex_Impl(const std::string& acName, sol::object aParam)

--- a/src/reverse/Type.h
+++ b/src/reverse/Type.h
@@ -20,7 +20,7 @@ struct Type
     virtual RED4ext::ScriptInstance GetValuePtr() const { return nullptr; }
 
     sol::object Index(const std::string& acName, sol::this_environment aThisEnv);
-    sol::object NewIndex(const std::string& acName, sol::object aParam);
+    sol::object NewIndex(const std::string& acName, sol::optional<sol::object> aParam);
 
     virtual sol::object Index_Impl(const std::string& acName, sol::this_environment aThisEnv);
     virtual sol::object NewIndex_Impl(const std::string& acName, sol::object aParam);

--- a/src/scripting/FunctionOverride.cpp
+++ b/src/scripting/FunctionOverride.cpp
@@ -235,24 +235,19 @@ void FunctionOverride::HandleOverridenFunction(RED4ext::IScriptable* apContext, 
 
             if (!apFunction->flags.isStatic)
             {
-                RED4ext::CStackType self;
+                args.reserve(apFunction->params.size + 1);
 
-                if (apContext->valueHolder)
+                const auto pContext = apContext ? apContext : apFrame->context;
+                if (pContext)
                 {
-                    self.type = apContext->unk30;
-                    self.value = apContext;
+                    const auto ref = reinterpret_cast<RED4ext::WeakHandle<RED4ext::IScriptable>*>(&pContext->ref);
+                    const auto weak = RED4ext::WeakHandle(*ref);
+                    args.emplace_back(make_object(luaState, WeakReference(lockedState, weak)));
                 }
                 else
                 {
-                    self.type = apFrame->context->unk30;
-                    self.value = apFrame->context;
+                    args.emplace_back(sol::nil);
                 }
-
-                args.reserve(apFunction->params.size + 1);
-
-                const auto ref = reinterpret_cast<RED4ext::WeakHandle<RED4ext::IScriptable>*>(&static_cast<RED4ext::IScriptable*>(self.value)->ref);
-                const auto weak = RED4ext::WeakHandle(*ref);
-                args.emplace_back(make_object(luaState, WeakReference(lockedState, weak)));
             }
             else
             {


### PR DESCRIPTION
- Fixed issue introduced by sol2 v3.3.0 where `nil` doesn't qualify as _anything_ in _some_ contexts.
- Improved context handling in function overrides (fixes crash on latest patch).
