### PR TITLE
fix: Crash when attempting to construct abstract class

### DIFF
--- a/src/reverse/RTTIHelper.cpp
+++ b/src/reverse/RTTIHelper.cpp
@@ -894,7 +894,7 @@ sol::object RTTIHelper::NewHandle(RED4ext::CBaseRTTIType* apType, sol::optional<
     result.value = NewInstance(apType, sol::nullopt, &allocator);
 
     // Wrap ISerializable descendants in Handle
-    if (result.value && apType->GetType() == RED4ext::ERTTIType::Class)
+    if (apType->GetType() == RED4ext::ERTTIType::Class)
     {
         static auto* s_pHandleType = m_pRtti->GetType(RED4ext::FNV1a64("handle:Activator"));
         static auto* s_pISerializableType = m_pRtti->GetType(RED4ext::FNV1a64("ISerializable"));
@@ -903,11 +903,13 @@ sol::object RTTIHelper::NewHandle(RED4ext::CBaseRTTIType* apType, sol::optional<
 
         if (pClass->IsA(s_pISerializableType))
         {
-            auto* pInstance = static_cast<RED4ext::ISerializable*>(result.value);
-            auto* pHandle = allocator.New<RED4ext::Handle<RED4ext::ISerializable>>(pInstance);
-
+            if (result.value)
+            {
+                auto* pInstance = static_cast<RED4ext::ISerializable*>(result.value);
+                auto* pHandle = allocator.New<RED4ext::Handle<RED4ext::ISerializable>>(pInstance);
+                result.value = pHandle;
+            }
             result.type = s_pHandleType; // To trick converter and deallocator
-            result.value = pHandle;
         }
     }
 

--- a/src/scripting/Scripting.cpp
+++ b/src/scripting/Scripting.cpp
@@ -751,6 +751,9 @@ sol::object Scripting::ToLua(LockedState& aState, RED4ext::CStackType& aResult)
         return make_object(state, std::string(static_cast<RED4ext::CString*>(aResult.value)->c_str()));
     if (pType->GetType() == RED4ext::ERTTIType::Handle)
     {
+        if (aResult.value == nullptr)
+            return sol::nil;
+
         const auto handle = *static_cast<RED4ext::Handle<RED4ext::IScriptable>*>(aResult.value);
         if (handle)
             return make_object(state, StrongReference(aState, handle, static_cast<RED4ext::CRTTIHandleType*>(pType)));


### PR DESCRIPTION
This small fix address situations where attempts to construct an abstract class results in a crash.

Currently, the code explicitly returns `nullptr` when constructing the class instance if the class has been marked as abstract, but the subsequent handle conversion logic does not check for the null value before attempting to convert it to a `Handle`. This guard ensures that the `nil` type is returned to Lua, resolving the crash scenario.

To reproduce, simply attempt to create a new instance of an abstract class like so:

```lua
MyAbstractType.new()
```
