### PR TITLE
Add BasicTypes overload operators

### DIFF
--- a/src/reverse/BasicTypes.cpp
+++ b/src/reverse/BasicTypes.cpp
@@ -16,6 +16,41 @@ bool Vector3::operator==(const Vector3& acRhs) const noexcept
     return x == acRhs.x && y == acRhs.y && z == acRhs.z;
 }
 
+bool Vector3::operator<(const Vector3& acRhs) const noexcept
+{
+    return x < acRhs.x && y < acRhs.y && z < acRhs.z;
+}
+
+bool Vector3::operator<=(const Vector3& acRhs) const noexcept
+{
+    return x <= acRhs.x && y <= acRhs.y && z <= acRhs.z;
+}
+
+Vector3 Vector3::operator+(const Vector3& acRhs) const noexcept
+{
+    return Vector3(x + acRhs.x, y + acRhs.y, z + acRhs.z);
+}
+
+Vector3 Vector3::operator-(const Vector3& acRhs) const noexcept
+{
+    return Vector3(x - acRhs.x, y - acRhs.y, z - acRhs.z);
+}
+
+Vector3 Vector3::operator*(const Vector3& acRhs) const noexcept
+{
+    return Vector3(x * acRhs.x, y * acRhs.y, z * acRhs.z);
+}
+
+Vector3 Vector3::operator/(const Vector3& acRhs) const noexcept
+{
+    if (acRhs.x == 0 || acRhs.y == 0 || acRhs.z == 0)
+    {
+        CET::Get().GetVM().ThrowLuaError("Divide by zero exception");
+        return acRhs;
+    }
+    return Vector3(x / acRhs.x, y / acRhs.y, z / acRhs.z);
+}
+
 std::string Vector4::ToString() const noexcept
 {
     return fmt::format("ToVector4{{ x = {}, y = {}, z = {}, w = {} }}", x, y, z, w);
@@ -24,6 +59,41 @@ std::string Vector4::ToString() const noexcept
 bool Vector4::operator==(const Vector4& acRhs) const noexcept
 {
     return x == acRhs.x && y == acRhs.y && z == acRhs.z && w == acRhs.w;
+}
+
+bool Vector4::operator<(const Vector4& acRhs) const noexcept
+{
+    return x < acRhs.x && y < acRhs.y && z < acRhs.z && w < acRhs.w;
+}
+
+bool Vector4::operator<=(const Vector4& acRhs) const noexcept
+{
+    return x <= acRhs.x && y <= acRhs.y && z <= acRhs.z && w <= acRhs.w;
+}
+
+Vector4 Vector4::operator+(const Vector4& acRhs) const noexcept
+{
+    return Vector4(x + acRhs.x, y + acRhs.y, z + acRhs.z, w + acRhs.w);
+}
+
+Vector4 Vector4::operator-(const Vector4& acRhs) const noexcept
+{
+    return Vector4(x - acRhs.x, y - acRhs.y, z - acRhs.z, w - acRhs.w);
+}
+
+Vector4 Vector4::operator*(const Vector4& acRhs) const noexcept
+{
+    return Vector4(x * acRhs.x, y * acRhs.y, z * acRhs.z, w * acRhs.w);
+}
+
+Vector4 Vector4::operator/(const Vector4& acRhs) const noexcept
+{
+    if (acRhs.x == 0 || acRhs.y == 0 || acRhs.z == 0 || acRhs.w == 0)
+    {
+        CET::Get().GetVM().ThrowLuaError("Divide by zero exception");
+        return acRhs;
+    }
+    return Vector4(x / acRhs.x, y / acRhs.y, z / acRhs.z, w / acRhs.w);
 }
 
 std::string EulerAngles::ToString() const noexcept

--- a/src/reverse/BasicTypes.h
+++ b/src/reverse/BasicTypes.h
@@ -16,6 +16,12 @@ struct Vector3
     std::string ToString() const noexcept;
 
     bool operator==(const Vector3& acRhs) const noexcept;
+    bool operator<(const Vector3& acRhs) const noexcept;
+    bool operator<=(const Vector3& acRhs) const noexcept;
+    Vector3 operator+(const Vector3& acRhs) const noexcept;
+    Vector3 operator-(const Vector3& acRhs) const noexcept;
+    Vector3 operator*(const Vector3& acRhs) const noexcept;
+    Vector3 operator/(const Vector3& acRhs) const noexcept;
 };
 
 struct Vector4
@@ -36,6 +42,12 @@ struct Vector4
     std::string ToString() const noexcept;
 
     bool operator==(const Vector4& acRhs) const noexcept;
+    bool operator<(const Vector4& acRhs) const noexcept;
+    bool operator<=(const Vector4& acRhs) const noexcept;
+    Vector4 operator+(const Vector4& acRhs) const noexcept;
+    Vector4 operator-(const Vector4& acRhs) const noexcept;
+    Vector4 operator*(const Vector4& acRhs) const noexcept;
+    Vector4 operator/(const Vector4& acRhs) const noexcept;
 };
 
 struct EulerAngles

--- a/src/scripting/LuaVM.cpp
+++ b/src/scripting/LuaVM.cpp
@@ -30,6 +30,13 @@ bool LuaVM::ExecuteLua(const std::string& acCommand) const
     return m_scripting.ExecuteLua(acCommand);
 }
 
+int LuaVM::ThrowLuaError(const std::string& acMessage) const
+{
+    lua_State* state = m_scripting.GetLockedState().Get().lua_state();
+
+    return luaL_error(state, "%s", acMessage.c_str());
+}
+
 void LuaVM::Update(float aDeltaTime)
 {
     if (!m_initialized)

--- a/src/scripting/LuaVM.h
+++ b/src/scripting/LuaVM.h
@@ -33,6 +33,7 @@ struct LuaVM
     [[nodiscard]] const TiltedPhoques::Map<std::string, std::reference_wrapper<const TiltedPhoques::Vector<VKBind>>>& GetAllBinds() const;
 
     bool ExecuteLua(const std::string& acCommand) const;
+    int ThrowLuaError(const std::string& acMessage) const;
 
     void Update(float aDeltaTime);
     void Draw() const;

--- a/src/scripting/Scripting.cpp
+++ b/src/scripting/Scripting.cpp
@@ -231,8 +231,26 @@ void Scripting::PostInitializeScripting()
     };
 
     luaVm.new_usertype<Vector3>(
-        "Vector3", sol::constructors<Vector3(float, float, float), Vector3(float, float), Vector3(float), Vector3(const Vector3&), Vector3()>(), sol::meta_function::to_string,
-        &Vector3::ToString, sol::meta_function::equal_to, &Vector3::operator==, "x", &Vector3::x, "y", &Vector3::y, "z", &Vector3::z);
+        "Vector3",
+        sol::constructors<
+            Vector3(float, float, float),
+            Vector3(float, float),
+            Vector3(float),
+            Vector3(const Vector3&),
+            Vector3()
+        >(),
+        sol::meta_function::to_string, &Vector3::ToString,
+        sol::meta_function::equal_to, &Vector3::operator==,
+        sol::meta_function::less_than, &Vector3::operator<,
+        sol::meta_function::less_than_or_equal_to, &Vector3::operator<=,
+        sol::meta_function::addition, &Vector3::operator+,
+        sol::meta_function::subtraction, &Vector3::operator-,
+        sol::meta_function::multiplication, &Vector3::operator*,
+        sol::meta_function::division, &Vector3::operator/,
+        "x", &Vector3::x,
+        "y", &Vector3::y,
+        "z", &Vector3::z
+    );
     globals["Vector3"] = luaVm["Vector3"];
 
     globals["ToVector3"] = [](sol::table table) -> Vector3
@@ -242,9 +260,27 @@ void Scripting::PostInitializeScripting()
 
     luaVm.new_usertype<Vector4>(
         "Vector4",
-        sol::constructors<Vector4(float, float, float, float), Vector4(float, float, float), Vector4(float, float), Vector4(float), Vector4(const Vector4&), Vector4()>(),
-        sol::meta_function::to_string, &Vector4::ToString, sol::meta_function::equal_to, &Vector4::operator==, "x", &Vector4::x, "y", &Vector4::y, "z", &Vector4::z, "w",
-        &Vector4::w);
+        sol::constructors<
+            Vector4(float, float, float, float),
+            Vector4(float, float, float),
+            Vector4(float, float),
+            Vector4(float),
+            Vector4(const Vector4&),
+            Vector4()
+        >(),
+        sol::meta_function::to_string, &Vector4::ToString,
+        sol::meta_function::equal_to, &Vector4::operator==,
+        sol::meta_function::less_than, &Vector4::operator<,
+        sol::meta_function::less_than_or_equal_to, &Vector4::operator<=,
+        sol::meta_function::addition, &Vector4::operator+,
+        sol::meta_function::subtraction, &Vector4::operator-,
+        sol::meta_function::multiplication, &Vector4::operator*,
+        sol::meta_function::division, &Vector4::operator/,
+        "x", &Vector4::x,
+        "y", &Vector4::y,
+        "z", &Vector4::z,
+        "w", &Vector4::w
+    );
     globals["Vector4"] = luaVm["Vector4"];
 
     globals["ToVector4"] = [](sol::table table) -> Vector4


### PR DESCRIPTION
Add overload operators for `Vector3` and `Vector4`.

- Includes +, -, *, /, < and <= operations.
- Add `ThrowLuaError` in `LuaVM` to throw when dividing by zero.
- Formats Lua usertypes in `Scripting` for easier maintenance.

![2024-01-20_CET_basictypes-overload-operators](https://github.com/maximegmd/CyberEngineTweaks/assets/950147/0b31c4cc-7620-4c18-a05f-58f568b8c306)
